### PR TITLE
hotfix(cartera): no cerrar cuotas partidas con hermano pendiente (seguimiento #1188)

### DIFF
--- a/apps/cartera-back/src/controllers/registerPayment.ts
+++ b/apps/cartera-back/src/controllers/registerPayment.ts
@@ -2697,6 +2697,25 @@ async function aplicarPagoNormalEnTx(
         .set({ pagado: true })
         .where(eq(cuotas_credito.cuota_id, pago.cuota_id));
 
+      // Cerrada la cuota, TODAS las filas validadas que la pagaron quedan
+      // pagado=true — en particular el cierre diferido que viajó como parcial
+      // (ver arriba): si quedara validated+pagado=false en cuota cerrada, el
+      // guard de parciales del abono a capital (pagado=false, monto>0,
+      // status≠pending) la tomaría como parcial vivo y saltaría el recálculo
+      // automático con revisar_parciales para siempre. También evita que el
+      // recálculo re-siembre estas filas como si fueran recibos abiertos.
+      await tx
+        .update(pagos_credito)
+        .set({ pagado: true })
+        .where(
+          and(
+            eq(pagos_credito.cuota_id, pago.cuota_id),
+            eq(pagos_credito.paymentFalse, false),
+            eq(pagos_credito.validationStatus, "validated"),
+            gt(pagos_credito.monto_aplicado, "0")
+          )
+        );
+
       // Limpiar `*_restante` huérfanos del resto de pagos de la cuota.
       // Si quedaron descuadrados por bugs históricos (pagos partidos
       // sin sincronización), ya no van a polucionar lecturas futuras

--- a/apps/cartera-back/src/controllers/registerPayment.ts
+++ b/apps/cartera-back/src/controllers/registerPayment.ts
@@ -2448,6 +2448,7 @@ async function aplicarPagoNormalEnTx(
     const cuotaAmount = new Big(credito.cuota ?? 0);
     let totalAplicadoEnCuota = new Big(pago.monto_aplicado ?? 0);
     let cuotaCompleta = false;
+    let cierreDiferido = false;
 
     if (pago.cuota_id !== null && cuotaAmount.gt(0)) {
       const otrosPagosValidados = await tx
@@ -2517,8 +2518,16 @@ async function aplicarPagoNormalEnTx(
             )
             .limit(1);
           if (hermanoPendiente) {
+            // La fila de cierre viene marcada pagado=true desde el registro
+            // (dejó su recibo en 0). Si se queda así ya validada, la mora
+            // tomaría la cuota como satisfecha aunque el hermano nunca se
+            // valide (latefee/procesarMoras excluyen cuotas con una fila viva
+            // pagado=true validated/no_required con monto>0). Mientras el
+            // cierre esté diferido, la fila viaja como parcial (pagado=false);
+            // cuotas_credito.pagado lo pone el hermano que cierra en RAMA B.
+            cierreDiferido = pago.pagado === true;
             console.log(
-              `📊 Cuota ${pago.cuota_id}: recibo en 0 pero hay otro pago pendiente sin validar (${hermanoPendiente.pago_id}) → NO se cierra con este pago`
+              `📊 Cuota ${pago.cuota_id}: recibo en 0 pero hay otro pago pendiente sin validar (${hermanoPendiente.pago_id}) → NO se cierra con este pago${cierreDiferido ? " (se difiere también su pagado=true)" : ""}`
             );
           } else {
             cuotaCompleta = true;
@@ -2561,10 +2570,15 @@ async function aplicarPagoNormalEnTx(
     if (!cuotaCompleta) {
       console.log("⚠️ La cuota aún no se cierra con este pago");
 
-      // Validar el pago
+      // Validar el pago. Si es un cierre diferido, suelta también su
+      // pagado=true de registro (ver comentario en el guard de arriba).
       await tx
         .update(pagos_credito)
-        .set({ validationStatus: "validated", fecha_aplicado: new Date() })
+        .set({
+          validationStatus: "validated",
+          fecha_aplicado: new Date(),
+          ...(cierreDiferido ? { pagado: false } : {}),
+        })
         .where(eq(pagos_credito.pago_id, pago_id));
 
       const abonoCapitalPago = new Big(pago.abono_capital ?? 0);

--- a/apps/cartera-back/src/controllers/registerPayment.ts
+++ b/apps/cartera-back/src/controllers/registerPayment.ts
@@ -2495,10 +2495,37 @@ async function aplicarPagoNormalEnTx(
           restantesRecibo.lte(0.01) &&
           new Big(pago.monto_aplicado ?? 0).gt(0)
         ) {
-          cuotaCompleta = true;
-          console.log(
-            `📊 Cuota ${pago.cuota_id}: recibo menor a la cuota mensual cubierto por completo (restantes en 0) → COMPLETA`
-          );
+          // Cuota partida en varios pagos: la fila de CIERRE queda con
+          // restantes 0 aunque un parcial anterior siga pendiente de validar.
+          // Si conta valida el cierre PRIMERO, cerrar aquí marcaría la cuota
+          // pagada y distribuiría a inversionistas solo con el pago de cola
+          // (la suma de arriba solo cuenta hermanos ya validados). Con otro
+          // pago pendiente vivo de la misma cuota NO se cierra: este pago se
+          // valida sin cerrar (RAMA A) y la cuota cierra al validar el último
+          // hermano, cuando la suma de validados alcanza.
+          const [hermanoPendiente] = await tx
+            .select({ pago_id: pagos_credito.pago_id })
+            .from(pagos_credito)
+            .where(
+              and(
+                eq(pagos_credito.cuota_id, pago.cuota_id),
+                eq(pagos_credito.validationStatus, "pending"),
+                eq(pagos_credito.paymentFalse, false),
+                gt(pagos_credito.monto_aplicado, "0"),
+                ne(pagos_credito.pago_id, pago_id)
+              )
+            )
+            .limit(1);
+          if (hermanoPendiente) {
+            console.log(
+              `📊 Cuota ${pago.cuota_id}: recibo en 0 pero hay otro pago pendiente sin validar (${hermanoPendiente.pago_id}) → NO se cierra con este pago`
+            );
+          } else {
+            cuotaCompleta = true;
+            console.log(
+              `📊 Cuota ${pago.cuota_id}: recibo menor a la cuota mensual cubierto por completo (restantes en 0) → COMPLETA`
+            );
+          }
         }
       }
     }

--- a/apps/cartera-back/src/controllers/updateCredit.ts
+++ b/apps/cartera-back/src/controllers/updateCredit.ts
@@ -1,5 +1,17 @@
 import Big from "big.js";
-import { eq, and, or, inArray, asc, gt, lte, gte, sql } from "drizzle-orm";
+import {
+  eq,
+  and,
+  or,
+  inArray,
+  notInArray,
+  isNull,
+  asc,
+  gt,
+  lte,
+  gte,
+  sql,
+} from "drizzle-orm";
 import jwt from "jsonwebtoken";
 import { db } from "../database";
 import {
@@ -1977,14 +1989,28 @@ export const recalcularPagosCredito = async ({
   // distribuido a inversionistas — su reparto guardado recién se aplica al
   // validarse, así que refrescarlo aquí es seguro y necesario: si quedaran
   // fuera, conta validaría el split viejo (interés pre-abono).
+  // Las filas de ABONO A CAPITAL (validationStatus 'capital'/'capital_validated')
+  // NUNCA entran al recálculo: su split es capital puro (abono_capital = monto),
+  // no un reparto de cuota. Redistribuirlas aquí les reescribe el split como si
+  // fueran pago de cuota — y si la cuota ya está cubierta por el pago mensual,
+  // les toca puro cero. Caso real: abono registrado sin aplicar, un "Recalcular
+  // Pagos" intermedio le dejó abono_capital en 0 y al aplicarse restó Q0 del
+  // crédito. También cubre abonos ya aplicados que quedaron con pagado=false.
+  const filaNoEsAbonoCapital = or(
+    isNull(pagos_credito.validationStatus),
+    notInArray(pagos_credito.validationStatus, ["capital", "capital_validated"]),
+  );
+
   const whereConditions =
     numero_cuota !== undefined
       ? and(
           eq(pagos_credito.credito_id, credito.credito_id),
           gte(cuotas_credito.numero_cuota, numero_cuota),
+          filaNoEsAbonoCapital,
         )
       : and(
           eq(pagos_credito.credito_id, credito.credito_id),
+          filaNoEsAbonoCapital,
           or(
             eq(pagos_credito.pagado, false),
             // Pagos registrados sin validar: solo con monto_aplicado > 0.


### PR DESCRIPTION
# Seguimiento del PR #1188: cierre de cuotas partidas

## Qué es esto

El PR #1188 (recalcular cuotas al aplicar un abono a capital) se mergeó por urgencia con un último comentario P1 de Codex sin atender. Este PR trae ese fix, más dos fixes hermanos que salieron al revisar los abonos de julio en prod (ver abajo).

## Qué encontró Codex

Una cuota pagada en **varios pagos** (parcial + cierre) tiene su fila de cierre con restantes en 0. La regla nueva del #1188 — "si el pago dejó el recibo en 0, la cuota cierra" — no distinguía ese caso: si conta validaba el pago de **cierre antes que el parcial**, la cuota se marcaba pagada y la distribución a inversionistas corría **solo con el pago de cola**, ignorando la plata del parcial aún sin validar.

## El fix

La regla ahora exige una condición más: que **no quede otro pago pendiente de validar en la misma cuota**. Si lo hay, el cierre fuera de orden se valida sin cerrar (como cualquier parcial) y la cuota cierra al validar el último pago, cuando la suma de validados alcanza — con la distribución completa.

## Por qué el #1188 tocó el cierre de cuotas (contexto para el reviewer)

Es la pregunta natural: el requerimiento era solo "recalcular tras un abono". La cadena fue:

1. El recálculo tenía un bug pre-existente: cerca de liquidar, el último recibo proyectaba **más capital del que quedaba** (sobre-cobro + sobre-reparto a inversionistas). Automatizarlo tras cada abono lo volvía bug garantizado → se topó el capital al saldo real.
2. Con el tope, el recibo final tras un abono grande suma **menos** que la cuota mensual — y el cierre exigía la cuota mensual completa. El cliente pagaba su saldo real y la cuota jamás cerraba → se agregó la regla "recibo en 0 = cierra".
3. Esa regla era muy ancha (este PR la angosta al caso exacto: recibo capado post-abono, sin hermanos pendientes).

Para una cuota normal de un crédito normal, el cierre funciona idéntico a como siempre.

## Fix 2: el cierre diferido suelta su `pagado=true` (P2 de Codex en este PR)

La fila de cierre viene marcada `pagado=true` desde el registro (dejó su recibo en 0). Al diferir el cierre quedaba `validated`+`pagado=true` con la cuota abierta — y la mora (latefee/procesarMoras) excluye cuotas que tengan una fila viva así: si el parcial hermano se anulaba o nunca se validaba, la cuota subpagada escapaba de la mora para siempre. Ahora, mientras el cierre esté diferido, la fila viaja como parcial (`pagado=false`); cuando el último hermano cierra la cuota, `cuotas_credito.pagado=true` la excluye de la mora por el camino normal. Y al cerrar, RAMA B restaura `pagado=true` en todas las filas validadas de la cuota — sin esto, el diferido quedaba como "parcial vivo" para siempre y el guard de parciales del abono a capital saltaría el recálculo automático (`revisar_parciales`) en todo abono futuro del crédito.

## Fix 3: el recálculo ya no toca filas de abono a capital (caso real de prod)

`recalcularPagosCredito` (el mismo que usa el botón "Recalcular Pagos") trataba **toda** fila como pago de cuota y le redistribuía su `monto_aplicado` contra el saldo. Una fila de abono a capital tiene split de capital puro (`abono_capital = monto`) — redistribuirla se lo borra.

Caso real (15-jul, crédito 8975): se registró un abono de Q607.98, Caja corrió "Recalcular Pagos" antes de aplicarlo (limpiando una reversión), la cuota ya estaba cubierta por la mensualidad → al abono le tocó split de **puros ceros** → al aplicarse restó **Q0** del crédito. El cliente pagó Q607.98 a la nada (reparación de data en curso, aparte).

Ahora ambos modos del recálculo excluyen las filas con status `capital`/`capital_validated`: su split se preserva y su monto no consume saldo de cuota ni casilla de amortización.

## Estado

- Tests del flujo de pagos: registerPayment 40/40, abonosCapital 10/10, revalidatePayment y policies ✅ (corridos por archivo; el run combinado tiene un fallo pre-existente de mocks compartidos de bun, presente también en `main`)
- Hilo de Codex en el #1188 respondido con referencia al Fix 1; P2 de este PR respondido con referencia al Fix 2

🤖 Generated with [Claude Code](https://claude.com/claude-code)
