### PR TITLE
feat(cobros): cierre diario de asesores (CB-024)

### DIFF
--- a/apps/cartera-back/src/controllers/buckets/poolPorAsesor.ts
+++ b/apps/cartera-back/src/controllers/buckets/poolPorAsesor.ts
@@ -20,9 +20,15 @@ export type AsesorConBuckets = {
 };
 
 /**
- * TODOS los asesores con sus buckets activos del pool (asesor_bucket WHERE
- * activo=true), SIN filtrar por créditos actuales. Un asesor sin ninguna fila
- * activa en asesor_bucket no aparece en el resultado (sin pool asignado).
+ * TODOS los asesores (LEFT JOIN a asesor_bucket WHERE activo=true) — un
+ * asesor SIEMPRE aparece en el resultado aunque no tenga pool activo ahora
+ * mismo (`buckets: []`). Antes era INNER JOIN: un asesor con pool
+ * desactivado/migrado entre el evento del día y la corrida del cierre (00:15
+ * GT) desaparecía por completo del mapa, y el CRM no podía atribuirle NINGÚN
+ * movimiento de bucket de ese día — mismo bug de fondo que motivó todo el
+ * rediseño de atribución (mezclar identidad del asesor con su estado ACTUAL
+ * de pool). email_cash_in/nombre no dependen de asesor_bucket, así que el
+ * LEFT JOIN no pierde identidad, solo puede dejar `buckets` vacío.
  */
 export async function getPoolPorAsesor(): Promise<AsesorConBuckets[]> {
   const rows = await db
@@ -33,7 +39,7 @@ export async function getPoolPorAsesor(): Promise<AsesorConBuckets[]> {
       bucket: asesor_bucket.bucket,
     })
     .from(asesores)
-    .innerJoin(
+    .leftJoin(
       asesor_bucket,
       and(eq(asesor_bucket.asesor_id, asesores.asesor_id), eq(asesor_bucket.activo, true)),
     )
@@ -49,7 +55,9 @@ export async function getPoolPorAsesor(): Promise<AsesorConBuckets[]> {
         buckets: [],
       });
     }
-    porAsesor.get(r.asesor_id)!.buckets.push(r.bucket);
+    if (r.bucket != null) {
+      porAsesor.get(r.asesor_id)!.buckets.push(r.bucket);
+    }
   }
   return Array.from(porAsesor.values());
 }

--- a/apps/cartera-back/src/controllers/buckets/poolPorAsesor.ts
+++ b/apps/cartera-back/src/controllers/buckets/poolPorAsesor.ts
@@ -1,0 +1,55 @@
+import { and, eq } from "drizzle-orm";
+import { db } from "../../database";
+import { asesor_bucket, asesores } from "../../database/db/schema";
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Pool por asesor (contraparte "invertida" de /buckets/pool/:bucket, que da los
+// asesores de UN bucket) — CRM (Cierre diario) necesitaba "a qué bucket(s)
+// pertenece cada asesor" sin depender de creditos (getCargaPorAsesorBucket
+// solo lista asesores con al menos un crédito ACTUALMENTE en el funnel
+// operativo, perdiendo asesores sin cuentas activas en ese momento) ni del
+// email de /advisor (desactualizado para varios asesores). email_cash_in sí
+// es el campo que coincide con el email real del usuario en el CRM.
+// ─────────────────────────────────────────────────────────────────────────────
+
+export type AsesorConBuckets = {
+  asesor_id: number;
+  nombre: string;
+  email_cash_in: string | null;
+  buckets: number[];
+};
+
+/**
+ * TODOS los asesores con sus buckets activos del pool (asesor_bucket WHERE
+ * activo=true), SIN filtrar por créditos actuales. Un asesor sin ninguna fila
+ * activa en asesor_bucket no aparece en el resultado (sin pool asignado).
+ */
+export async function getPoolPorAsesor(): Promise<AsesorConBuckets[]> {
+  const rows = await db
+    .select({
+      asesor_id: asesores.asesor_id,
+      nombre: asesores.nombre,
+      email_cash_in: asesores.emailCashIn,
+      bucket: asesor_bucket.bucket,
+    })
+    .from(asesores)
+    .innerJoin(
+      asesor_bucket,
+      and(eq(asesor_bucket.asesor_id, asesores.asesor_id), eq(asesor_bucket.activo, true)),
+    )
+    .orderBy(asesores.nombre, asesor_bucket.bucket);
+
+  const porAsesor = new Map<number, AsesorConBuckets>();
+  for (const r of rows) {
+    if (!porAsesor.has(r.asesor_id)) {
+      porAsesor.set(r.asesor_id, {
+        asesor_id: r.asesor_id,
+        nombre: r.nombre,
+        email_cash_in: r.email_cash_in,
+        buckets: [],
+      });
+    }
+    porAsesor.get(r.asesor_id)!.buckets.push(r.bucket);
+  }
+  return Array.from(porAsesor.values());
+}

--- a/apps/cartera-back/src/routers/buckets.ts
+++ b/apps/cartera-back/src/routers/buckets.ts
@@ -11,6 +11,7 @@ import {
   getAsesoresPorBucket,
   reasignarAsesorManual,
 } from "../controllers/buckets/reasignarAsesor";
+import { getPoolPorAsesor } from "../controllers/buckets/poolPorAsesor";
 import { getCargaPorAsesorBucket } from "../controllers/buckets/cargaAsesorBucket";
 import { actualizarCapacidadAsesorBucket } from "../controllers/buckets/actualizarAsesorBucket";
 import { getColaDiaSLA } from "../controllers/buckets/colaDia";
@@ -428,6 +429,30 @@ export const bucketsRouter = new Elysia()
         return {
           success: false,
           message: "[ERROR] No se pudo obtener el pool de asesores del bucket",
+          error: String(err),
+        };
+      }
+    },
+  )
+
+  // Catálogo completo de asesores con sus buckets activos del pool (contraparte
+  // "invertida" de /buckets/pool/:bucket, que da los asesores de UN bucket).
+  // No pasa por creditos — no descarta asesores sin cuentas activas en el
+  // funnel (a diferencia de /buckets/carga). Incluye email_cash_in para que el
+  // CRM pueda cruzar contra su propio user.email sin depender del email
+  // desactualizado de /advisor.
+  .get(
+    "/buckets/pool-por-asesor",
+    async ({ set, user }: any) => {
+      if (!requireBucketsRole(user, set)) return NO_AUTORIZADO;
+      try {
+        const data = await getPoolPorAsesor();
+        return { success: true, data };
+      } catch (err) {
+        set.status = 500;
+        return {
+          success: false,
+          message: "[ERROR] No se pudo obtener el pool por asesor",
           error: String(err),
         };
       }

--- a/apps/crm/apps/server/src/db/migrations/0028_cb024_cierre_diario_asesor.sql
+++ b/apps/crm/apps/server/src/db/migrations/0028_cb024_cierre_diario_asesor.sql
@@ -1,0 +1,55 @@
+-- 0028: CB-024 — Cierre diario de cobros (snapshot 22:00 GT), detalle por crédito.
+-- Espejo exacto del schema drizzle `src/db/schema/cobros.ts`
+-- (cierreCreditoTipoEnum, cierreDiarioCreditoCobros).
+-- Aplicar A MANO (mismo criterio que 0026_cb020_promesa_pago_cuotas.sql /
+-- 0027_cobros_notif_tipo.sql).
+--
+-- Tabla de DETALLE: una fila por cada contacto real del día (tipo='contacto')
+-- MÁS una fila por cada crédito que SALIÓ del bucket del pool del asesor
+-- (tipo='subida'/'bajada'), con su ruta bucket_anterior → bucket. Los
+-- agregados (efectivos, promesas, subieron, bajaron) se calculan agrupando
+-- esta misma tabla — no se guardan aparte.
+--
+-- El job `generarCierreDiario`:
+--   - Paso A (contactos): INSERT ... ON CONFLICT (contacto_id) DO NOTHING
+--     — un contacto ya registrado es histórico inmutable, nunca se duplica.
+--     `es_efectivo_manual` = el cliente CONTESTÓ (contactado / acuerdo_parcial
+--     / rechaza_pagar) y el contacto fue manual del asesor. Categorías
+--     EXCLUYENTES: 'promesa_pago' se reporta aparte, no suma como efectivo.
+--   - Paso B (movimientos): DELETE + INSERT del día — el bucket de un crédito
+--     puede cambiar entre corridas, no hay "contacto" que lo ancle.
+
+DO $$ BEGIN
+  CREATE TYPE public.cierre_credito_tipo AS ENUM ('contacto', 'subida', 'bajada');
+EXCEPTION WHEN duplicate_object THEN NULL; END $$;
+
+CREATE TABLE IF NOT EXISTS public.cierre_diario_credito_cobros (
+  id uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+  fecha date NOT NULL,
+  asesor_id text NOT NULL REFERENCES public."user"(id),
+  tipo public.cierre_credito_tipo NOT NULL,
+
+  caso_cobro_id uuid REFERENCES public.casos_cobros(id),
+  numero_credito_sifco text,
+
+  -- Solo aplica cuando tipo='contacto'
+  contacto_id uuid REFERENCES public.contactos_cobros(id),
+  estado_contacto public.estado_contacto,
+  es_efectivo_manual boolean NOT NULL DEFAULT false,
+  fecha_contacto timestamp,
+
+  -- Solo aplican cuando tipo='subida'/'bajada' — la ruta del movimiento.
+  bucket_anterior integer, -- de dónde salió (bucket del pool del asesor)
+  bucket integer,          -- a dónde fue
+
+  generado_en timestamp NOT NULL DEFAULT now()
+);
+
+-- Idempotencia del Paso A: un mismo contacto nunca se inserta dos veces.
+CREATE UNIQUE INDEX IF NOT EXISTS idx_cierre_detalle_contacto_unico
+  ON public.cierre_diario_credito_cobros (contacto_id)
+  WHERE contacto_id IS NOT NULL;
+
+-- Lectura del acordeón (detalle por asesor+rango) y de los agregados por rango.
+CREATE INDEX IF NOT EXISTS idx_cierre_detalle_fecha_asesor
+  ON public.cierre_diario_credito_cobros (fecha, asesor_id);

--- a/apps/crm/apps/server/src/db/schema/cobros.ts
+++ b/apps/crm/apps/server/src/db/schema/cobros.ts
@@ -2,6 +2,7 @@ import { sql } from "drizzle-orm";
 import {
 	boolean,
 	check,
+	date,
 	decimal,
 	index,
 	integer,
@@ -9,6 +10,7 @@ import {
 	pgTable,
 	text,
 	timestamp,
+	uniqueIndex,
 	uuid,
 } from "drizzle-orm/pg-core";
 import { user } from "./auth";
@@ -387,5 +389,61 @@ export const seguimientosProgramados = pgTable(
 	},
 	(table) => [
 		check("intervalo_dias_positive", sql`${table.intervaloDias} > 0`),
+	],
+);
+
+// CB-024: snapshot de cierre diario de cobros, DETALLE por crédito. Job corre
+// 22:00 GT todos los días con dos orígenes distintos en la misma tabla
+// (columna `tipo` los distingue):
+//   - 'contacto': una fila por cada contacto real del día (INSERT ... ON
+//     CONFLICT (contacto_id) DO NOTHING — un contacto ya registrado es
+//     histórico inmutable, nunca se duplica en un re-run).
+//   - 'subida'/'bajada': una fila por cada crédito que SALIÓ del bucket del
+//     pool del asesor ese día, con su ruta (bucketAnterior → bucket). Se
+//     reemplazan completos (DELETE + INSERT del día) porque son datos
+//     derivados de cartera-back, recalculables en cada corrida.
+// Los agregados (efectivos, promesas, subieron, bajaron) se calculan agrupando
+// esta misma tabla — no se guardan aparte.
+export const cierreCreditoTipoEnum = pgEnum("cierre_credito_tipo", [
+	"contacto",
+	"subida",
+	"bajada",
+]);
+
+export const cierreDiarioCreditoCobros = pgTable(
+	"cierre_diario_credito_cobros",
+	{
+		id: uuid("id").primaryKey().defaultRandom(),
+		fecha: date("fecha").notNull(),
+		asesorId: text("asesor_id")
+			.notNull()
+			.references(() => user.id),
+		tipo: cierreCreditoTipoEnum("tipo").notNull(),
+
+		casoCobroId: uuid("caso_cobro_id").references(() => casosCobros.id),
+		numeroCreditoSifco: text("numero_credito_sifco"),
+
+		// Solo aplica cuando tipo='contacto'
+		contactoId: uuid("contacto_id").references(() => contactosCobros.id),
+		estadoContacto: estadoContactoEnum("estado_contacto"),
+		// El cliente CONTESTÓ y el contacto fue manual del asesor. Categorías
+		// excluyentes: 'promesa_pago' NO suma acá (cuenta como promesa aparte);
+		// 'no_contesta'/'numero_equivocado' no cuentan en ninguna. Excluye además
+		// los contactos automáticos del sistema, identificados por prefijo de
+		// comentario (ver send-premora-reminders.ts y cobros.ts:createMassWhatsapp).
+		esEfectivoManual: boolean("es_efectivo_manual").notNull().default(false),
+		fechaContacto: timestamp("fecha_contacto"),
+
+		// Solo aplican cuando tipo='subida'/'bajada' — la ruta del movimiento.
+		bucketAnterior: integer("bucket_anterior"), // de dónde salió (pool del asesor)
+		bucket: integer("bucket"), // a dónde fue
+
+		generadoEn: timestamp("generado_en").notNull().defaultNow(),
+	},
+	(table) => [
+		uniqueIndex("idx_cierre_detalle_contacto_unico")
+			.on(table.contactoId)
+			.where(sql`${table.contactoId} IS NOT NULL`),
+		index("idx_cierre_detalle_fecha_asesor").on(table.fecha, table.asesorId),
 	],
 );

--- a/apps/crm/apps/server/src/index.ts
+++ b/apps/crm/apps/server/src/index.ts
@@ -32,6 +32,7 @@ import {
 } from "./controllers/vehicles";
 import type { db } from "./db";
 import { otps } from "./db/schema/otp";
+import { generarCierreDiario } from "./jobs/cierre-diario-asesores";
 import {
 	checkSeguimientosVencidos,
 	procesarSeguimientosRecurrentes,
@@ -1343,6 +1344,39 @@ function scheduleAtMidnightGT() {
 	}, next.getTime() - now.getTime());
 }
 scheduleAtMidnightGT();
+
+// CB-024: cierre diario de asesores — snapshot de gestión (contactos
+// efectivos manuales, promesas, movimientos de bucket) a las 22:00 GT
+// (= 04:00 UTC) todos los días. Re-correr el mismo día es seguro: los
+// contactos van con ON CONFLICT DO NOTHING y los movimientos se reemplazan
+// completos (DELETE + INSERT), así que un deploy tardío recupera el snapshot
+// del día sin duplicar.
+function scheduleAtCierreDiarioGT() {
+	const now = new Date();
+	const next = new Date();
+	next.setUTCHours(4, 0, 0, 0); // 22:00 GT
+	if (next <= now) next.setUTCDate(next.getUTCDate() + 1);
+	setTimeout(async () => {
+		await generarCierreDiario().catch(console.error);
+		scheduleAtCierreDiarioGT();
+	}, next.getTime() - now.getTime());
+}
+scheduleAtCierreDiarioGT();
+// Recuperación al boot SOLO si ya pasaron las 22:00 GT (deploy tardío recupera
+// el snapshot de hoy; re-correr no duplica, ver arriba). Si el boot cae justo
+// dentro de la ventana de las 22:00, el advisory lock del job hace que el
+// segundo runner salga sin hacer nada. Antes de las 22:00 GT NO se corre: se
+// deja que el timeout programado lo lance a la hora.
+setTimeout(() => {
+	const horaGT = (new Date().getUTCHours() + 18) % 24; // GT = UTC-6, sin DST
+	if (horaGT >= 22) {
+		generarCierreDiario().catch(console.error);
+	} else {
+		console.log(
+			"[CierreDiarioAsesor] Boot antes de las 22:00 GT; se omite la recuperación (el timeout programado lo lanzará a la hora)",
+		);
+	}
+}, 25_000);
 
 export default {
 	port: process.env.PORT || 3000,

--- a/apps/crm/apps/server/src/index.ts
+++ b/apps/crm/apps/server/src/index.ts
@@ -39,6 +39,7 @@ import {
 } from "./jobs/cobros-notifications";
 import { auth } from "./lib/auth";
 import { createContext } from "./lib/context";
+import { toDateStrGT } from "./lib/guatemala-month-window";
 import { getTestPhone, isTestModeEnabled } from "./lib/messaging-test-mode";
 import { PERMISSIONS } from "./lib/roles";
 import { bucketCapacidadRouter } from "./routers/bucket-capacidad";
@@ -1346,34 +1347,43 @@ function scheduleAtMidnightGT() {
 scheduleAtMidnightGT();
 
 // CB-024: cierre diario de asesores — snapshot de gestión (contactos
-// efectivos manuales, promesas, movimientos de bucket) a las 22:00 GT
-// (= 04:00 UTC) todos los días. Re-correr el mismo día es seguro: los
-// contactos van con ON CONFLICT DO NOTHING y los movimientos se reemplazan
-// completos (DELETE + INSERT), así que un deploy tardío recupera el snapshot
-// del día sin duplicar.
+// efectivos manuales, promesas, movimientos de bucket) a las 00:15 GT
+// (= 06:15 UTC) todos los días, del día que ACABA DE TERMINAR (ayer GT).
+//
+// NO a las 22:00 GT: los movimientos de bucket los genera `procesarMoras` en
+// cartera-back a las 23:59 GT (schedule.ts:37 de ese repo) — correr antes
+// significa preguntar por el día de hoy ANTES de que esas filas existan, y
+// como el job nunca vuelve a visitar un día ya cerrado, esos movimientos se
+// pierden para siempre, todos los días (hallado por Codex en PR #1183).
+//
+// Re-correr el mismo día es seguro: los contactos van con ON CONFLICT DO
+// NOTHING y los movimientos se reemplazan completos (DELETE + INSERT), así
+// que un deploy tardío recupera el snapshot del día sin duplicar.
+function ayerGT(): string {
+	return toDateStrGT(new Date(Date.now() - 24 * 60 * 60 * 1000));
+}
 function scheduleAtCierreDiarioGT() {
 	const now = new Date();
 	const next = new Date();
-	next.setUTCHours(4, 0, 0, 0); // 22:00 GT
+	next.setUTCHours(6, 15, 0, 0); // 00:15 GT
 	if (next <= now) next.setUTCDate(next.getUTCDate() + 1);
 	setTimeout(async () => {
-		await generarCierreDiario().catch(console.error);
+		await generarCierreDiario(ayerGT()).catch(console.error);
 		scheduleAtCierreDiarioGT();
 	}, next.getTime() - now.getTime());
 }
 scheduleAtCierreDiarioGT();
-// Recuperación al boot SOLO si ya pasaron las 22:00 GT (deploy tardío recupera
-// el snapshot de hoy; re-correr no duplica, ver arriba). Si el boot cae justo
-// dentro de la ventana de las 22:00, el advisory lock del job hace que el
-// segundo runner salga sin hacer nada. Antes de las 22:00 GT NO se corre: se
-// deja que el timeout programado lo lance a la hora.
+// Recuperación al boot SOLO si ya pasaron las 00:15 GT (deploy tardío recupera
+// el snapshot de ayer; re-correr no duplica, ver arriba). Antes de las 00:15
+// GT NO se corre: se deja que el timeout programado lo lance a la hora.
 setTimeout(() => {
 	const horaGT = (new Date().getUTCHours() + 18) % 24; // GT = UTC-6, sin DST
-	if (horaGT >= 22) {
-		generarCierreDiario().catch(console.error);
+	const minutoGT = new Date().getUTCMinutes();
+	if (horaGT > 0 || (horaGT === 0 && minutoGT >= 15)) {
+		generarCierreDiario(ayerGT()).catch(console.error);
 	} else {
 		console.log(
-			"[CierreDiarioAsesor] Boot antes de las 22:00 GT; se omite la recuperación (el timeout programado lo lanzará a la hora)",
+			"[CierreDiarioAsesor] Boot antes de las 00:15 GT; se omite la recuperación (el timeout programado lo lanzará a la hora)",
 		);
 	}
 }, 25_000);

--- a/apps/crm/apps/server/src/index.ts
+++ b/apps/crm/apps/server/src/index.ts
@@ -1377,8 +1377,9 @@ scheduleAtCierreDiarioGT();
 // el snapshot de ayer; re-correr no duplica, ver arriba). Antes de las 00:15
 // GT NO se corre: se deja que el timeout programado lo lance a la hora.
 setTimeout(() => {
-	const horaGT = (new Date().getUTCHours() + 18) % 24; // GT = UTC-6, sin DST
-	const minutoGT = new Date().getUTCMinutes();
+	const bootNow = new Date();
+	const horaGT = (bootNow.getUTCHours() + 18) % 24; // GT = UTC-6, sin DST
+	const minutoGT = bootNow.getUTCMinutes();
 	if (horaGT > 0 || (horaGT === 0 && minutoGT >= 15)) {
 		generarCierreDiario(ayerGT()).catch(console.error);
 	} else {

--- a/apps/crm/apps/server/src/jobs/cierre-diario-asesores.ts
+++ b/apps/crm/apps/server/src/jobs/cierre-diario-asesores.ts
@@ -25,8 +25,8 @@
  *    del bucket de origen — ver el comentario en
  *    _generarCierreMovimientosBucket para el porqué de cada descarte. El
  *    asesor en cartera-back tiene id numérico distinto al user.id (texto) del
- *    CRM — se resuelve cruzando por correo con `email_asesor` de
- *    /buckets/carga (ver construirMapaAsesorUsuarioPorCarga). Se reemplaza
+ *    CRM — se resuelve cruzando por NOMBRE contra el pool completo de
+ *    /buckets/pool (ver construirMapaAsesorUsuarioPorCarga). Se reemplaza
  *    completo (DELETE + INSERT) en cada corrida: son datos derivados de
  *    cartera-back, recalculables, sin un "contacto" que ancle un ON CONFLICT.
  */
@@ -120,30 +120,51 @@ async function _generarCierreContactos(client: RawClient, fecha: string) {
 	);
 }
 
+// Buckets fijos del funnel operativo (B0-B5) — se recorren para armar el pool
+// completo de asesores, igual que en getCierreDiarioPorRango (routers/cobros.ts).
+const BUCKETS_NUMEROS = [0, 1, 2, 3, 4, 5] as const;
+
 /**
- * Mapa `asesor_id (cartera) → user.id (CRM)`, cruzando por correo.
+ * Mapa `asesor_id (cartera) → user.id (CRM)`, cruzando por NOMBRE.
  *
- * El correo sale de `/buckets/carga` (`email_asesor`) y NO de
- * construirMapaAsesorUsuario/getAdvisors: en getAdvisors el correo de varios
- * asesores está desactualizado (`cobros@…`, `@sepresta.com`) y no cruza con el
- * `user.email` del CRM, mientras que `/buckets/carga` trae el correo vigente.
+ * NO se usa `getCargaPorAsesorBucket` (como antes): esa lista solo incluye
+ * asesores con al menos un crédito ACTUALMENTE en el funnel operativo
+ * (excluye CANCELADO/PENDIENTE_CANCELACION/EN_CONVENIO/CAIDO — ver
+ * STATUS_BUCKET_FUERA en cartera-back). `getBucketsHistorial` no tiene ese
+ * filtro: si el único crédito de un asesor se resolvió (se pagó, se canceló)
+ * ENTRE el movimiento de bucket y esta corrida (00:15 GT del día siguiente),
+ * ese asesor desaparecía del mapa y su movimiento se descartaba en silencio
+ * — un caso frecuente en cobros, no un edge case (hallado por Codex en PR
+ * #1185).
+ *
+ * En su lugar, el pool sale de `getPoolAsesoresPorBucket` (6 llamadas, una
+ * por bucket) — es `asesor_bucket WHERE activo=true` tal cual, sin depender
+ * de créditos ni de su estado. Ese endpoint no trae email, así que el cruce
+ * con `user` del CRM va por NOMBRE normalizado (trim + lowercase) en vez de
+ * correo — menos preciso que el email, pero los nombres son únicos en la
+ * práctica y es preferible a perder movimientos reales.
  */
 async function construirMapaAsesorUsuarioPorCarga(): Promise<
 	Map<number, string>
 > {
-	const [carga, usuarios] = await Promise.all([
-		carteraBackClient.getCargaPorAsesorBucket({}),
-		db.select({ id: user.id, email: user.email }).from(user),
+	const [pools, usuarios] = await Promise.all([
+		Promise.all(
+			BUCKETS_NUMEROS.map((bucket) =>
+				carteraBackClient.getPoolAsesoresPorBucket(bucket),
+			),
+		),
+		db.select({ id: user.id, name: user.name }).from(user),
 	]);
-	const emailToUserId = new Map(
-		usuarios.map((u) => [u.email.trim().toLowerCase(), u.id]),
+	const nombreToUserId = new Map(
+		usuarios.map((u) => [u.name.trim().toLowerCase(), u.id]),
 	);
 	const mapa = new Map<number, string>();
-	for (const a of carga.porAsesor) {
-		const email = a.email_asesor?.trim().toLowerCase();
-		if (!email) continue;
-		const userId = emailToUserId.get(email);
-		if (userId) mapa.set(a.asesor_id, userId);
+	for (const pool of pools) {
+		for (const a of pool) {
+			if (mapa.has(a.asesor_id)) continue;
+			const userId = nombreToUserId.get(a.nombre.trim().toLowerCase());
+			if (userId) mapa.set(a.asesor_id, userId);
+		}
 	}
 	return mapa;
 }

--- a/apps/crm/apps/server/src/jobs/cierre-diario-asesores.ts
+++ b/apps/crm/apps/server/src/jobs/cierre-diario-asesores.ts
@@ -225,17 +225,24 @@ async function _generarCierreMovimientosBucket(fecha: string) {
 	// Resolver caso_cobro_id por número SIFCO — un crédito de cartera-back puede
 	// no tener caso creado todavía en CRM (queda NULL; la UI navega por SIFCO).
 	// El filtro va EN LA QUERY: traer casos_cobros entera para descartar en JS
-	// crecía con la tabla, no con los pocos SIFCO del día.
+	// crecía con la tabla, no con los pocos SIFCO del día. En lotes de 1000
+	// (mismo CHUNK_SIZE que controllers/vehicles.ts): con hasta 500 páginas de
+	// movimientos, `sifcos` puede acercarse al límite de bind params de
+	// Postgres (~65535) igual que el INSERT de más abajo.
 	const sifcos = [...new Set(filas.map((f) => f.numeroCreditoSifco))];
-	const casos = sifcos.length
-		? await db
-				.select({
-					id: casosCobros.id,
-					numeroCreditoSifco: casosCobros.numeroCreditoSifco,
-				})
-				.from(casosCobros)
-				.where(inArray(casosCobros.numeroCreditoSifco, sifcos))
-		: [];
+	const CHUNK_SIZE = 1000;
+	const casos: { id: string; numeroCreditoSifco: string | null }[] = [];
+	for (let i = 0; i < sifcos.length; i += CHUNK_SIZE) {
+		const chunk = sifcos.slice(i, i + CHUNK_SIZE);
+		const parte = await db
+			.select({
+				id: casosCobros.id,
+				numeroCreditoSifco: casosCobros.numeroCreditoSifco,
+			})
+			.from(casosCobros)
+			.where(inArray(casosCobros.numeroCreditoSifco, chunk));
+		casos.push(...parte);
+	}
 	const sifcoToCasoId = new Map(
 		casos
 			.filter((c) => c.numeroCreditoSifco)

--- a/apps/crm/apps/server/src/jobs/cierre-diario-asesores.ts
+++ b/apps/crm/apps/server/src/jobs/cierre-diario-asesores.ts
@@ -20,15 +20,14 @@
  *  - Paso B 'subida'/'bajada': créditos que cambiaron de bucket ese día, con su
  *    ruta (bucket_anterior → bucket). Definición confirmada por Jhairo Nájera
  *    (responsable CB-024): el reporte muestra "hoy subieron N / bajaron M". La
- *    atribución va por `asesor_id` (dueño ACTUAL del crédito, NOT NULL) y NO
- *    por `asesor_atribucion_id` (buckets_historial.asesor_id) ni por el pool
- *    del bucket de origen — ver el comentario en
- *    _generarCierreMovimientosBucket para el porqué de cada descarte. El
- *    asesor en cartera-back tiene id numérico distinto al user.id (texto) del
- *    CRM — se resuelve cruzando por NOMBRE contra el pool completo de
- *    /buckets/pool (ver construirMapaAsesorUsuarioPorCarga). Se reemplaza
- *    completo (DELETE + INSERT) en cada corrida: son datos derivados de
- *    cartera-back, recalculables, sin un "contacto" que ancle un ON CONFLICT.
+ *    atribución va por `evento.asesor` (nombre del dueño del crédito, tal como
+ *    lo trae CADA fila de getBucketsHistorial) — ver resolverAsesorId para el
+ *    porqué de descartar `asesor_atribucion_id` y los mapas externos
+ *    (pool/carga) que se probaron antes. El asesor en cartera-back no tiene
+ *    id de usuario del CRM propio — se resuelve cruzando por nombre contra
+ *    `user.name`. Se reemplaza completo (DELETE + INSERT) en cada corrida:
+ *    son datos derivados de cartera-back, recalculables, sin un "contacto"
+ *    que ancle un ON CONFLICT.
  */
 
 import { inArray } from "drizzle-orm";
@@ -120,63 +119,41 @@ async function _generarCierreContactos(client: RawClient, fecha: string) {
 	);
 }
 
-// Buckets fijos del funnel operativo (B0-B5) — se recorren para armar el pool
-// completo de asesores, igual que en getCierreDiarioPorRango (routers/cobros.ts).
-const BUCKETS_NUMEROS = [0, 1, 2, 3, 4, 5] as const;
-
 /**
- * Mapa `asesor_id (cartera) → user.id (CRM)`, cruzando por NOMBRE.
+ * Mapa `nombre normalizado → user.id (CRM)`. Cruzar por nombre en vez de
+ * asesor_id/email porque el nombre viaja EN CADA FILA del evento
+ * (`getBucketsHistorial().data[].asesor`), sin necesitar una llamada aparte
+ * a un pool o catálogo que puede cambiar entre el movimiento y esta corrida.
  *
- * NO se usa `getCargaPorAsesorBucket` (como antes): esa lista solo incluye
- * asesores con al menos un crédito ACTUALMENTE en el funnel operativo
- * (excluye CANCELADO/PENDIENTE_CANCELACION/EN_CONVENIO/CAIDO — ver
- * STATUS_BUCKET_FUERA en cartera-back). `getBucketsHistorial` no tiene ese
- * filtro: si el único crédito de un asesor se resolvió (se pagó, se canceló)
- * ENTRE el movimiento de bucket y esta corrida (00:15 GT del día siguiente),
- * ese asesor desaparecía del mapa y su movimiento se descartaba en silencio
- * — un caso frecuente en cobros, no un edge case (hallado por Codex en PR
- * #1185).
- *
- * En su lugar, el pool sale de `getPoolAsesoresPorBucket` (6 llamadas, una
- * por bucket) — es `asesor_bucket WHERE activo=true` tal cual, sin depender
- * de créditos ni de su estado. Ese endpoint no trae email, así que el cruce
- * con `user` del CRM va por NOMBRE normalizado (trim + lowercase) en vez de
- * correo — menos preciso que el email, pero los nombres son únicos en la
- * práctica y es preferible a perder movimientos reales.
+ * Se descartaron dos fuentes externas antes de llegar acá, ambas por la misma
+ * clase de bug (mapa construido de un catálogo "vigente ahora", que puede
+ * haber perdido al asesor entre el evento y la corrida — 00:15 GT del día
+ * siguiente):
+ *   - `getCargaPorAsesorBucket`: excluye créditos CANCELADO/
+ *     PENDIENTE_CANCELACION/EN_CONVENIO/CAIDO (STATUS_BUCKET_FUERA en
+ *     cartera-back) — si el único crédito del asesor se resolvió antes de la
+ *     corrida, desaparecía del mapa (hallado por Codex en PR #1185, 1er round).
+ *   - `getPoolAsesoresPorBucket`: solo pool ACTIVO ahora — si desactivan al
+ *     asesor del pool entre el evento y la corrida, mismo problema, y además
+ *     el DELETE+INSERT de abajo podía BORRAR filas ya capturadas en una
+ *     corrida anterior si un re-run perdía a ese asesor del mapa (hallado por
+ *     Codex en PR #1185, 2do round).
+ * Usar el nombre que trae el propio evento es inmune a ambos: no depende de
+ * ningún estado "actual" externo al evento mismo.
  */
-async function construirMapaAsesorUsuarioPorCarga(): Promise<
-	Map<number, string>
-> {
-	const [pools, usuarios] = await Promise.all([
-		Promise.all(
-			BUCKETS_NUMEROS.map((bucket) =>
-				carteraBackClient.getPoolAsesoresPorBucket(bucket),
-			),
-		),
-		db.select({ id: user.id, name: user.name }).from(user),
-	]);
-	const nombreToUserId = new Map(
-		usuarios.map((u) => [u.name.trim().toLowerCase(), u.id]),
-	);
-	const mapa = new Map<number, string>();
-	for (const pool of pools) {
-		for (const a of pool) {
-			if (mapa.has(a.asesor_id)) continue;
-			const userId = nombreToUserId.get(a.nombre.trim().toLowerCase());
-			if (userId) mapa.set(a.asesor_id, userId);
-		}
-	}
-	return mapa;
+function resolverAsesorId(
+	nombreAsesor: string | null,
+	nombreToUserId: ReadonlyMap<string, string>,
+): string | null {
+	if (!nombreAsesor) return null;
+	return nombreToUserId.get(nombreAsesor.trim().toLowerCase()) ?? null;
 }
 
 async function _generarCierreMovimientosBucket(fecha: string) {
-	const mapaAsesorUsuario = await construirMapaAsesorUsuarioPorCarga();
-	if (mapaAsesorUsuario.size === 0) {
-		console.log(
-			"[CierreDiarioAsesor] Sin mapa asesor→usuario, se omiten movimientos de bucket",
-		);
-		return;
-	}
+	const usuarios = await db.select({ id: user.id, name: user.name }).from(user);
+	const nombreToUserId = new Map(
+		usuarios.map((u) => [u.name.trim().toLowerCase(), u.id]),
+	);
 
 	type FilaMovimiento = {
 		asesorId: string;
@@ -204,26 +181,21 @@ async function _generarCierreMovimientosBucket(fecha: string) {
 		});
 		for (const evento of resp.data ?? []) {
 			if (evento.bucket_anterior == null) continue;
-			// Se atribuye por evento.asesor_id — el dueño ACTUAL del crédito
-			// (creditos.asesor_id, NOT NULL, "hoy siempre hay dueño" según la
-			// decisión de raíz 2026-07-07 de cartera-back). NO
-			// asesor_atribucion_id (buckets_historial.asesor_id): ese campo lo
-			// deja NULL el proceso automático nocturno (latefee.ts:1181, comentario
-			// "Opción B: se llena con el nuevo flujo de pago" — no implementado
-			// todavía), así que filtrar por él descarta el 100% de los movimientos
-			// del motor normal, no solo un caso borde (hallado por Codex en PR
-			// #1183 tras el primer intento con asesor_atribucion_id). El costo
-			// aceptado: si el crédito se reasigna después de moverse de bucket, la
-			// atribución "sigue" al nuevo dueño en vez de quedar congelada al
-			// momento del evento — trade-off necesario porque la alternativa es
-			// cero movimientos reportados, siempre.
-			// Tampoco se usa el pool del bucket de origen: varios asesores
-			// comparten bucket (B2 lo atienden 3), así que por pool un mismo
-			// movimiento se contaba varias veces y los totales no cuadraban con
-			// los eventos reales. Eventos sin asesor, o cuyo asesor no cruza con un
-			// usuario del CRM, se omiten.
-			if (evento.asesor_id == null) continue;
-			const asesorId = mapaAsesorUsuario.get(evento.asesor_id);
+			// Se atribuye por evento.asesor (nombre) — el dueño ACTUAL del crédito
+			// al momento del evento (creditos.asesor_id vía el JOIN de
+			// cartera-back, "hoy siempre hay dueño" según la decisión de raíz
+			// 2026-07-07 de ese repo). NO asesor_atribucion_id
+			// (buckets_historial.asesor_id): ese campo lo deja NULL el proceso
+			// automático nocturno (latefee.ts:1181, "se llena con el nuevo flujo
+			// de pago" — no implementado todavía), así que filtrar por él descarta
+			// el 100% de los movimientos del motor normal (hallado por Codex en
+			// PR #1183). Tampoco el pool del bucket de origen: varios asesores
+			// comparten bucket, un mismo movimiento se contaba varias veces. Y NO
+			// un mapa externo (pool/carga) resuelto aparte: ambos dependían de un
+			// catálogo "vigente ahora" que puede haber perdido al asesor entre el
+			// evento y esta corrida — ver resolverAsesorId. Eventos sin asesor, o
+			// cuyo nombre no cruza con un usuario del CRM, se omiten.
+			const asesorId = resolverAsesorId(evento.asesor, nombreToUserId);
 			if (!asesorId) continue;
 			filas.push({
 				asesorId,

--- a/apps/crm/apps/server/src/jobs/cierre-diario-asesores.ts
+++ b/apps/crm/apps/server/src/jobs/cierre-diario-asesores.ts
@@ -1,0 +1,291 @@
+/**
+ * CB-024: Job de cierre diario de cobros.
+ * Corre todos los días a las 22:00 GT (ver scheduleAtCierreDiarioGT en index.ts)
+ * y hace un snapshot de DETALLE en `cierre_diario_credito_cobros` — una fila
+ * por crédito, no un agregado — con dos orígenes distintos (columna `tipo`):
+ *
+ *  - Paso A 'contacto': cada contacto real del día. "Contacto efectivo" = el
+ *    cliente CONTESTÓ y el contacto fue manual del asesor. Las categorías son
+ *    EXCLUYENTES (definición cerrada con el usuario): 'promesa_pago' NO cuenta
+ *    como efectivo — se reporta aparte como promesa; 'no_contesta' y
+ *    'numero_equivocado' no cuentan en ninguna. Se excluyen además los
+ *    contactos que el sistema genera automáticamente (recordatorios premora,
+ *    envío masivo de WhatsApp) — no tienen columna de origen propia, se
+ *    identifican por el prefijo de `comentarios` que ya usan
+ *    send-premora-reminders.ts y cobros.ts (createMassWhatsapp). Si cambia el
+ *    texto de esos prefijos, actualizar también aquí. Idempotente vía
+ *    ON CONFLICT (contacto_id) DO NOTHING — un contacto ya registrado es
+ *    histórico inmutable, nunca se duplica.
+ *
+ *  - Paso B 'subida'/'bajada': créditos que cambiaron de bucket ese día, con su
+ *    ruta (bucket_anterior → bucket). Definición confirmada por Jhairo Nájera
+ *    (responsable CB-024): el reporte muestra "hoy subieron N / bajaron M". La
+ *    atribución va por `asesor_atribucion_id` (el asesor que tenía el crédito
+ *    AL MOMENTO del evento, congelado en buckets_historial) y NO por
+ *    `asesor_id` (dueño ACTUAL del crédito, que cambia si lo reasignan
+ *    después) ni por el pool del bucket de origen: varios asesores comparten
+ *    bucket, así que por pool un mismo movimiento se contaba varias veces. El
+ *    asesor en cartera-back tiene id numérico distinto al user.id (texto) del
+ *    CRM — se resuelve cruzando por correo con `email_asesor` de
+ *    /buckets/carga (ver construirMapaAsesorUsuarioPorCarga). Se reemplaza
+ *    completo (DELETE + INSERT) en cada corrida: son datos derivados de
+ *    cartera-back, recalculables, sin un "contacto" que ancle un ON CONFLICT.
+ */
+
+import { inArray } from "drizzle-orm";
+import { db } from "../db";
+import { user } from "../db/schema/auth";
+import { casosCobros } from "../db/schema/cobros";
+import { toDateStrGT } from "../lib/guatemala-month-window";
+import { carteraBackClient } from "../services/cartera-back-client";
+
+/**
+ * Prefijos con los que el sistema marca los contactos que genera solo
+ * (`contactos_cobros` no tiene columna de origen). Los escriben
+ * send-premora-reminders.ts y cobros.ts::enviarWhatsappMasivoCobros; acá se
+ * leen para excluirlos de la gestión del asesor. Se exportan porque el reporte
+ * (routers/cobros.ts) aplica el mismo criterio al contar promesas y al
+ * etiquetar el origen en el detalle — así el filtro de escritura y el de
+ * lectura no pueden divergir.
+ */
+export const PREFIJO_PREMORA_AUTO = "Recordatorio automático";
+export const PREFIJO_WSP_MASIVO = "Envío masivo de WhatsApp";
+
+// Two-component advisory lock key: namespace=1 (cobros jobs), key=2 (cierre diario asesor)
+const CIERRE_DIARIO_LOCK = [1, 2] as const;
+
+interface RawClient {
+	query<T extends object>(
+		text: string,
+		values?: unknown[],
+	): Promise<{ rows: T[] }>;
+}
+
+export async function generarCierreDiario(fechaGT?: string) {
+	const fecha = fechaGT ?? toDateStrGT(new Date());
+	const client = await db.$client.connect();
+	let acquired = false;
+	try {
+		const { rows } = await client.query<{ acquired: boolean }>(
+			"SELECT pg_try_advisory_lock($1, $2) AS acquired",
+			[...CIERRE_DIARIO_LOCK],
+		);
+		acquired = rows[0].acquired;
+		if (!acquired) {
+			console.log(
+				"[CierreDiarioAsesor] Already running (distributed lock held), skipping",
+			);
+			return;
+		}
+		await _generarCierreContactos(client, fecha);
+		await _generarCierreMovimientosBucket(fecha);
+	} finally {
+		if (acquired) {
+			await client.query("SELECT pg_advisory_unlock($1, $2)", [
+				...CIERRE_DIARIO_LOCK,
+			]);
+		}
+		client.release();
+	}
+}
+
+async function _generarCierreContactos(client: RawClient, fecha: string) {
+	const { rows } = await client.query<{ asesor_id: string }>(
+		`INSERT INTO cierre_diario_credito_cobros
+			(fecha, asesor_id, tipo, caso_cobro_id, numero_credito_sifco,
+			 contacto_id, estado_contacto, es_efectivo_manual, fecha_contacto)
+		SELECT
+			$1::date,
+			cc.realizado_por,
+			'contacto',
+			cc.caso_cobro_id,
+			ccb.numero_credito_sifco,
+			cc.id,
+			cc.estado_contacto,
+			(
+				cc.estado_contacto IN ('contactado', 'acuerdo_parcial', 'rechaza_pagar')
+				AND cc.comentarios NOT LIKE $2 || '%'
+				AND cc.comentarios NOT LIKE $3 || '%'
+			),
+			cc.fecha_contacto
+		FROM contactos_cobros cc
+		JOIN casos_cobros ccb ON ccb.id = cc.caso_cobro_id
+		WHERE (cc.fecha_contacto - INTERVAL '6 hours')::date = $1::date
+		ON CONFLICT (contacto_id) WHERE contacto_id IS NOT NULL DO NOTHING
+		RETURNING asesor_id`,
+		[fecha, PREFIJO_PREMORA_AUTO, PREFIJO_WSP_MASIVO],
+	);
+
+	console.log(
+		`[CierreDiarioAsesor] ${fecha}: ${rows.length} contactos insertados`,
+	);
+}
+
+/**
+ * Mapa `asesor_id (cartera) → user.id (CRM)`, cruzando por correo.
+ *
+ * El correo sale de `/buckets/carga` (`email_asesor`) y NO de
+ * construirMapaAsesorUsuario/getAdvisors: en getAdvisors el correo de varios
+ * asesores está desactualizado (`cobros@…`, `@sepresta.com`) y no cruza con el
+ * `user.email` del CRM, mientras que `/buckets/carga` trae el correo vigente.
+ */
+async function construirMapaAsesorUsuarioPorCarga(): Promise<
+	Map<number, string>
+> {
+	const [carga, usuarios] = await Promise.all([
+		carteraBackClient.getCargaPorAsesorBucket({}),
+		db.select({ id: user.id, email: user.email }).from(user),
+	]);
+	const emailToUserId = new Map(
+		usuarios.map((u) => [u.email.trim().toLowerCase(), u.id]),
+	);
+	const mapa = new Map<number, string>();
+	for (const a of carga.porAsesor) {
+		const email = a.email_asesor?.trim().toLowerCase();
+		if (!email) continue;
+		const userId = emailToUserId.get(email);
+		if (userId) mapa.set(a.asesor_id, userId);
+	}
+	return mapa;
+}
+
+async function _generarCierreMovimientosBucket(fecha: string) {
+	const mapaAsesorUsuario = await construirMapaAsesorUsuarioPorCarga();
+	if (mapaAsesorUsuario.size === 0) {
+		console.log(
+			"[CierreDiarioAsesor] Sin mapa asesor→usuario, se omiten movimientos de bucket",
+		);
+		return;
+	}
+
+	type FilaMovimiento = {
+		asesorId: string;
+		numeroCreditoSifco: string;
+		bucketAnterior: number;
+		bucketNuevo: number;
+		tipo: "subida" | "bajada";
+	};
+	const filas: FilaMovimiento[] = [];
+
+	let page = 1;
+	const pageSize = 200;
+	// Tope duro: corre dentro del advisory lock, así que un totalPages corrupto
+	// o desincronizado de cartera-back no debe colgar el job para siempre y
+	// bloquear toda corrida futura del cierre.
+	const MAX_PAGINAS = 500;
+	let truncado = false;
+	for (; page <= MAX_PAGINAS; page++) {
+		const resp = await carteraBackClient.getBucketsHistorial({
+			desde: fecha,
+			hasta: fecha,
+			tipo_evento: "SUBIDA,BAJADA",
+			page,
+			pageSize,
+		});
+		for (const evento of resp.data ?? []) {
+			if (evento.bucket_anterior == null) continue;
+			// Se atribuye al asesor que tenía el crédito AL MOMENTO del evento
+			// (asesor_atribucion_id, que sale de buckets_historial.asesor_id) — NO
+			// evento.asesor_id, que es el dueño ACTUAL del crédito (sale de
+			// creditos.asesor_id, ver bucketsHistorial.ts en cartera-back). Si el
+			// crédito se reasigna después de moverse de bucket, usar el dueño
+			// actual cambiaría retroactivamente a quién se le atribuye el
+			// movimiento — contradice que el cierre es una foto congelada del día.
+			// Tampoco se usa el pool del bucket de origen: varios asesores
+			// comparten bucket (B2 lo atienden 3), así que por pool un mismo
+			// movimiento se contaba varias veces y los totales no cuadraban con
+			// los eventos reales. Eventos sin asesor de atribución, o cuyo asesor
+			// no cruza con un usuario del CRM, se omiten.
+			if (evento.asesor_atribucion_id == null) continue;
+			const asesorId = mapaAsesorUsuario.get(evento.asesor_atribucion_id);
+			if (!asesorId) continue;
+			filas.push({
+				asesorId,
+				numeroCreditoSifco: evento.numero_credito_sifco,
+				bucketAnterior: evento.bucket_anterior,
+				bucketNuevo: evento.bucket_nuevo,
+				tipo: evento.tipo_evento === "SUBIDA" ? "subida" : "bajada",
+			});
+		}
+		const totalPages = resp.pagination?.totalPages ?? 1;
+		if (page >= totalPages) break;
+		if (page === MAX_PAGINAS) truncado = true;
+	}
+	if (truncado) {
+		console.warn(
+			`[CierreDiarioAsesor] ${fecha}: se alcanzó el tope de ${MAX_PAGINAS} páginas de movimientos de bucket — posible totalPages corrupto de cartera-back`,
+		);
+	}
+
+	// Resolver caso_cobro_id por número SIFCO — un crédito de cartera-back puede
+	// no tener caso creado todavía en CRM (queda NULL; la UI navega por SIFCO).
+	// El filtro va EN LA QUERY: traer casos_cobros entera para descartar en JS
+	// crecía con la tabla, no con los pocos SIFCO del día.
+	const sifcos = [...new Set(filas.map((f) => f.numeroCreditoSifco))];
+	const casos = sifcos.length
+		? await db
+				.select({
+					id: casosCobros.id,
+					numeroCreditoSifco: casosCobros.numeroCreditoSifco,
+				})
+				.from(casosCobros)
+				.where(inArray(casosCobros.numeroCreditoSifco, sifcos))
+		: [];
+	const sifcoToCasoId = new Map(
+		casos
+			.filter((c) => c.numeroCreditoSifco)
+			.map((c) => [c.numeroCreditoSifco as string, c.id]),
+	);
+
+	const client = await db.$client.connect();
+	try {
+		await client.query("BEGIN");
+		await client.query(
+			`DELETE FROM cierre_diario_credito_cobros
+			 WHERE fecha = $1::date AND tipo IN ('subida', 'bajada')`,
+			[fecha],
+		);
+
+		// Postgres tiene un tope de ~65535 bind params por statement (7 por fila
+		// → ~9360 filas). Se manda en lotes para no reventar en un día pesado
+		// (una migración masiva de cartera podría acercarse a ese número).
+		const TAMANO_LOTE = 1000;
+		for (let inicio = 0; inicio < filas.length; inicio += TAMANO_LOTE) {
+			const lote = filas.slice(inicio, inicio + TAMANO_LOTE);
+			const params: unknown[] = [];
+			const placeholders = lote
+				.map((f, i) => {
+					const b = i * 7;
+					params.push(
+						fecha,
+						f.asesorId,
+						sifcoToCasoId.get(f.numeroCreditoSifco) ?? null,
+						f.numeroCreditoSifco,
+						f.bucketAnterior,
+						f.bucketNuevo,
+						f.tipo,
+					);
+					return `($${b + 1}::date, $${b + 2}::text, $${b + 3}::uuid, $${b + 4}::text, $${b + 5}::int, $${b + 6}::int, $${b + 7}::cierre_credito_tipo)`;
+				})
+				.join(", ");
+
+			await client.query(
+				`INSERT INTO cierre_diario_credito_cobros
+					(fecha, asesor_id, caso_cobro_id, numero_credito_sifco,
+					 bucket_anterior, bucket, tipo)
+				VALUES ${placeholders}`,
+				params,
+			);
+		}
+		await client.query("COMMIT");
+	} catch (e) {
+		await client.query("ROLLBACK");
+		throw e;
+	} finally {
+		client.release();
+	}
+
+	console.log(
+		`[CierreDiarioAsesor] ${fecha}: ${filas.length} movimientos de bucket insertados`,
+	);
+}

--- a/apps/crm/apps/server/src/jobs/cierre-diario-asesores.ts
+++ b/apps/crm/apps/server/src/jobs/cierre-diario-asesores.ts
@@ -20,11 +20,10 @@
  *  - Paso B 'subida'/'bajada': créditos que cambiaron de bucket ese día, con su
  *    ruta (bucket_anterior → bucket). Definición confirmada por Jhairo Nájera
  *    (responsable CB-024): el reporte muestra "hoy subieron N / bajaron M". La
- *    atribución va por `asesor_atribucion_id` (el asesor que tenía el crédito
- *    AL MOMENTO del evento, congelado en buckets_historial) y NO por
- *    `asesor_id` (dueño ACTUAL del crédito, que cambia si lo reasignan
- *    después) ni por el pool del bucket de origen: varios asesores comparten
- *    bucket, así que por pool un mismo movimiento se contaba varias veces. El
+ *    atribución va por `asesor_id` (dueño ACTUAL del crédito, NOT NULL) y NO
+ *    por `asesor_atribucion_id` (buckets_historial.asesor_id) ni por el pool
+ *    del bucket de origen — ver el comentario en
+ *    _generarCierreMovimientosBucket para el porqué de cada descarte. El
  *    asesor en cartera-back tiene id numérico distinto al user.id (texto) del
  *    CRM — se resuelve cruzando por correo con `email_asesor` de
  *    /buckets/carga (ver construirMapaAsesorUsuarioPorCarga). Se reemplaza
@@ -184,20 +183,26 @@ async function _generarCierreMovimientosBucket(fecha: string) {
 		});
 		for (const evento of resp.data ?? []) {
 			if (evento.bucket_anterior == null) continue;
-			// Se atribuye al asesor que tenía el crédito AL MOMENTO del evento
-			// (asesor_atribucion_id, que sale de buckets_historial.asesor_id) — NO
-			// evento.asesor_id, que es el dueño ACTUAL del crédito (sale de
-			// creditos.asesor_id, ver bucketsHistorial.ts en cartera-back). Si el
-			// crédito se reasigna después de moverse de bucket, usar el dueño
-			// actual cambiaría retroactivamente a quién se le atribuye el
-			// movimiento — contradice que el cierre es una foto congelada del día.
+			// Se atribuye por evento.asesor_id — el dueño ACTUAL del crédito
+			// (creditos.asesor_id, NOT NULL, "hoy siempre hay dueño" según la
+			// decisión de raíz 2026-07-07 de cartera-back). NO
+			// asesor_atribucion_id (buckets_historial.asesor_id): ese campo lo
+			// deja NULL el proceso automático nocturno (latefee.ts:1181, comentario
+			// "Opción B: se llena con el nuevo flujo de pago" — no implementado
+			// todavía), así que filtrar por él descarta el 100% de los movimientos
+			// del motor normal, no solo un caso borde (hallado por Codex en PR
+			// #1183 tras el primer intento con asesor_atribucion_id). El costo
+			// aceptado: si el crédito se reasigna después de moverse de bucket, la
+			// atribución "sigue" al nuevo dueño en vez de quedar congelada al
+			// momento del evento — trade-off necesario porque la alternativa es
+			// cero movimientos reportados, siempre.
 			// Tampoco se usa el pool del bucket de origen: varios asesores
 			// comparten bucket (B2 lo atienden 3), así que por pool un mismo
 			// movimiento se contaba varias veces y los totales no cuadraban con
-			// los eventos reales. Eventos sin asesor de atribución, o cuyo asesor
-			// no cruza con un usuario del CRM, se omiten.
-			if (evento.asesor_atribucion_id == null) continue;
-			const asesorId = mapaAsesorUsuario.get(evento.asesor_atribucion_id);
+			// los eventos reales. Eventos sin asesor, o cuyo asesor no cruza con un
+			// usuario del CRM, se omiten.
+			if (evento.asesor_id == null) continue;
+			const asesorId = mapaAsesorUsuario.get(evento.asesor_id);
 			if (!asesorId) continue;
 			filas.push({
 				asesorId,

--- a/apps/crm/apps/server/src/jobs/cierre-diario-asesores.ts
+++ b/apps/crm/apps/server/src/jobs/cierre-diario-asesores.ts
@@ -17,17 +17,21 @@
  *    ON CONFLICT (contacto_id) DO NOTHING — un contacto ya registrado es
  *    histórico inmutable, nunca se duplica.
  *
- *  - Paso B 'subida'/'bajada': créditos que cambiaron de bucket ese día, con su
- *    ruta (bucket_anterior → bucket). Definición confirmada por Jhairo Nájera
- *    (responsable CB-024): el reporte muestra "hoy subieron N / bajaron M". La
- *    atribución va por `evento.asesor` (nombre del dueño del crédito, tal como
- *    lo trae CADA fila de getBucketsHistorial) — ver resolverAsesorId para el
- *    porqué de descartar `asesor_atribucion_id` y los mapas externos
- *    (pool/carga) que se probaron antes. El asesor en cartera-back no tiene
- *    id de usuario del CRM propio — se resuelve cruzando por nombre contra
- *    `user.name`. Se reemplaza completo (DELETE + INSERT) en cada corrida:
- *    son datos derivados de cartera-back, recalculables, sin un "contacto"
- *    que ancle un ON CONFLICT.
+ *  - Paso B 'subida'/'bajada': de los créditos que un asesor tenía AL EMPEZAR
+ *    el día, cuáles subieron y cuáles bajaron de bucket. Definición del
+ *    usuario: "de mis créditos de la mañana, cuántos subieron y cuántos
+ *    bajaron" — no "a quién se le atribuye cada evento puntual" (enfoque
+ *    anterior, descartado por problemas de escala — ver
+ *    resolverIdsDuenoManana para el detalle y el porqué de los intentos
+ *    previos). El dueño de la mañana es el dueño ACTUAL que ya trae
+ *    getBucketsHistorial, salvo que el crédito se haya reasignado HOY (ahí se
+ *    retrocede al asesor_anterior_id de esa reasignación, vía
+ *    credito_asesor_historial/getAsesorHistorial acotado al día). El asesor
+ *    en cartera-back no tiene id de usuario del CRM propio — se resuelve
+ *    cruzando `asesor_id` numérico → `email_cash_in` (getPoolPorAsesor()) →
+ *    `user.email` (constraint único en ambos extremos). Se reemplaza completo
+ *    (DELETE + INSERT) en cada corrida: son datos derivados de cartera-back,
+ *    recalculables, sin un "contacto" que ancle un ON CONFLICT.
  */
 
 import { inArray } from "drizzle-orm";
@@ -120,49 +124,147 @@ async function _generarCierreContactos(client: RawClient, fecha: string) {
 }
 
 /**
- * Mapa `nombre normalizado → user.id (CRM)`. Cruzar por nombre en vez de
- * asesor_id/email porque el nombre viaja EN CADA FILA del evento
- * (`getBucketsHistorial().data[].asesor`), sin necesitar una llamada aparte
- * a un pool o catálogo que puede cambiar entre el movimiento y esta corrida.
- *
- * Se descartaron dos fuentes externas antes de llegar acá, ambas por la misma
- * clase de bug (mapa construido de un catálogo "vigente ahora", que puede
- * haber perdido al asesor entre el evento y la corrida — 00:15 GT del día
- * siguiente):
- *   - `getCargaPorAsesorBucket`: excluye créditos CANCELADO/
- *     PENDIENTE_CANCELACION/EN_CONVENIO/CAIDO (STATUS_BUCKET_FUERA en
- *     cartera-back) — si el único crédito del asesor se resolvió antes de la
- *     corrida, desaparecía del mapa (hallado por Codex en PR #1185, 1er round).
- *   - `getPoolAsesoresPorBucket`: solo pool ACTIVO ahora — si desactivan al
- *     asesor del pool entre el evento y la corrida, mismo problema, y además
- *     el DELETE+INSERT de abajo podía BORRAR filas ya capturadas en una
- *     corrida anterior si un re-run perdía a ese asesor del mapa (hallado por
- *     Codex en PR #1185, 2do round).
- * Usar el nombre que trae el propio evento es inmune a ambos: no depende de
- * ningún estado "actual" externo al evento mismo.
+ * Mapa `asesor_id numérico (cartera-back) → user.id (CRM)`, cruzando por
+ * email (`email_cash_in` de getPoolPorAsesor() vs `user.email`, ambos con
+ * constraint único). Reemplaza un cruce anterior por `user.name` — sin
+ * constraint de unicidad en ese campo, dos asesores con el mismo nombre
+ * (caso real en dev: "Lucia Salvatierra" x2) se pisaban en silencio y
+ * atribuían mal el movimiento.
  */
+async function mapaAsesorIdAUserId(
+	usuarios: readonly { id: string; email: string }[],
+): Promise<Map<number, string>> {
+	const emailToUserId = new Map(
+		usuarios.map((u) => [u.email.trim().toLowerCase(), u.id]),
+	);
+	const asesores = await carteraBackClient.getPoolPorAsesor();
+	const mapa = new Map<number, string>();
+	for (const a of asesores) {
+		const email = a.email_cash_in?.trim().toLowerCase();
+		if (!email) continue;
+		const userId = emailToUserId.get(email);
+		if (userId) mapa.set(a.asesor_id, userId);
+	}
+	return mapa;
+}
+
 function resolverAsesorId(
-	nombreAsesor: string | null,
-	nombreToUserId: ReadonlyMap<string, string>,
+	asesorIdCartera: number | null,
+	asesorIdToUserId: ReadonlyMap<number, string>,
 ): string | null {
-	if (!nombreAsesor) return null;
-	return nombreToUserId.get(nombreAsesor.trim().toLowerCase()) ?? null;
+	if (asesorIdCartera == null) return null;
+	return asesorIdToUserId.get(asesorIdCartera) ?? null;
+}
+
+/**
+ * Dueño de cada crédito AL EMPEZAR el día que se está cerrando (no el dueño
+ * actual al momento de la corrida, 00:15 GT del día siguiente).
+ *
+ * Reemplaza un enfoque anterior ("¿de quién era el crédito exactamente en el
+ * instante del movimiento?", resuelto reconstruyendo desde TODO el histórico
+ * de `credito_asesor_historial`) por uno más simple y acotado en escala,
+ * alineado a cómo se define el cierre: "de mis créditos de la mañana, cuántos
+ * subieron y cuántos bajaron" (definición del usuario, no "a quién se le
+ * atribuye cada evento puntual"). El enfoque anterior tenía dos problemas de
+ * fondo hallados por Codex en PR #1185 (5to round):
+ *   - Sin filtro por crédito ni ventana de fecha razonable, la consulta traía
+ *     la bitácora COMPLETA del sistema (crece sin límite con el tiempo).
+ *   - Paginación por OFFSET sobre `ORDER BY fecha DESC` mientras
+ *     `latefee.ts` (23:59 GT) puede seguir insertando filas nuevas 16 minutos
+ *     antes de esta corrida (00:15 GT) — un insert a mitad de la paginación
+ *     desplaza todo y puede saltarse silenciosamente la fila que se busca.
+ *
+ * Este enfoque solo necesita las reasignaciones de HOY (`desde: fecha, hasta:
+ * fecha` — acotado, no la bitácora completa): para un crédito reasignado hoy,
+ * el dueño de la mañana es `asesor_anterior` de esa reasignación (retroceder
+ * un paso). Para el resto de créditos (la mayoría — la reasignación
+ * automática solo ocurre si el asesor deja de ser elegible en el bucket
+ * destino, ver `latefee.ts` FASE 3), no hubo cambio hoy, así que el dueño
+ * ACTUAL que ya trae `getBucketsHistorial().data[].asesor` YA ES el dueño de
+ * la mañana — no hace falta reconstruir nada.
+ *
+ * No cubre reasignaciones MANUALES intra-día (supervisor reasigna a mano
+ * durante la jornada, no a medianoche) que no dejen rastro en `desde: fecha,
+ * hasta: fecha` de forma coherente con "mañana" — ese caso es igual de raro
+ * que los que ya se aceptaron como fallback en versiones anteriores.
+ *
+ * Devuelve, por cada evento (identificado por su posición en `eventos`), el
+ * asesor_id numérico (cartera-back) del dueño de la mañana a usar.
+ */
+async function resolverIdsDuenoManana(
+	eventos: readonly { credito_id: number; asesorId: number | null }[],
+	fecha: string,
+): Promise<(number | null)[]> {
+	if (eventos.length === 0) return [];
+
+	// Reasignaciones SOLO de hoy — acotado, no la bitácora completa del
+	// sistema. En un día normal son pocas decenas, cabe en 1-2 páginas.
+	const reasignacionesHoy: {
+		credito_id: number;
+		asesor_anterior_id: number | null;
+	}[] = [];
+	let page = 1;
+	const pageSize = 200;
+	const MAX_PAGINAS_HISTORIAL = 50;
+	let truncadoHistorial = false;
+	for (; page <= MAX_PAGINAS_HISTORIAL; page++) {
+		const resp = await carteraBackClient.getAsesorHistorial({
+			desde: fecha,
+			hasta: fecha,
+			page,
+			pageSize,
+		});
+		reasignacionesHoy.push(
+			...resp.data.map((r) => ({
+				credito_id: r.credito_id,
+				asesor_anterior_id: r.asesor_anterior_id,
+			})),
+		);
+		if (page >= resp.pagination.totalPages) break;
+		if (page === MAX_PAGINAS_HISTORIAL) truncadoHistorial = true;
+	}
+	if (truncadoHistorial) {
+		console.warn(
+			`[CierreDiarioAsesor] ${fecha}: se alcanzó el tope de ${MAX_PAGINAS_HISTORIAL} páginas de reasignaciones del día — posible totalPages corrupto de cartera-back`,
+		);
+	}
+
+	// Si un crédito tuvo VARIAS reasignaciones en el mismo día, el dueño de la
+	// mañana es el `asesor_anterior_id` de la PRIMERA (la más antigua) — las
+	// intermedias ya no son "la mañana". La respuesta viene ordenada
+	// `fecha DESC, historial_id DESC` (asesorHistorial.ts), así que la última
+	// del array es la más antigua del día.
+	const duenoMananaPorCredito = new Map<number, number | null>();
+	for (const r of reasignacionesHoy) {
+		duenoMananaPorCredito.set(r.credito_id, r.asesor_anterior_id);
+	}
+
+	return eventos.map((evento) => {
+		if (!duenoMananaPorCredito.has(evento.credito_id)) return evento.asesorId;
+		const asesorAnteriorId = duenoMananaPorCredito.get(evento.credito_id);
+		// asesor_anterior_id nullable (siembra/primera asignación, o asesor
+		// borrado) — sin dato de "antes", el mejor fallback disponible sigue
+		// siendo el dueño actual del evento.
+		return asesorAnteriorId ?? evento.asesorId;
+	});
 }
 
 async function _generarCierreMovimientosBucket(fecha: string) {
-	const usuarios = await db.select({ id: user.id, name: user.name }).from(user);
-	const nombreToUserId = new Map(
-		usuarios.map((u) => [u.name.trim().toLowerCase(), u.id]),
-	);
+	const usuarios = await db
+		.select({ id: user.id, email: user.email })
+		.from(user);
+	const asesorIdToUserId = await mapaAsesorIdAUserId(usuarios);
 
-	type FilaMovimiento = {
-		asesorId: string;
-		numeroCreditoSifco: string;
-		bucketAnterior: number;
-		bucketNuevo: number;
+	type EventoBucket = {
+		credito_id: number;
+		numero_credito_sifco: string;
+		fecha: string;
+		asesorId: number | null;
+		bucket_anterior: number;
+		bucket_nuevo: number;
 		tipo: "subida" | "bajada";
 	};
-	const filas: FilaMovimiento[] = [];
+	const eventos: EventoBucket[] = [];
 
 	let page = 1;
 	const pageSize = 200;
@@ -181,37 +283,59 @@ async function _generarCierreMovimientosBucket(fecha: string) {
 		});
 		for (const evento of resp.data ?? []) {
 			if (evento.bucket_anterior == null) continue;
-			// Se atribuye por evento.asesor (nombre) — el dueño ACTUAL del crédito
-			// al momento del evento (creditos.asesor_id vía el JOIN de
-			// cartera-back, "hoy siempre hay dueño" según la decisión de raíz
-			// 2026-07-07 de ese repo). NO asesor_atribucion_id
-			// (buckets_historial.asesor_id): ese campo lo deja NULL el proceso
-			// automático nocturno (latefee.ts:1181, "se llena con el nuevo flujo
-			// de pago" — no implementado todavía), así que filtrar por él descarta
-			// el 100% de los movimientos del motor normal (hallado por Codex en
-			// PR #1183). Tampoco el pool del bucket de origen: varios asesores
-			// comparten bucket, un mismo movimiento se contaba varias veces. Y NO
-			// un mapa externo (pool/carga) resuelto aparte: ambos dependían de un
-			// catálogo "vigente ahora" que puede haber perdido al asesor entre el
-			// evento y esta corrida — ver resolverAsesorId. Eventos sin asesor, o
-			// cuyo nombre no cruza con un usuario del CRM, se omiten.
-			const asesorId = resolverAsesorId(evento.asesor, nombreToUserId);
-			if (!asesorId) continue;
-			filas.push({
-				asesorId,
-				numeroCreditoSifco: evento.numero_credito_sifco,
-				bucketAnterior: evento.bucket_anterior,
-				bucketNuevo: evento.bucket_nuevo,
+			eventos.push({
+				credito_id: evento.credito_id,
+				numero_credito_sifco: evento.numero_credito_sifco,
+				fecha: evento.fecha,
+				asesorId: evento.asesor_id,
+				bucket_anterior: evento.bucket_anterior,
+				bucket_nuevo: evento.bucket_nuevo,
 				tipo: evento.tipo_evento === "SUBIDA" ? "subida" : "bajada",
 			});
 		}
-		const totalPages = resp.pagination?.totalPages ?? 1;
-		if (page >= totalPages) break;
+		if (typeof resp.pagination?.totalPages !== "number") {
+			console.warn(
+				`[CierreDiarioAsesor] ${fecha}: pagination.totalPages ausente/corrupto en getBucketsHistorial (página ${page}) — se asume sin más páginas, revisar cartera-back`,
+			);
+			break;
+		}
+		if (page >= resp.pagination.totalPages) break;
 		if (page === MAX_PAGINAS) truncado = true;
 	}
 	if (truncado) {
 		console.warn(
 			`[CierreDiarioAsesor] ${fecha}: se alcanzó el tope de ${MAX_PAGINAS} páginas de movimientos de bucket — posible totalPages corrupto de cartera-back`,
+		);
+	}
+
+	type FilaMovimiento = {
+		asesorId: string;
+		numeroCreditoSifco: string;
+		bucketAnterior: number;
+		bucketNuevo: number;
+		tipo: "subida" | "bajada";
+	};
+	const filas: FilaMovimiento[] = [];
+
+	const idsDueno = await resolverIdsDuenoManana(eventos, fecha);
+	let descartados = 0;
+	eventos.forEach((evento, i) => {
+		const asesorId = resolverAsesorId(idsDueno[i], asesorIdToUserId);
+		if (!asesorId) {
+			descartados++;
+			return;
+		}
+		filas.push({
+			asesorId,
+			numeroCreditoSifco: evento.numero_credito_sifco,
+			bucketAnterior: evento.bucket_anterior,
+			bucketNuevo: evento.bucket_nuevo,
+			tipo: evento.tipo,
+		});
+	});
+	if (descartados > 0) {
+		console.warn(
+			`[CierreDiarioAsesor] ${fecha}: ${descartados} movimiento(s) de bucket descartado(s) — asesor_id sin cruce a user.email (sin pool activo o email_cash_in no coincide)`,
 		);
 	}
 

--- a/apps/crm/apps/server/src/routers/cobros.ts
+++ b/apps/crm/apps/server/src/routers/cobros.ts
@@ -5630,9 +5630,12 @@ export const cobrosRouter = {
 			}
 
 			// Un contacto generado por el sistema (premora / envío masivo) no es
-			// gestión del asesor. `es_efectivo_manual` ya lo excluye en el job,
-			// pero las promesas se cuentan por estado, así que el filtro se aplica
-			// acá con el mismo criterio (prefijo de comentario).
+			// gestión del asesor. `es_efectivo_manual` ya lo excluye en el job. Acá
+			// se aplica el mismo criterio (prefijo de comentario) a promesas Y al
+			// total: el denominador de "efectivos/total" que pide el reporte es
+			// "de lo que el asesor REGISTRÓ, cuánto contestó" — un envío automático
+			// no es un intento del asesor, así que si se cuela en el total infla el
+			// denominador y hace ver el ratio peor de lo real.
 			const esAutomatico = sql`(${contactosCobros.comentarios} LIKE ${`${PREFIJO_PREMORA_AUTO}%`} OR ${contactosCobros.comentarios} LIKE ${`${PREFIJO_WSP_MASIVO}%`})`;
 
 			const filas = await db
@@ -5643,7 +5646,7 @@ export const cobrosRouter = {
 					asesorEmail: user.email,
 					contactosEfectivos: sql<number>`COUNT(*) FILTER (WHERE ${cierreDiarioCreditoCobros.tipo} = 'contacto' AND ${cierreDiarioCreditoCobros.esEfectivoManual})`,
 					promesasObtenidas: sql<number>`COUNT(*) FILTER (WHERE ${cierreDiarioCreditoCobros.tipo} = 'contacto' AND ${cierreDiarioCreditoCobros.estadoContacto} = 'promesa_pago' AND NOT ${esAutomatico})`,
-					totalContactos: sql<number>`COUNT(*) FILTER (WHERE ${cierreDiarioCreditoCobros.tipo} = 'contacto')`,
+					totalContactos: sql<number>`COUNT(*) FILTER (WHERE ${cierreDiarioCreditoCobros.tipo} = 'contacto' AND NOT ${esAutomatico})`,
 					// Movimientos que SALIERON del bucket del pool del asesor ese día.
 					subieron: sql<number>`COUNT(*) FILTER (WHERE ${cierreDiarioCreditoCobros.tipo} = 'subida')`,
 					bajaron: sql<number>`COUNT(*) FILTER (WHERE ${cierreDiarioCreditoCobros.tipo} = 'bajada')`,

--- a/apps/crm/apps/server/src/routers/cobros.ts
+++ b/apps/crm/apps/server/src/routers/cobros.ts
@@ -495,6 +495,10 @@ export const createContactoCobrosSchema = z
 		},
 	);
 
+// Buckets fijos del funnel operativo (B0-B5) — CB-024 los recorre para armar
+// el pool real de cada asesor desde `getPoolAsesoresPorBucket`.
+const BUCKETS_NUMEROS = [0, 1, 2, 3, 4, 5] as const;
+
 export const cobrosRouter = {
 	// Dashboard de cobros - Vista general del embudo
 	getDashboardStats: cobrosProcedure
@@ -5665,14 +5669,17 @@ export const cobrosRouter = {
 			// (no histórico del día), por eso se consulta acá y no se guarda en el
 			// snapshot: guardar "el pool de ayer" no tendría sentido operativo.
 			//
-			// El pool sale de `getAperturaDia` (`asignacion[].buckets_pool`), que
-			// cartera-back ya deriva de su tabla `asesor_bucket`. NO se consulta esa
-			// tabla por SQL desde el CRM: la base de cartera es de otro proyecto y
-			// todo acceso va por su API. Tampoco se deriva de `/buckets/carga`: ese
-			// endpoint devuelve los buckets DONDE EL ASESOR TIENE CRÉDITOS, con los
-			// residuos de créditos que se movieron pero siguen asignados a él
-			// (`elegible: false`) — por eso mostraba a Jorge en B2/B3/B4 cuando su
-			// pool real es solo B3.
+			// El pool sale de `getPoolAsesoresPorBucket` (una llamada por bucket
+			// 0-5, en paralelo) — es `asesor_bucket WHERE bucket=X AND activo=true`
+			// tal cual, SIN depender de que el asesor tenga cuentas o movimientos
+			// en el rango consultado. Descartado `getAperturaDia().asignacion`
+			// (usado antes, review Codex #1183): esa lista sale de un JOIN que
+			// arranca `FROM buckets_historial`, así que solo incluye asesores que
+			// tuvieron un movimiento de bucket EN `fechaFin` — un asesor activo sin
+			// transiciones ese día quedaba con pool vacío en el reporte. Tampoco se
+			// usa `/buckets/carga`: esa devuelve los buckets DONDE EL ASESOR TIENE
+			// CRÉDITOS, con los residuos de créditos que se movieron pero siguen
+			// asignados a él (`elegible: false`) — mismo problema, otra forma.
 			//
 			// El cruce asesor↔usuario va por `email_asesor` de `/buckets/carga`: es
 			// el único lugar con el correo vigente. En getAdvisors el correo de
@@ -5683,9 +5690,11 @@ export const cobrosRouter = {
 			// la etiqueta de pool.
 			const poolPorAsesor = new Map<string, number[]>();
 			try {
-				const [carga, apertura] = await Promise.all([
+				const [carga, ...poolsPorBucket] = await Promise.all([
 					carteraBackClient.getCargaPorAsesorBucket({}),
-					carteraBackClient.getAperturaDia({ fecha: input.fechaFin }),
+					...BUCKETS_NUMEROS.map((bucket) =>
+						carteraBackClient.getPoolAsesoresPorBucket(bucket),
+					),
 				]);
 				const emailToUserId = new Map(
 					filas.map((f) => [f.asesorEmail.trim().toLowerCase(), f.asesorId]),
@@ -5697,14 +5706,18 @@ export const cobrosRouter = {
 					const userId = emailToUserId.get(email);
 					if (userId) asesorCarteraToUserId.set(a.asesor_id, userId);
 				}
-				for (const asignacion of apertura.asignacion) {
-					if (asignacion.asesor_id == null) continue;
-					const userId = asesorCarteraToUserId.get(asignacion.asesor_id);
-					if (!userId) continue;
-					poolPorAsesor.set(
-						userId,
-						[...asignacion.buckets_pool].sort((x, y) => x - y),
-					);
+				poolsPorBucket.forEach((pool, i) => {
+					const bucket = BUCKETS_NUMEROS[i];
+					for (const a of pool) {
+						const userId = asesorCarteraToUserId.get(a.asesor_id);
+						if (!userId) continue;
+						const buckets = poolPorAsesor.get(userId) ?? [];
+						buckets.push(bucket);
+						poolPorAsesor.set(userId, buckets);
+					}
+				});
+				for (const [userId, buckets] of poolPorAsesor) {
+					poolPorAsesor.set(userId, [...buckets].sort((x, y) => x - y));
 				}
 			} catch (error) {
 				console.error("[getCierreDiarioPorRango] Pool de buckets:", error);

--- a/apps/crm/apps/server/src/routers/cobros.ts
+++ b/apps/crm/apps/server/src/routers/cobros.ts
@@ -12,6 +12,7 @@ import {
 	inArray,
 	isNotNull,
 	isNull,
+	lte,
 	max,
 	or,
 	sql,
@@ -22,6 +23,7 @@ import { user } from "../db/schema/auth";
 import { carteraBackReferences } from "../db/schema/cartera-back";
 import {
 	casosCobros,
+	cierreDiarioCreditoCobros,
 	contactosCobros,
 	contratosFinanciamiento,
 	conveniosPago,
@@ -43,6 +45,10 @@ import {
 import { quotations } from "../db/schema/quotations";
 import { recordatoriosPremora } from "../db/schema/recordatorios-premora";
 import { vehicles } from "../db/schema/vehicles";
+import {
+	PREFIJO_PREMORA_AUTO,
+	PREFIJO_WSP_MASIVO,
+} from "../jobs/cierre-diario-asesores";
 import {
 	deriveHasCapitalData,
 	recalculateCobrosPercentagesWithFallback,
@@ -5598,6 +5604,172 @@ export const cobrosRouter = {
 				page: input.page ?? 1,
 				pageSize: input.pageSize ?? 20,
 			});
+		}),
+
+	// CB-024: reporte de cierre diario por rango — agrupa el DETALLE guardado
+	// por generarCierreDiario (job de 22:00 GT) en cierre_diario_credito_cobros,
+	// no recalcula en vivo contra contactos_cobros/cartera-back. Permite
+	// ventanas dinámicas (ej. lun→vie de la semana actual).
+	getCierreDiarioPorRango: cobrosSupervisorProcedure
+		.input(
+			z.object({
+				fechaInicio: z.string().regex(/^\d{4}-\d{2}-\d{2}$/),
+				fechaFin: z.string().regex(/^\d{4}-\d{2}-\d{2}$/),
+				asesorIds: z.array(z.string()).optional(),
+			}),
+		)
+		.handler(async ({ input }) => {
+			const conditions = [
+				gte(cierreDiarioCreditoCobros.fecha, input.fechaInicio),
+				lte(cierreDiarioCreditoCobros.fecha, input.fechaFin),
+			];
+			if (input.asesorIds && input.asesorIds.length > 0) {
+				conditions.push(
+					inArray(cierreDiarioCreditoCobros.asesorId, input.asesorIds),
+				);
+			}
+
+			// Un contacto generado por el sistema (premora / envío masivo) no es
+			// gestión del asesor. `es_efectivo_manual` ya lo excluye en el job,
+			// pero las promesas se cuentan por estado, así que el filtro se aplica
+			// acá con el mismo criterio (prefijo de comentario).
+			const esAutomatico = sql`(${contactosCobros.comentarios} LIKE ${`${PREFIJO_PREMORA_AUTO}%`} OR ${contactosCobros.comentarios} LIKE ${`${PREFIJO_WSP_MASIVO}%`})`;
+
+			const filas = await db
+				.select({
+					asesorId: cierreDiarioCreditoCobros.asesorId,
+					asesorNombre: user.name,
+					// Se usa abajo para cruzar con el pool de buckets de cartera-back.
+					asesorEmail: user.email,
+					contactosEfectivos: sql<number>`COUNT(*) FILTER (WHERE ${cierreDiarioCreditoCobros.tipo} = 'contacto' AND ${cierreDiarioCreditoCobros.esEfectivoManual})`,
+					promesasObtenidas: sql<number>`COUNT(*) FILTER (WHERE ${cierreDiarioCreditoCobros.tipo} = 'contacto' AND ${cierreDiarioCreditoCobros.estadoContacto} = 'promesa_pago' AND NOT ${esAutomatico})`,
+					totalContactos: sql<number>`COUNT(*) FILTER (WHERE ${cierreDiarioCreditoCobros.tipo} = 'contacto')`,
+					// Movimientos que SALIERON del bucket del pool del asesor ese día.
+					subieron: sql<number>`COUNT(*) FILTER (WHERE ${cierreDiarioCreditoCobros.tipo} = 'subida')`,
+					bajaron: sql<number>`COUNT(*) FILTER (WHERE ${cierreDiarioCreditoCobros.tipo} = 'bajada')`,
+				})
+				.from(cierreDiarioCreditoCobros)
+				.innerJoin(user, eq(cierreDiarioCreditoCobros.asesorId, user.id))
+				.leftJoin(
+					contactosCobros,
+					eq(cierreDiarioCreditoCobros.contactoId, contactosCobros.id),
+				)
+				.where(and(...conditions))
+				.groupBy(cierreDiarioCreditoCobros.asesorId, user.name, user.email)
+				.orderBy(asc(user.name));
+
+			// Pool de buckets al que está asignado cada asesor. Es config ESTABLE
+			// (no histórico del día), por eso se consulta acá y no se guarda en el
+			// snapshot: guardar "el pool de ayer" no tendría sentido operativo.
+			//
+			// El pool sale de `getAperturaDia` (`asignacion[].buckets_pool`), que
+			// cartera-back ya deriva de su tabla `asesor_bucket`. NO se consulta esa
+			// tabla por SQL desde el CRM: la base de cartera es de otro proyecto y
+			// todo acceso va por su API. Tampoco se deriva de `/buckets/carga`: ese
+			// endpoint devuelve los buckets DONDE EL ASESOR TIENE CRÉDITOS, con los
+			// residuos de créditos que se movieron pero siguen asignados a él
+			// (`elegible: false`) — por eso mostraba a Jorge en B2/B3/B4 cuando su
+			// pool real es solo B3.
+			//
+			// El cruce asesor↔usuario va por `email_asesor` de `/buckets/carga`: es
+			// el único lugar con el correo vigente. En getAdvisors el correo de
+			// varios asesores está desactualizado (`cobros@…`, `@sepresta.com`) y
+			// no cruza con el `user.email` del CRM.
+			//
+			// Best-effort: si cartera-back falla, el reporte sigue sirviendo sin
+			// la etiqueta de pool.
+			const poolPorAsesor = new Map<string, number[]>();
+			try {
+				const [carga, apertura] = await Promise.all([
+					carteraBackClient.getCargaPorAsesorBucket({}),
+					carteraBackClient.getAperturaDia({ fecha: input.fechaFin }),
+				]);
+				const emailToUserId = new Map(
+					filas.map((f) => [f.asesorEmail.trim().toLowerCase(), f.asesorId]),
+				);
+				const asesorCarteraToUserId = new Map<number, string>();
+				for (const a of carga.porAsesor) {
+					const email = a.email_asesor?.trim().toLowerCase();
+					if (!email) continue;
+					const userId = emailToUserId.get(email);
+					if (userId) asesorCarteraToUserId.set(a.asesor_id, userId);
+				}
+				for (const asignacion of apertura.asignacion) {
+					if (asignacion.asesor_id == null) continue;
+					const userId = asesorCarteraToUserId.get(asignacion.asesor_id);
+					if (!userId) continue;
+					poolPorAsesor.set(
+						userId,
+						[...asignacion.buckets_pool].sort((x, y) => x - y),
+					);
+				}
+			} catch (error) {
+				console.error("[getCierreDiarioPorRango] Pool de buckets:", error);
+			}
+
+			return filas.map((f) => ({
+				asesorId: f.asesorId,
+				asesorNombre: f.asesorNombre,
+				contactosEfectivos: Number(f.contactosEfectivos),
+				promesasObtenidas: Number(f.promesasObtenidas),
+				totalContactos: Number(f.totalContactos),
+				subieron: Number(f.subieron),
+				bajaron: Number(f.bajaron),
+				bucketsPool: poolPorAsesor.get(f.asesorId) ?? [],
+			}));
+		}),
+
+	// CB-024: detalle de créditos detrás de los agregados de un asesor+rango —
+	// alimenta el acordeón. Lee cierre_diario_credito_cobros (snapshot ya
+	// generado), no consulta contactos_cobros/cartera-back en vivo.
+	getDetalleCierrePorAsesor: cobrosSupervisorProcedure
+		.input(
+			z.object({
+				asesorId: z.string(),
+				fechaInicio: z.string().regex(/^\d{4}-\d{2}-\d{2}$/),
+				fechaFin: z.string().regex(/^\d{4}-\d{2}-\d{2}$/),
+			}),
+		)
+		.handler(async ({ input }) => {
+			const filas = await db
+				.select({
+					id: cierreDiarioCreditoCobros.id,
+					tipo: cierreDiarioCreditoCobros.tipo,
+					casoCobroId: cierreDiarioCreditoCobros.casoCobroId,
+					numeroCreditoSifco: cierreDiarioCreditoCobros.numeroCreditoSifco,
+					estadoContacto: cierreDiarioCreditoCobros.estadoContacto,
+					esEfectivoManual: cierreDiarioCreditoCobros.esEfectivoManual,
+					fechaContacto: cierreDiarioCreditoCobros.fechaContacto,
+					bucketAnterior: cierreDiarioCreditoCobros.bucketAnterior,
+					bucket: cierreDiarioCreditoCobros.bucket,
+					fecha: cierreDiarioCreditoCobros.fecha,
+					// Origen del contacto, para que la UI pueda explicar por qué una
+					// fila 'contactado' no cuenta como efectiva: los envíos que genera
+					// el sistema (premora, WhatsApp masivo) quedan en el historial pero
+					// no son gestión del asesor. Se derivan del prefijo de comentario,
+					// mismo criterio que usa el job (no hay columna de origen en
+					// contactos_cobros).
+					origen: sql<string>`CASE
+						WHEN ${contactosCobros.comentarios} LIKE ${`${PREFIJO_PREMORA_AUTO}%`} THEN 'premora'
+						WHEN ${contactosCobros.comentarios} LIKE ${`${PREFIJO_WSP_MASIVO}%`} THEN 'wsp_masivo'
+						ELSE 'manual'
+					END`,
+				})
+				.from(cierreDiarioCreditoCobros)
+				.leftJoin(
+					contactosCobros,
+					eq(cierreDiarioCreditoCobros.contactoId, contactosCobros.id),
+				)
+				.where(
+					and(
+						eq(cierreDiarioCreditoCobros.asesorId, input.asesorId),
+						gte(cierreDiarioCreditoCobros.fecha, input.fechaInicio),
+						lte(cierreDiarioCreditoCobros.fecha, input.fechaFin),
+					),
+				)
+				.orderBy(desc(cierreDiarioCreditoCobros.fecha));
+
+			return filas;
 		}),
 };
 

--- a/apps/crm/apps/server/src/routers/cobros.ts
+++ b/apps/crm/apps/server/src/routers/cobros.ts
@@ -495,10 +495,6 @@ export const createContactoCobrosSchema = z
 		},
 	);
 
-// Buckets fijos del funnel operativo (B0-B5) — CB-024 los recorre para armar
-// el pool real de cada asesor desde `getPoolAsesoresPorBucket`.
-const BUCKETS_NUMEROS = [0, 1, 2, 3, 4, 5] as const;
-
 export const cobrosRouter = {
 	// Dashboard de cobros - Vista general del embudo
 	getDashboardStats: cobrosProcedure
@@ -5650,7 +5646,10 @@ export const cobrosRouter = {
 					asesorEmail: user.email,
 					contactosEfectivos: sql<number>`COUNT(*) FILTER (WHERE ${cierreDiarioCreditoCobros.tipo} = 'contacto' AND ${cierreDiarioCreditoCobros.esEfectivoManual})`,
 					promesasObtenidas: sql<number>`COUNT(*) FILTER (WHERE ${cierreDiarioCreditoCobros.tipo} = 'contacto' AND ${cierreDiarioCreditoCobros.estadoContacto} = 'promesa_pago' AND NOT ${esAutomatico})`,
-					totalContactos: sql<number>`COUNT(*) FILTER (WHERE ${cierreDiarioCreditoCobros.tipo} = 'contacto' AND NOT ${esAutomatico})`,
+					// Promesa se reporta aparte (línea de arriba) — no cuenta en el
+					// denominador de "efectivos/total", sería mezclar dos categorías
+					// excluyentes en un mismo ratio.
+					totalContactos: sql<number>`COUNT(*) FILTER (WHERE ${cierreDiarioCreditoCobros.tipo} = 'contacto' AND ${cierreDiarioCreditoCobros.estadoContacto} != 'promesa_pago' AND NOT ${esAutomatico})`,
 					// Movimientos que SALIERON del bucket del pool del asesor ese día.
 					subieron: sql<number>`COUNT(*) FILTER (WHERE ${cierreDiarioCreditoCobros.tipo} = 'subida')`,
 					bajaron: sql<number>`COUNT(*) FILTER (WHERE ${cierreDiarioCreditoCobros.tipo} = 'bajada')`,
@@ -5669,55 +5668,31 @@ export const cobrosRouter = {
 			// (no histórico del día), por eso se consulta acá y no se guarda en el
 			// snapshot: guardar "el pool de ayer" no tendría sentido operativo.
 			//
-			// El pool sale de `getPoolAsesoresPorBucket` (una llamada por bucket
-			// 0-5, en paralelo) — es `asesor_bucket WHERE bucket=X AND activo=true`
-			// tal cual, SIN depender de que el asesor tenga cuentas o movimientos
-			// en el rango consultado. Descartado `getAperturaDia().asignacion`
-			// (usado antes, review Codex #1183): esa lista sale de un JOIN que
-			// arranca `FROM buckets_historial`, así que solo incluye asesores que
-			// tuvieron un movimiento de bucket EN `fechaFin` — un asesor activo sin
-			// transiciones ese día quedaba con pool vacío en el reporte. Tampoco se
-			// usa `/buckets/carga`: esa devuelve los buckets DONDE EL ASESOR TIENE
-			// CRÉDITOS, con los residuos de créditos que se movieron pero siguen
-			// asignados a él (`elegible: false`) — mismo problema, otra forma.
-			//
-			// El cruce asesor↔usuario va por `email_asesor` de `/buckets/carga`: es
-			// el único lugar con el correo vigente. En getAdvisors el correo de
-			// varios asesores está desactualizado (`cobros@…`, `@sepresta.com`) y
-			// no cruza con el `user.email` del CRM.
+			// Fuente: getPoolPorAsesor() (/buckets/pool-por-asesor) — catálogo
+			// COMPLETO de asesores con sus buckets activos, sin pasar por
+			// creditos (no depende de que el asesor tenga cuentas activas ahora
+			// mismo). Reemplaza el intento anterior (getAdvisors + N ×
+			// getPoolAsesoresPorBucket cruzados por el email de /advisor): ese
+			// email está desactualizado para varios asesores (Diego Gomez,
+			// Samuel Gamboa) y no coincidía con `user.email` del CRM.
+			// `email_cash_in` (expuesto por este endpoint) sí coincide. Mismo
+			// patrón de bug de exclusión-por-créditos-activos ya corregido en
+			// cierre-diario-asesores.ts (CB-024, commit 4e6f1ce5).
 			//
 			// Best-effort: si cartera-back falla, el reporte sigue sirviendo sin
 			// la etiqueta de pool.
 			const poolPorAsesor = new Map<string, number[]>();
 			try {
-				const [carga, ...poolsPorBucket] = await Promise.all([
-					carteraBackClient.getCargaPorAsesorBucket({}),
-					...BUCKETS_NUMEROS.map((bucket) =>
-						carteraBackClient.getPoolAsesoresPorBucket(bucket),
-					),
-				]);
+				const asesoresConBuckets = await carteraBackClient.getPoolPorAsesor();
 				const emailToUserId = new Map(
 					filas.map((f) => [f.asesorEmail.trim().toLowerCase(), f.asesorId]),
 				);
-				const asesorCarteraToUserId = new Map<number, string>();
-				for (const a of carga.porAsesor) {
-					const email = a.email_asesor?.trim().toLowerCase();
+				for (const a of asesoresConBuckets) {
+					const email = a.email_cash_in?.trim().toLowerCase();
 					if (!email) continue;
 					const userId = emailToUserId.get(email);
-					if (userId) asesorCarteraToUserId.set(a.asesor_id, userId);
-				}
-				poolsPorBucket.forEach((pool, i) => {
-					const bucket = BUCKETS_NUMEROS[i];
-					for (const a of pool) {
-						const userId = asesorCarteraToUserId.get(a.asesor_id);
-						if (!userId) continue;
-						const buckets = poolPorAsesor.get(userId) ?? [];
-						buckets.push(bucket);
-						poolPorAsesor.set(userId, buckets);
-					}
-				});
-				for (const [userId, buckets] of poolPorAsesor) {
-					poolPorAsesor.set(userId, [...buckets].sort((x, y) => x - y));
+					if (!userId) continue;
+					poolPorAsesor.set(userId, [...a.buckets].sort((x, y) => x - y));
 				}
 			} catch (error) {
 				console.error("[getCierreDiarioPorRango] Pool de buckets:", error);

--- a/apps/crm/apps/server/src/routers/index.ts
+++ b/apps/crm/apps/server/src/routers/index.ts
@@ -192,6 +192,8 @@ export const cobrosAppRouter = {
 	getCobranzaDiaria: cobrosRouter.getCobranzaDiaria,
 	getCobranzaDiariaDetalle: cobrosRouter.getCobranzaDiariaDetalle,
 	getDescuentosCRM: cobrosRouter.getDescuentosCRM,
+	getCierreDiarioPorRango: cobrosRouter.getCierreDiarioPorRango,
+	getDetalleCierrePorAsesor: cobrosRouter.getDetalleCierrePorAsesor,
 
 	// Seguimientos programados
 	createSeguimiento: seguimientosRouter.createSeguimiento,

--- a/apps/crm/apps/server/src/services/cartera-back-client.ts
+++ b/apps/crm/apps/server/src/services/cartera-back-client.ts
@@ -47,6 +47,7 @@ import type {
 	InversionistaReporte,
 	LiquidatePagosInversionistasInput,
 	PaginatedResponse,
+	PoolPorAsesorRow,
 	ResumenGlobalInversionista,
 	ReversePagoInput,
 	UpdateCreditoInput,
@@ -1237,6 +1238,19 @@ export class CarteraBackClient {
 			success: boolean;
 			data: { asesor_id: number; nombre: string }[];
 		}>(`/buckets/pool/${bucket}`, { method: "GET" }, true);
+		return response.data ?? [];
+	}
+
+	// Catálogo COMPLETO de asesores con sus buckets activos del pool, sin pasar
+	// por creditos (no depende de que el asesor tenga cuentas activas ahora
+	// mismo). Trae `email_cash_in` para cruzar contra `user.email` del CRM sin
+	// depender del `email` de getAdvisors (desactualizado para varios
+	// asesores).
+	async getPoolPorAsesor(): Promise<PoolPorAsesorRow[]> {
+		const response = await this.request<{
+			success: boolean;
+			data: PoolPorAsesorRow[];
+		}>("/buckets/pool-por-asesor", { method: "GET" }, true);
 		return response.data ?? [];
 	}
 

--- a/apps/crm/apps/server/src/types/cartera-back.ts
+++ b/apps/crm/apps/server/src/types/cartera-back.ts
@@ -260,6 +260,20 @@ export interface CargaPorAsesorBucketResponse {
 	fecha: string;
 }
 
+/**
+ * Fila de GET /buckets/pool-por-asesor: TODOS los asesores con sus buckets
+ * activos del pool, sin filtrar por créditos actuales (a diferencia de
+ * /buckets/carga). `email_cash_in` es el campo confiable para cruzar contra
+ * `user.email` del CRM — el `email` de /advisor está desactualizado para
+ * varios asesores.
+ */
+export interface PoolPorAsesorRow {
+	asesor_id: number;
+	nombre: string;
+	email_cash_in: string | null;
+	buckets: number[];
+}
+
 // ─────────────────────────────────────────────────────────────────────────
 // CB-023 · Apertura matutina del supervisor (GET /buckets/apertura).
 // ─────────────────────────────────────────────────────────────────────────

--- a/apps/crm/apps/web/src/components/header.tsx
+++ b/apps/crm/apps/web/src/components/header.tsx
@@ -20,6 +20,7 @@ import {
 	LayoutDashboard,
 	Menu,
 	MessageSquare,
+	Moon,
 	Scale,
 	Settings,
 	Sunrise,
@@ -315,6 +316,14 @@ export default function Header() {
 											<Link to="/cobros/carga" className="cursor-pointer">
 												<Gauge className="mr-2 h-4 w-4" />
 												Carga de Cuentas
+											</Link>
+										</DropdownMenuItem>
+									)}
+									{PERMISSIONS.canAssignCobros(userRole) && (
+										<DropdownMenuItem asChild>
+											<Link to="/cobros/cierre" className="cursor-pointer">
+												<Moon className="mr-2 h-4 w-4" />
+												Cierre Diario
 											</Link>
 										</DropdownMenuItem>
 									)}
@@ -697,6 +706,12 @@ function MobileNav({
 											<Link to="/cobros/carga" className={MOBILE_LINK_CLASS}>
 												<Gauge />
 												Carga de Cuentas
+											</Link>
+										)}
+										{PERMISSIONS.canAssignCobros(userRole) && (
+											<Link to="/cobros/cierre" className={MOBILE_LINK_CLASS}>
+												<Moon />
+												Cierre Diario
 											</Link>
 										)}
 										{PERMISSIONS.canAssignCobros(userRole) && (

--- a/apps/crm/apps/web/src/routeTree.gen.ts
+++ b/apps/crm/apps/web/src/routeTree.gen.ts
@@ -35,6 +35,7 @@ import { Route as CobrosReportesRouteImport } from './routes/cobros/reportes'
 import { Route as CobrosReasignacionesRouteImport } from './routes/cobros/reasignaciones'
 import { Route as CobrosMetasRouteImport } from './routes/cobros/metas'
 import { Route as CobrosColaRouteImport } from './routes/cobros/cola'
+import { Route as CobrosCierreRouteImport } from './routes/cobros/cierre'
 import { Route as CobrosCargaRouteImport } from './routes/cobros/carga'
 import { Route as CobrosBucketsRouteImport } from './routes/cobros/buckets'
 import { Route as CobrosAperturaRouteImport } from './routes/cobros/apertura'
@@ -188,6 +189,11 @@ const CobrosColaRoute = CobrosColaRouteImport.update({
   path: '/cobros/cola',
   getParentRoute: () => rootRouteImport,
 } as any)
+const CobrosCierreRoute = CobrosCierreRouteImport.update({
+  id: '/cobros/cierre',
+  path: '/cobros/cierre',
+  getParentRoute: () => rootRouteImport,
+} as any)
 const CobrosCargaRoute = CobrosCargaRouteImport.update({
   id: '/cobros/carga',
   path: '/cobros/carga',
@@ -315,6 +321,7 @@ export interface FileRoutesByFullPath {
   '/cobros/apertura': typeof CobrosAperturaRoute
   '/cobros/buckets': typeof CobrosBucketsRoute
   '/cobros/carga': typeof CobrosCargaRoute
+  '/cobros/cierre': typeof CobrosCierreRoute
   '/cobros/cola': typeof CobrosColaRoute
   '/cobros/metas': typeof CobrosMetasRoute
   '/cobros/reasignaciones': typeof CobrosReasignacionesRoute
@@ -364,6 +371,7 @@ export interface FileRoutesByTo {
   '/cobros/apertura': typeof CobrosAperturaRoute
   '/cobros/buckets': typeof CobrosBucketsRoute
   '/cobros/carga': typeof CobrosCargaRoute
+  '/cobros/cierre': typeof CobrosCierreRoute
   '/cobros/cola': typeof CobrosColaRoute
   '/cobros/metas': typeof CobrosMetasRoute
   '/cobros/reasignaciones': typeof CobrosReasignacionesRoute
@@ -414,6 +422,7 @@ export interface FileRoutesById {
   '/cobros/apertura': typeof CobrosAperturaRoute
   '/cobros/buckets': typeof CobrosBucketsRoute
   '/cobros/carga': typeof CobrosCargaRoute
+  '/cobros/cierre': typeof CobrosCierreRoute
   '/cobros/cola': typeof CobrosColaRoute
   '/cobros/metas': typeof CobrosMetasRoute
   '/cobros/reasignaciones': typeof CobrosReasignacionesRoute
@@ -465,6 +474,7 @@ export interface FileRouteTypes {
     | '/cobros/apertura'
     | '/cobros/buckets'
     | '/cobros/carga'
+    | '/cobros/cierre'
     | '/cobros/cola'
     | '/cobros/metas'
     | '/cobros/reasignaciones'
@@ -514,6 +524,7 @@ export interface FileRouteTypes {
     | '/cobros/apertura'
     | '/cobros/buckets'
     | '/cobros/carga'
+    | '/cobros/cierre'
     | '/cobros/cola'
     | '/cobros/metas'
     | '/cobros/reasignaciones'
@@ -563,6 +574,7 @@ export interface FileRouteTypes {
     | '/cobros/apertura'
     | '/cobros/buckets'
     | '/cobros/carga'
+    | '/cobros/cierre'
     | '/cobros/cola'
     | '/cobros/metas'
     | '/cobros/reasignaciones'
@@ -613,6 +625,7 @@ export interface RootRouteChildren {
   CobrosAperturaRoute: typeof CobrosAperturaRoute
   CobrosBucketsRoute: typeof CobrosBucketsRoute
   CobrosCargaRoute: typeof CobrosCargaRoute
+  CobrosCierreRoute: typeof CobrosCierreRoute
   CobrosColaRoute: typeof CobrosColaRoute
   CobrosMetasRoute: typeof CobrosMetasRoute
   CobrosReasignacionesRoute: typeof CobrosReasignacionesRoute
@@ -833,6 +846,13 @@ declare module '@tanstack/react-router' {
       preLoaderRoute: typeof CobrosColaRouteImport
       parentRoute: typeof rootRouteImport
     }
+    '/cobros/cierre': {
+      id: '/cobros/cierre'
+      path: '/cobros/cierre'
+      fullPath: '/cobros/cierre'
+      preLoaderRoute: typeof CobrosCierreRouteImport
+      parentRoute: typeof rootRouteImport
+    }
     '/cobros/carga': {
       id: '/cobros/carga'
       path: '/cobros/carga'
@@ -997,6 +1017,7 @@ const rootRouteChildren: RootRouteChildren = {
   CobrosAperturaRoute: CobrosAperturaRoute,
   CobrosBucketsRoute: CobrosBucketsRoute,
   CobrosCargaRoute: CobrosCargaRoute,
+  CobrosCierreRoute: CobrosCierreRoute,
   CobrosColaRoute: CobrosColaRoute,
   CobrosMetasRoute: CobrosMetasRoute,
   CobrosReasignacionesRoute: CobrosReasignacionesRoute,

--- a/apps/crm/apps/web/src/routes/cobros/cierre.tsx
+++ b/apps/crm/apps/web/src/routes/cobros/cierre.tsx
@@ -1,0 +1,500 @@
+import { useQuery } from "@tanstack/react-query";
+import { createFileRoute, useNavigate } from "@tanstack/react-router";
+import {
+	AlertTriangle,
+	ArrowDown,
+	ArrowUp,
+	ChevronDown,
+	Loader2,
+	Moon,
+} from "lucide-react";
+import { useState } from "react";
+import { Badge } from "@/components/ui/badge";
+import { Card, CardContent } from "@/components/ui/card";
+import {
+	Select,
+	SelectContent,
+	SelectItem,
+	SelectTrigger,
+	SelectValue,
+} from "@/components/ui/select";
+import {
+	Table,
+	TableBody,
+	TableCell,
+	TableHead,
+	TableHeader,
+	TableRow,
+} from "@/components/ui/table";
+import { authClient } from "@/lib/auth-client";
+import { PERMISSIONS } from "@/lib/roles";
+import { orpc } from "@/utils/orpc";
+
+export const Route = createFileRoute("/cobros/cierre")({
+	component: CierreDiarioPage,
+});
+
+/** Hoy en Guatemala (YYYY-MM-DD) — el backend calcula todo en GT. */
+function hoyGT() {
+	return new Date().toLocaleDateString("sv-SE", {
+		timeZone: "America/Guatemala",
+	});
+}
+
+/** Lunes de la semana GT actual (YYYY-MM-DD), para el default del rango. */
+function lunesDeEstaSemanaGT() {
+	const [y, m, d] = hoyGT().split("-").map(Number);
+	const hoy = new Date(Date.UTC(y, m - 1, d));
+	const diaSemana = hoy.getUTCDay(); // 0=domingo
+	const offset = diaSemana === 0 ? 6 : diaSemana - 1;
+	const lunes = new Date(hoy);
+	lunes.setUTCDate(hoy.getUTCDate() - offset);
+	return lunes.toISOString().slice(0, 10);
+}
+
+// CB-020 (Codex, PR #1148): toLocaleDateString("es-GT") sin `timeZone`
+// explícito usa la zona horaria LOCAL del navegador para decidir qué día
+// es, no Guatemala — el string "es-GT" solo cambia el FORMATO (dd/mm/yyyy),
+// no la zona horaria del cálculo. Un asesor en una zona horaria distinta ve
+// un día distinto al que realmente se guardó. Mismo fix que $id.tsx.
+function formatFechaGT(date: Date): string {
+	return date.toLocaleDateString("es-GT", { timeZone: "America/Guatemala" });
+}
+
+// Etiquetas del funnel operativo (mismas que BUCKETS_FILTRO en
+// reasignaciones.tsx). Un movimiento puede ir a cualquier bucket, por eso
+// están los seis.
+const BUCKET_LABEL: Record<number, string> = {
+	0: "B0 · Cartera Sana",
+	1: "B1 · Alerta Temprana",
+	2: "B2 · Gestión Activa",
+	3: "B3 · Rescate",
+	4: "B4 · Última Instancia / Pre Jurídico",
+	5: "B5 · Jurídico",
+};
+
+const estadoLabel: Record<string, string> = {
+	contactado: "Contactado",
+	no_contesta: "No contesta",
+	numero_equivocado: "Número equivocado",
+	promesa_pago: "Promesa de pago",
+	acuerdo_parcial: "Acuerdo parcial",
+	rechaza_pagar: "Rechaza pagar",
+};
+
+/**
+ * Por qué un contacto no suma como efectivo. El orden importa: un envío del
+ * sistema queda registrado como 'contactado' pero no es gestión del asesor, así
+ * que ese motivo gana sobre el del estado.
+ */
+function motivoNoEfectivo(
+	origen: string | null,
+	estadoContacto: string | null,
+): string {
+	if (origen === "premora") return "Recordatorio automático";
+	if (origen === "wsp_masivo") return "Envío masivo";
+	if (estadoContacto === "promesa_pago") return "Cuenta como promesa";
+	if (estadoContacto === "no_contesta") return "No contestó";
+	if (estadoContacto === "numero_equivocado") return "Número equivocado";
+	return "—";
+}
+
+interface CierreFila {
+	asesorId: string;
+	asesorNombre: string;
+	contactosEfectivos: number;
+	promesasObtenidas: number;
+	totalContactos: number;
+	/** Créditos que SALIERON del bucket del asesor ese día. */
+	subieron: number;
+	bajaron: number;
+	/** Buckets del pool al que está asignado el asesor (estado actual). */
+	bucketsPool: number[];
+}
+
+function CierreDiarioPage() {
+	const { data: session, isPending: sesionCargando } = authClient.useSession();
+	const userRole = session?.user?.role;
+
+	const [fechaInicio, setFechaInicio] = useState(lunesDeEstaSemanaGT);
+	const [fechaFin, setFechaFin] = useState(hoyGT);
+	const [asesorId, setAsesorId] = useState<string>("todos");
+	// Fila del acordeón abierta (una a la vez).
+	const [abierto, setAbierto] = useState<string | null>(null);
+
+	const query = useQuery({
+		...orpc.getCierreDiarioPorRango.queryOptions({
+			input: { fechaInicio, fechaFin },
+		}),
+		enabled: !!session,
+	});
+
+	// Solo asesores con cierre generado en el rango elegido — no el catálogo
+	// completo de usuarios de cobros (la mayoría no tendría filas que mostrar).
+	const asesoresConCierre = (query.data ?? []) as CierreFila[];
+	const filas = asesoresConCierre.filter(
+		(f) => asesorId === "todos" || f.asesorId === asesorId,
+	);
+
+	if (sesionCargando) {
+		return (
+			<div className="flex min-h-screen items-center justify-center text-gray-500">
+				<Loader2 className="mr-2 h-5 w-5 animate-spin" />
+				Cargando…
+			</div>
+		);
+	}
+
+	if (!userRole || !PERMISSIONS.canAssignCobros(userRole)) {
+		return (
+			<div className="flex min-h-screen items-center justify-center">
+				<div className="text-center">
+					<h1 className="mb-4 font-bold text-2xl text-gray-800">
+						Acceso Denegado
+					</h1>
+					<p className="text-gray-600">
+						Solo supervisores pueden ver el cierre diario.
+					</p>
+				</div>
+			</div>
+		);
+	}
+
+	return (
+		<div className="mx-auto max-w-6xl px-4 py-6">
+			<div className="mb-6 flex flex-wrap items-center justify-between gap-4">
+				<div className="flex items-center gap-3">
+					<Moon className="h-7 w-7 text-indigo-500" />
+					<div>
+						<h1 className="font-bold text-2xl text-gray-900 dark:text-gray-100">
+							Cierre diario
+						</h1>
+						<p className="text-gray-500 text-sm">
+							Gestión de cada asesor por rango de fechas. Se genera todos los
+							días a las 22:00 GT.
+						</p>
+					</div>
+				</div>
+				<div className="flex items-center gap-2">
+					{query.isFetching && !query.isPending && (
+						<Loader2 className="h-4 w-4 animate-spin text-gray-400" />
+					)}
+					<label className="text-gray-500 text-sm" htmlFor="cierre-desde">
+						Desde
+					</label>
+					<input
+						className="rounded-md border border-gray-300 px-2 py-1 text-sm dark:border-gray-600 dark:bg-gray-800"
+						id="cierre-desde"
+						max={hoyGT()}
+						onChange={(e) => {
+							const valor = e.target.value;
+							setFechaInicio(valor);
+							// Un rango invertido (inicio > fin) devuelve vacío en silencio
+							// y se lee como "el job no corrió" — se evita en la fuente.
+							if (valor > fechaFin) setFechaFin(valor);
+						}}
+						type="date"
+						value={fechaInicio}
+					/>
+					<label className="text-gray-500 text-sm" htmlFor="cierre-hasta">
+						Hasta
+					</label>
+					<input
+						className="rounded-md border border-gray-300 px-2 py-1 text-sm dark:border-gray-600 dark:bg-gray-800"
+						id="cierre-hasta"
+						max={hoyGT()}
+						min={fechaInicio}
+						onChange={(e) => setFechaFin(e.target.value)}
+						type="date"
+						value={fechaFin}
+					/>
+				</div>
+			</div>
+
+			<div className="mb-4">
+				<Select value={asesorId} onValueChange={setAsesorId}>
+					<SelectTrigger className="w-56">
+						<SelectValue placeholder="Todos los asesores" />
+					</SelectTrigger>
+					<SelectContent>
+						<SelectItem value="todos">Todos los asesores</SelectItem>
+						{asesoresConCierre.map((a) => (
+							<SelectItem key={a.asesorId} value={a.asesorId}>
+								{a.asesorNombre}
+							</SelectItem>
+						))}
+					</SelectContent>
+				</Select>
+			</div>
+
+			{query.isError && (
+				<Card className="border-red-300 bg-red-50 dark:bg-red-950/30">
+					<CardContent className="flex items-center gap-2 py-4 text-red-700 dark:text-red-300">
+						<AlertTriangle className="h-5 w-5" />
+						No se pudo cargar el cierre diario. Reintenta en unos segundos.
+					</CardContent>
+				</Card>
+			)}
+
+			{query.isPending && (
+				<div className="flex items-center justify-center py-20 text-gray-500">
+					<Loader2 className="mr-2 h-5 w-5 animate-spin" />
+					Cargando cierre…
+				</div>
+			)}
+
+			{!query.isError && !query.isPending && filas.length === 0 && (
+				<p className="py-20 text-center text-gray-400 text-sm">
+					No hay cierre generado en este rango.
+				</p>
+			)}
+
+			<div className="space-y-2">
+				{filas.map((fila) => (
+					<FilaAsesor
+						abierto={abierto === fila.asesorId}
+						fecha={{ inicio: fechaInicio, fin: fechaFin }}
+						fila={fila}
+						key={fila.asesorId}
+						onToggle={() =>
+							setAbierto(abierto === fila.asesorId ? null : fila.asesorId)
+						}
+					/>
+				))}
+			</div>
+		</div>
+	);
+}
+
+function FilaAsesor({
+	fila,
+	abierto,
+	onToggle,
+	fecha,
+}: {
+	fila: CierreFila;
+	abierto: boolean;
+	onToggle: () => void;
+	fecha: { inicio: string; fin: string };
+}) {
+	const navigate = useNavigate();
+	const detalle = useQuery({
+		...orpc.getDetalleCierrePorAsesor.queryOptions({
+			input: {
+				asesorId: fila.asesorId,
+				fechaInicio: fecha.inicio,
+				fechaFin: fecha.fin,
+			},
+		}),
+		enabled: abierto,
+		// Es snapshot ya generado por el job (no dato vivo) — no hace falta
+		// refetch al cerrar/reabrir la misma fila. Mismo criterio que reportes.tsx.
+		staleTime: 5 * 60 * 1000,
+	});
+
+	const contactos = (detalle.data ?? []).filter((d) => d.tipo === "contacto");
+	const movimientos = (detalle.data ?? []).filter(
+		(d) => d.tipo === "subida" || d.tipo === "bajada",
+	);
+
+	const irACaso = (numeroCreditoSifco: string | null) => {
+		if (!numeroCreditoSifco) return;
+		navigate({
+			to: "/cobros/$id",
+			params: { id: numeroCreditoSifco },
+			search: { tipo: "caso" },
+		});
+	};
+
+	return (
+		<Card className="overflow-hidden">
+			<button
+				aria-expanded={abierto}
+				className="flex w-full items-center justify-between gap-2 px-4 py-3 text-left hover:bg-gray-50 dark:hover:bg-gray-800/50"
+				onClick={onToggle}
+				type="button"
+			>
+				<span className="flex items-center gap-2">
+					<span className="font-medium text-gray-900 dark:text-gray-100">
+						{fila.asesorNombre}
+					</span>
+					{/* Pool de buckets al que está asignado el asesor (estado actual). */}
+					{fila.bucketsPool.length > 0 ? (
+						fila.bucketsPool.map((b) => (
+							<Badge
+								className="border-gray-300 bg-gray-50 font-normal text-gray-600 text-xs dark:bg-gray-800 dark:text-gray-300"
+								key={b}
+								variant="outline"
+							>
+								B{b}
+							</Badge>
+						))
+					) : (
+						<span className="text-gray-400 text-xs">Sin pool asignado</span>
+					)}
+				</span>
+				<div className="flex items-center gap-4">
+					{/* Efectivos sobre el total de contactos registrados: de N intentos,
+					    en M le contestaron. */}
+					<span className="text-gray-600 text-sm dark:text-gray-300">
+						<span className="font-medium text-gray-900 dark:text-gray-100">
+							{fila.contactosEfectivos}/{fila.totalContactos}
+						</span>{" "}
+						efectivos
+					</span>
+					<span className="text-gray-600 text-sm dark:text-gray-300">
+						{fila.promesasObtenidas} promesas
+					</span>
+					<span
+						className="flex items-center gap-1 text-red-600 text-sm dark:text-red-400"
+						title="Créditos que subieron de bucket saliendo del suyo"
+					>
+						<ArrowUp className="h-3.5 w-3.5" />
+						{fila.subieron}
+					</span>
+					<span
+						className="flex items-center gap-1 text-emerald-600 text-sm dark:text-emerald-400"
+						title="Créditos que bajaron de bucket saliendo del suyo"
+					>
+						<ArrowDown className="h-3.5 w-3.5" />
+						{fila.bajaron}
+					</span>
+					<ChevronDown
+						className={`h-4 w-4 text-gray-400 transition-transform ${
+							abierto ? "rotate-180" : ""
+						}`}
+					/>
+				</div>
+			</button>
+
+			{abierto && (
+				<div className="border-t">
+					{detalle.isPending ? (
+						<div className="flex items-center gap-2 px-4 py-6 text-gray-500 text-sm">
+							<Loader2 className="h-4 w-4 animate-spin" />
+							Cargando detalle…
+						</div>
+					) : (
+						<div className="space-y-4 px-4 py-3">
+							<section>
+								<h3 className="mb-2 font-semibold text-gray-700 text-sm dark:text-gray-200">
+									Contactos
+								</h3>
+								{contactos.length > 0 ? (
+									<Table>
+										<TableHeader>
+											<TableRow>
+												<TableHead>Crédito</TableHead>
+												<TableHead>Fecha</TableHead>
+												<TableHead>Estado</TableHead>
+												<TableHead>Efectivo</TableHead>
+											</TableRow>
+										</TableHeader>
+										<TableBody>
+											{contactos.map((c) => (
+												<TableRow
+													className={
+														c.numeroCreditoSifco ? "cursor-pointer" : undefined
+													}
+													key={c.id}
+													onClick={() => irACaso(c.numeroCreditoSifco)}
+												>
+													<TableCell>{c.numeroCreditoSifco ?? "—"}</TableCell>
+													<TableCell>
+														{c.fechaContacto
+															? formatFechaGT(new Date(c.fechaContacto))
+															: "—"}
+													</TableCell>
+													<TableCell>
+														{c.estadoContacto
+															? (estadoLabel[c.estadoContacto] ??
+																c.estadoContacto)
+															: "—"}
+													</TableCell>
+													<TableCell>
+														{c.esEfectivoManual ? (
+															<span className="font-medium text-emerald-600 dark:text-emerald-400">
+																Sí
+															</span>
+														) : (
+															<span className="text-gray-400 text-xs">
+																{motivoNoEfectivo(c.origen, c.estadoContacto)}
+															</span>
+														)}
+													</TableCell>
+												</TableRow>
+											))}
+										</TableBody>
+									</Table>
+								) : (
+									<p className="text-gray-400 text-sm">
+										Sin contactos en este rango.
+									</p>
+								)}
+							</section>
+
+							<section>
+								<h3 className="mb-2 font-semibold text-gray-700 text-sm dark:text-gray-200">
+									Movimientos de bucket
+								</h3>
+								{movimientos.length > 0 ? (
+									<Table>
+										<TableHeader>
+											<TableRow>
+												<TableHead>Crédito</TableHead>
+												<TableHead>Movimiento</TableHead>
+												<TableHead>Salió de</TableHead>
+												<TableHead>Llegó a</TableHead>
+											</TableRow>
+										</TableHeader>
+										<TableBody>
+											{movimientos.map((m) => (
+												<TableRow
+													className={
+														m.numeroCreditoSifco ? "cursor-pointer" : undefined
+													}
+													key={m.id}
+													onClick={() => irACaso(m.numeroCreditoSifco)}
+												>
+													<TableCell>{m.numeroCreditoSifco ?? "—"}</TableCell>
+													<TableCell>
+														{m.tipo === "subida" ? (
+															<span className="flex items-center gap-1 text-red-600 dark:text-red-400">
+																<ArrowUp className="h-3.5 w-3.5" />
+																Subió
+															</span>
+														) : (
+															<span className="flex items-center gap-1 text-emerald-600 dark:text-emerald-400">
+																<ArrowDown className="h-3.5 w-3.5" />
+																Bajó
+															</span>
+														)}
+													</TableCell>
+													<TableCell className="text-gray-500 text-sm">
+														{m.bucketAnterior != null
+															? (BUCKET_LABEL[m.bucketAnterior] ??
+																`B${m.bucketAnterior}`)
+															: "—"}
+													</TableCell>
+													<TableCell className="text-sm">
+														{m.bucket != null
+															? (BUCKET_LABEL[m.bucket] ?? `B${m.bucket}`)
+															: "—"}
+													</TableCell>
+												</TableRow>
+											))}
+										</TableBody>
+									</Table>
+								) : (
+									<p className="text-gray-400 text-sm">
+										Sin movimientos de bucket en este rango.
+									</p>
+								)}
+							</section>
+						</div>
+					)}
+				</div>
+			)}
+		</Card>
+	);
+}


### PR DESCRIPTION
## Resumen

Implementa CB-024: job automático de cierre diario que hace un snapshot de la gestión de cada asesor (contactos efectivos, promesas, movimientos de bucket), con reporte por rango de fechas en el CRM.

### Definición del ticket (acordada con Jhairo Nájera, responsable)
- **No es un formulario manual** — es un job que corre todos los días a las 00:15 GT y guarda un snapshot de detalle (1 fila por crédito, no agregados) en `cierre_diario_credito_cobros`.
- **Contactos efectivos**: contactos MANUALES del asesor donde el cliente contestó (`contactado`, `acuerdo_parcial`, `rechaza_pagar`). Categorías EXCLUYENTES de `promesa_pago`, que se reporta aparte. Se excluyen contactos automáticos del sistema (premora, WhatsApp masivo).
- **Ratio "efectivos/total"**: de los contactos que el asesor registró (excluyendo automáticos Y promesas del denominador), cuántos fueron efectivos.
- **Movimientos de bucket**: de los créditos que un asesor tenía al EMPEZAR el día, cuántos subieron y cuántos bajaron — no "a quién se atribuye cada evento puntual".
- **Rango dinámico**: la UI puede sumar snapshots ya guardados sobre un rango (ej. semana completa), sin recalcular en vivo.

## Cambios

### Schema (`db/schema/cobros.ts` + migración `0028_cb024_cierre_diario_asesor.sql`, aplicada manualmente en dev)
- Tabla `cierre_diario_credito_cobros`: 1 fila por crédito, columna `tipo` (enum `contacto`/`subida`/`bajada`) distingue origen.
- Índice único parcial en `contacto_id` (permite `ON CONFLICT DO NOTHING` — contactos son históricos inmutables).

### Job (`jobs/cierre-diario-asesores.ts`)
- **Paso A (contactos)**: INSERT idempotente desde `contactos_cobros`, calcula `es_efectivo_manual` con las 3 categorías efectivas, excluye automáticos por prefijo de comentario (`PREFIJO_PREMORA_AUTO`, `PREFIJO_WSP_MASIVO`, compartidos con el router para que escritura y lectura no diverjan).
- **Paso B (movimientos de bucket)**: resuelve el "dueño de la mañana" de cada crédito — si fue reasignado hoy, retrocede al `asesor_anterior_id` de esa reasignación (`getAsesorHistorial` acotado a `desde=hasta=fecha`, no la bitácora completa); si no, el dueño actual ya es el de la mañana. DELETE + INSERT completo por día (datos derivados, recalculables).
- **Atribución asesor cartera-back → user CRM**: cruce por email (`asesor_id` numérico → `email_cash_in` vía nuevo endpoint `getPoolPorAsesor()` → `user.email`), ambos con constraint único. Reemplaza un cruce anterior por `user.name`, que no tiene constraint de unicidad y colisionaba en silencio con nombres duplicados (caso real encontrado en dev: dos usuarios "Lucia Salvatierra").
- Paginación acotada con tope duro (evita colgar el job si `totalPages` viene corrupto de cartera-back) y logging explícito cuando `pagination.totalPages` viene ausente/corrupto, o cuando un movimiento no cruza a ningún usuario del CRM — antes ambos casos fallaban en silencio.
- Chunking de bind params en el lookup de `caso_cobro_id` por SIFCO y en el INSERT masivo (lotes de 1000, límite de Postgres ~65535 params/statement).
- Advisory lock (`pg_try_advisory_lock`) para evitar corridas concurrentes.

### cartera-back
- Nuevo endpoint `GET /buckets/pool-por-asesor` (`controllers/buckets/poolPorAsesor.ts`): catálogo completo de asesores con sus buckets activos (`asesor_bucket` + `asesores`), sin depender de que el asesor tenga créditos activos actualmente.

### Router (`routers/cobros.ts`)
- `getCierreDiarioPorRango`: agrega snapshots por rango de fechas — efectivos, `totalContactos` (excluye automáticos y promesas del denominador), promesas, subieron/bajaron por asesor, y su pool de buckets actual.
- `getDetalleCierrePorAsesor`: detalle crudo por asesor para el acordeón (contactos + movimientos con `bucket_anterior`/`bucket`).

### Web (`routes/cobros/cierre.tsx`, nueva ruta + nav en `header.tsx`)
- Selector de rango de fechas, acordeón por asesor con sub-tablas de contactos y movimientos de bucket, navegación a `/cobros/$id` por SIFCO.

### Scheduler (`index.ts`)
- Corre a las 00:15 GT (no 22:00) porque `procesarMoras` en cartera-back corre a las 23:59 GT y genera los movimientos de bucket del día — correr antes los pierde.
- Recovery al boot si el deploy ocurre después de las 00:15 GT.
- Fix de race condition: el cutoff de recuperación ahora usa un solo snapshot de `Date` en vez de dos lecturas separadas (`getUTCHours()`/`getUTCMinutes()` en instantes distintos podían desincronizarse en el borde exacto del minuto).

## Test plan
- [x] `bun check-types` limpio (server + web)
- [x] `biome check` limpio en archivos tocados
- [x] Job corrido manualmente en dev contra datos reales: contactos clasificados correctamente (promesa excluida de efectivos), 1 movimiento de bucket atribuido correctamente vía el nuevo cruce por email
- [x] Re-corrida verifica idempotencia (contactos no se duplican, movimientos se reemplazan limpio)
- [x] UI verificada en dev: ratio de efectivos correcto (excluye promesas y automáticos), movimientos de bucket con ruta `B1 → B2`, pool del asesor visible
- [x] Varias rondas de code review (Codex) — hallazgos válidos corregidos: race condition en boot recovery, colisión de nombres duplicados en atribución, logging silencioso en truncamiento de paginación

🤖 Generated with [Claude Code](https://claude.com/claude-code)