### PR TITLE
feat(cobros): monto comprometido y próximo paso en promesas (CB-025)

### DIFF
--- a/apps/crm/apps/server/src/db/migrations/0029_cb025_monto_comprometido.sql
+++ b/apps/crm/apps/server/src/db/migrations/0029_cb025_monto_comprometido.sql
@@ -1,0 +1,22 @@
+-- 0029: CB-025 — Monto comprometido y Próximo Paso en el historial de contactos.
+-- Espejo exacto del schema drizzle `src/db/schema/cobros.ts` (contactosCobros).
+-- Idempotente: seguro de re-correr. Aplicar A MANO (no drizzle-kit push/migrate
+-- corrido desde este trabajo — mismo criterio que 0026_cb020_promesa_pago_cuotas.sql).
+--
+-- monto_comprometido: campo puramente informativo. NO participa en
+-- evaluarPromesa (lib/promesa-pago.ts) — cumplida/incumplida sigue
+-- derivándose solo de cuota_inicio/cuota_fin/incluye_mora contra
+-- cartera-back. Opcional: las promesas ya existentes (sin monto) siguen
+-- siendo válidas.
+--
+-- proximo_paso: qué hacer en el próximo contacto (fecha_proximo_contacto solo
+-- dice CUÁNDO, no QUÉ). Texto libre a propósito — el AC de CB-025 pide
+-- "próximo paso" sin catálogo cerrado, y ya hay un catálogo pendiente de
+-- negocio (estado_contacto, ver nota en el schema) — no sumar un segundo
+-- enum sin decisión de negocio detrás.
+
+ALTER TABLE public.contactos_cobros
+  ADD COLUMN IF NOT EXISTS monto_comprometido numeric(12,2);
+
+ALTER TABLE public.contactos_cobros
+  ADD COLUMN IF NOT EXISTS proximo_paso text;

--- a/apps/crm/apps/server/src/db/schema/cobros.ts
+++ b/apps/crm/apps/server/src/db/schema/cobros.ts
@@ -38,6 +38,19 @@ export const metodoContactoEnum = pgEnum("metodo_contacto", [
 	"carta_notarial",
 ]);
 
+// CB-025: catálogo de resultados PROVISIONAL — "Definición de listo" del
+// ticket deja pendiente el catálogo final (qué cuenta como contacto
+// efectivo, si "contactado" debe partirse en más resultados, etc.). Decisión
+// de negocio sin cerrar, no técnica.
+// Para AGREGAR un valor cuando negocio decida: `ALTER TYPE public.estado_contacto
+// ADD VALUE 'nuevo_valor'` es seguro (no bloquea, no requiere rescribir tabla).
+// Para QUITAR o RENOMBRAR uno existente: Postgres no lo permite directo sobre
+// un pgEnum nativo — requiere crear un tipo nuevo, migrar la columna
+// (`ALTER TABLE ... ALTER COLUMN ... TYPE nuevo_tipo USING ...`) y actualizar
+// filas existentes. Si el catálogo final termina necesitando renombrar/quitar
+// valores, considerar migrar esta columna de enum a texto libre + lista de
+// valores válidos en TypeScript en ese momento — mucho más barato de cambiar
+// después que un pgEnum.
 export const estadoContactoEnum = pgEnum("estado_contacto", [
 	"contactado",
 	"no_contesta",
@@ -221,10 +234,22 @@ export const contactosCobros = pgTable(
 		cuotaFin: integer("cuota_fin"),
 		incluyeMora: boolean("incluye_mora").notNull().default(false),
 		estadoPromesa: estadoPromesaEnum("estado_promesa"),
+		// CB-025: monto que el cliente dijo que va a pagar. Informativo — NO lo
+		// lee evaluarPromesa, cumplida/incumplida sigue viniendo solo de
+		// cuota_inicio/cuota_fin/incluye_mora contra cartera-back. Opcional.
+		montoComprometido: decimal("monto_comprometido", {
+			precision: 12,
+			scale: 2,
+		}),
 
 		// Próximo seguimiento
 		requiereSeguimiento: boolean("requiere_seguimiento").default(false),
 		fechaProximoContacto: timestamp("fecha_proximo_contacto"),
+		// CB-025: qué hacer en el próximo contacto (fechaProximoContacto solo
+		// dice CUÁNDO, no QUÉ). Texto libre a propósito — el AC del ticket solo
+		// pide "próximo paso", sin catálogo cerrado (ver nota en
+		// estadoContactoEnum sobre catálogos pendientes de negocio).
+		proximoPaso: text("proximo_paso"),
 
 		// Usuario que realizó el contacto
 		realizadoPor: text("realizado_por")

--- a/apps/crm/apps/server/src/routers/cobros-contacto-schema.test.ts
+++ b/apps/crm/apps/server/src/routers/cobros-contacto-schema.test.ts
@@ -74,4 +74,43 @@ describe("createContactoCobrosSchema — promesa_pago", () => {
 		);
 		expect(result.success).toBe(true);
 	});
+
+	// CB-025: montoComprometido es informativo y opcional — no debe volverse
+	// obligatorio por accidente al tocar este schema en el futuro.
+	test("promesa con montoComprometido → válido", () => {
+		const result = createContactoCobrosSchema.safeParse(
+			base({ incluyeMora: true, montoComprometido: "2500.00" }),
+		);
+		expect(result.success).toBe(true);
+	});
+
+	test("promesa sin montoComprometido → sigue siendo válido (opcional)", () => {
+		const result = createContactoCobrosSchema.safeParse(
+			base({ incluyeMora: true }),
+		);
+		expect(result.success).toBe(true);
+	});
+
+	test("montoComprometido con formato inválido → inválido (code review)", () => {
+		const result = createContactoCobrosSchema.safeParse(
+			base({ incluyeMora: true, montoComprometido: "2,500.00" }),
+		);
+		expect(result.success).toBe(false);
+	});
+
+	// CB-025: proximoPaso es texto libre y opcional — sin catálogo cerrado,
+	// no debe volverse obligatorio por accidente al tocar este schema.
+	test("promesa con proximoPaso → válido", () => {
+		const result = createContactoCobrosSchema.safeParse(
+			base({ incluyeMora: true, proximoPaso: "Llamar de nuevo el viernes" }),
+		);
+		expect(result.success).toBe(true);
+	});
+
+	test("promesa sin proximoPaso → sigue siendo válido (opcional)", () => {
+		const result = createContactoCobrosSchema.safeParse(
+			base({ incluyeMora: true }),
+		);
+		expect(result.success).toBe(true);
+	});
 });

--- a/apps/crm/apps/server/src/routers/cobros.ts
+++ b/apps/crm/apps/server/src/routers/cobros.ts
@@ -431,11 +431,23 @@ export const createContactoCobrosSchema = z
 		compromisosPago: z.string().optional(),
 		requiereSeguimiento: z.boolean().default(false),
 		fechaProximoContacto: z.date().optional(),
+		// CB-025: qué hacer, no cuándo (eso es fechaProximoContacto). Texto
+		// libre, opcional — sin catálogo cerrado (ver nota en
+		// estadoContactoEnum sobre catálogos pendientes de negocio).
+		proximoPaso: z.string().optional(),
 		// CB-020: promesa de pago atada a cuotas — solo relevantes cuando
 		// estadoContacto = 'promesa_pago'.
 		cuotaInicio: z.number().int().positive().optional(),
 		cuotaFin: z.number().int().positive().optional(),
 		incluyeMora: z.boolean().default(false),
+		// CB-025: informativo, no participa en evaluarPromesa — por eso sin
+		// .refine() que lo exija. Mismo regex que montoAcordado/
+		// montoCuotaConvenio (createConvenioPago, arriba) para no dejar pasar
+		// basura a una columna numeric(12,2).
+		montoComprometido: z
+			.string()
+			.regex(/^\d+(\.\d{1,2})?$/, "Formato de monto inválido")
+			.optional(),
 	})
 	// CB-020: promesa_pago exige rango de cuotas y/o mora — una
 	// promesa vacía de ambos no verifica nada real. El web (PR
@@ -1489,10 +1501,12 @@ export const cobrosRouter = {
 					compromisosPago: contactosCobros.compromisosPago,
 					requiereSeguimiento: contactosCobros.requiereSeguimiento,
 					fechaProximoContacto: contactosCobros.fechaProximoContacto,
+					proximoPaso: contactosCobros.proximoPaso,
 					cuotaInicio: contactosCobros.cuotaInicio,
 					cuotaFin: contactosCobros.cuotaFin,
 					incluyeMora: contactosCobros.incluyeMora,
 					estadoPromesa: contactosCobros.estadoPromesa,
+					montoComprometido: contactosCobros.montoComprometido,
 					realizadoPorId: contactosCobros.realizadoPor,
 					realizadoPor: user.name,
 				})

--- a/apps/crm/apps/web/src/components/contacto-modal.tsx
+++ b/apps/crm/apps/web/src/components/contacto-modal.tsx
@@ -17,6 +17,7 @@ import { toast } from "sonner";
 import { Button } from "@/components/ui/button";
 import { Calendar } from "@/components/ui/calendar";
 import { Checkbox } from "@/components/ui/checkbox";
+import { CurrencyInput } from "@/components/ui/currency-input";
 import {
 	Dialog,
 	DialogClose,
@@ -118,6 +119,10 @@ interface ContactoModalProps {
 	// $id.tsx filtra por fechaVencimiento < hoy antes de pasarlas — reusa la
 	// data que ya carga vía getHistorialPagos, no duplica el fetch aquí.
 	cuotasDisponibles?: Array<{ numeroCuota: number }>;
+	// CB-025: mora + cuota del caso, en crudo (sin formatear), para sugerir
+	// un monto en la variante "promesa". El caller ya lo tiene en memoria
+	// (misma fórmula que montoAdeudado) — no dispara query nueva.
+	montoSugerido?: number;
 	// Variables para plantillas de mensaje
 	fechaPago?: string;
 	cuotaMensual?: string;
@@ -143,6 +148,7 @@ export function ContactoModal({
 	onOpenChange,
 	variante = "completo",
 	cuotasDisponibles = [],
+	montoSugerido,
 	fechaPago = "",
 	cuotaMensual = "",
 	placa = "",
@@ -272,6 +278,10 @@ export function ContactoModal({
 			cuotaInicio: undefined as number | undefined,
 			cuotaFin: undefined as number | undefined,
 			incluyeMora: false,
+			// CB-025: monto que el cliente prometió pagar — informativo, opcional.
+			montoComprometido: "",
+			// CB-025: qué hacer en el próximo contacto — texto libre, opcional.
+			proximoPaso: "",
 		},
 		onSubmit: async ({ value }) => {
 			// NO ELIMINAR sin también quitar el botón submit de canSubmit
@@ -303,6 +313,9 @@ export function ContactoModal({
 			client.createContactoCobros({
 				casoCobroId,
 				...data,
+				// "" no es un decimal válido — undefined omite la columna.
+				montoComprometido: data.montoComprometido || undefined,
+				proximoPaso: data.proximoPaso || undefined,
 			}),
 		onSuccess: () => {
 			toast.success("Contacto registrado correctamente");
@@ -1123,6 +1136,33 @@ export function ContactoModal({
 									)
 								}
 							</form.Subscribe>
+
+							{/* CB-025: monto que el cliente dijo que va a pagar —
+							    informativo, opcional. No participa en evaluarPromesa. */}
+							<form.Field name="montoComprometido">
+								{(field) => (
+									<div className="space-y-2">
+										<Label htmlFor="montoComprometido">
+											Monto comprometido (opcional)
+										</Label>
+										<CurrencyInput
+											id="montoComprometido"
+											value={field.state.value}
+											onChange={(value) => field.handleChange(value)}
+										/>
+										{montoSugerido != null && montoSugerido > 0 && (
+											<p className="text-muted-foreground text-sm">
+												Debe Q
+												{montoSugerido.toLocaleString("es-GT", {
+													minimumFractionDigits: 2,
+													maximumFractionDigits: 2,
+												})}{" "}
+												entre mora y cuota.
+											</p>
+										)}
+									</div>
+								)}
+							</form.Field>
 						</div>
 					)}
 
@@ -1230,6 +1270,25 @@ export function ContactoModal({
 									</form.Field>
 								)
 							}
+						</form.Field>
+
+						{/* CB-025: qué hacer, no cuándo (la fecha de arriba). Texto libre,
+						    opcional, en ambas variantes — el AC del ticket aplica a
+						    cualquier gestión, no solo a promesas. */}
+						<form.Field name="proximoPaso">
+							{(field) => (
+								<div className="space-y-2">
+									<Label htmlFor="proximoPaso">
+										¿Cuál es el próximo paso? (opcional)
+									</Label>
+									<Textarea
+										id="proximoPaso"
+										placeholder="Ej. Llamar de nuevo, enviar carta notarial, escalar a jurídico..."
+										value={field.state.value}
+										onChange={(e) => field.handleChange(e.target.value)}
+									/>
+								</div>
+							)}
 						</form.Field>
 					</div>
 

--- a/apps/crm/apps/web/src/components/contacto-modal.tsx
+++ b/apps/crm/apps/web/src/components/contacto-modal.tsx
@@ -17,7 +17,10 @@ import { toast } from "sonner";
 import { Button } from "@/components/ui/button";
 import { Calendar } from "@/components/ui/calendar";
 import { Checkbox } from "@/components/ui/checkbox";
-import { CurrencyInput } from "@/components/ui/currency-input";
+import {
+	CurrencyInput,
+	normalizeForSubmit,
+} from "@/components/ui/currency-input";
 import {
 	Dialog,
 	DialogClose,
@@ -313,8 +316,13 @@ export function ContactoModal({
 			client.createContactoCobros({
 				casoCobroId,
 				...data,
-				// "" no es un decimal válido — undefined omite la columna.
-				montoComprometido: data.montoComprometido || undefined,
+				// Enter dispara submit sin pasar por el onBlur del CurrencyInput
+				// (que es donde normalmente se limpia un punto colgante como
+				// "2500.") — se normaliza también acá, justo antes de armar el
+				// payload, para no depender de que el campo haya perdido foco
+				// (Codex, PR #1191, ronda 3).
+				montoComprometido:
+					normalizeForSubmit(data.montoComprometido) || undefined,
 				proximoPaso: data.proximoPaso || undefined,
 			}),
 		onSuccess: () => {

--- a/apps/crm/apps/web/src/components/ui/currency-input.tsx
+++ b/apps/crm/apps/web/src/components/ui/currency-input.tsx
@@ -38,9 +38,11 @@ function sanitize(input: string) {
 
 // Valor final a enviar (onBlur / submit) — a diferencia de sanitize(), acá sí
 // se descarta un punto sin dígitos o una parte entera vacía: "2500." → "2500",
-// ".50" → "0.50". Un decimal(12,2) no acepta ninguno de los dos crudos
-// (Codex, PR #1191).
-function normalizeForSubmit(raw: string) {
+// ".50" → "0.50". Un decimal(12,2) no acepta ninguno de los dos crudos.
+// Exportada para que quien envía el formulario (ej. Enter dispara submit sin
+// pasar por el onBlur del input) pueda limpiar el valor justo antes de
+// mandarlo, sin duplicar esta lógica (Codex, PR #1191, ronda 3).
+export function normalizeForSubmit(raw: string) {
 	if (!raw) return raw;
 	const [intPart, decPart] = raw.split(".");
 	if (decPart === undefined) return raw;

--- a/apps/crm/apps/web/src/components/ui/currency-input.tsx
+++ b/apps/crm/apps/web/src/components/ui/currency-input.tsx
@@ -24,17 +24,28 @@ function sanitize(input: string) {
 	const clean = input.replace(/,/g, "").replace(/[^0-9.]/g, "");
 	if (!clean) return { normalized: "", intPart: "", decPart: null };
 	const parts = clean.split(".");
-	// "" antes del punto (".50") → "0" — un decimal(12,2) no acepta ".50".
-	const intPart = parts[0] || "0";
+	const intPart = parts[0] ?? "";
 	const hasDecimal = parts.length > 1;
-	const rawDecPart = hasDecimal ? parts.slice(1).join("").slice(0, 2) : null;
-	// Punto colgante sin dígitos ("2500.") no es un decimal válido — se
-	// descarta el punto hasta que el usuario escriba al menos un dígito
-	// (Codex, PR #1191: este string a medias pasaba el sanitize pero
-	// reventaba el regex del backend en createContactoCobrosSchema).
-	const decPart = rawDecPart === "" ? null : rawDecPart;
+	// decPart conserva "" (punto recién tecleado, sin dígitos aún) para que
+	// el display no se coma el punto mientras el usuario sigue escribiendo
+	// (Codex, PR #1191 ronda 2: convertir "" a null aquí rompía "12." → "3"
+	// porque el display perdía el punto antes de que el usuario pudiera
+	// escribir el decimal). La limpieza para el backend va en normalizeForSubmit.
+	const decPart = hasDecimal ? parts.slice(1).join("").slice(0, 2) : null;
 	const normalized = decPart !== null ? `${intPart}.${decPart}` : intPart;
 	return { normalized, intPart, decPart };
+}
+
+// Valor final a enviar (onBlur / submit) — a diferencia de sanitize(), acá sí
+// se descarta un punto sin dígitos o una parte entera vacía: "2500." → "2500",
+// ".50" → "0.50". Un decimal(12,2) no acepta ninguno de los dos crudos
+// (Codex, PR #1191).
+function normalizeForSubmit(raw: string) {
+	if (!raw) return raw;
+	const [intPart, decPart] = raw.split(".");
+	if (decPart === undefined) return raw;
+	if (decPart === "") return intPart || "0";
+	return `${intPart || "0"}.${decPart}`;
 }
 
 export function CurrencyInput({
@@ -91,7 +102,13 @@ export function CurrencyInput({
 						setDisplay("");
 						return;
 					}
-					const n = Number(value);
+					// Recién al perder foco se descarta un punto colgante o una
+					// parte entera vacía — mientras el usuario escribe, sanitize()
+					// los conserva para no comerse el punto que acaba de teclear
+					// (Codex, PR #1191 ronda 2).
+					const cleaned = normalizeForSubmit(value);
+					if (cleaned !== value) onChange(cleaned);
+					const n = Number(cleaned);
 					if (Number.isNaN(n)) return;
 					setDisplay(
 						new Intl.NumberFormat(locale, {

--- a/apps/crm/apps/web/src/components/ui/currency-input.tsx
+++ b/apps/crm/apps/web/src/components/ui/currency-input.tsx
@@ -22,10 +22,17 @@ function formatWithSeparators(raw: string, locale: string) {
 
 function sanitize(input: string) {
 	const clean = input.replace(/,/g, "").replace(/[^0-9.]/g, "");
+	if (!clean) return { normalized: "", intPart: "", decPart: null };
 	const parts = clean.split(".");
-	const intPart = parts[0] ?? "";
+	// "" antes del punto (".50") → "0" — un decimal(12,2) no acepta ".50".
+	const intPart = parts[0] || "0";
 	const hasDecimal = parts.length > 1;
-	const decPart = hasDecimal ? parts.slice(1).join("").slice(0, 2) : null;
+	const rawDecPart = hasDecimal ? parts.slice(1).join("").slice(0, 2) : null;
+	// Punto colgante sin dígitos ("2500.") no es un decimal válido — se
+	// descarta el punto hasta que el usuario escriba al menos un dígito
+	// (Codex, PR #1191: este string a medias pasaba el sanitize pero
+	// reventaba el regex del backend en createContactoCobrosSchema).
+	const decPart = rawDecPart === "" ? null : rawDecPart;
 	const normalized = decPart !== null ? `${intPart}.${decPart}` : intPart;
 	return { normalized, intPart, decPart };
 }

--- a/apps/crm/apps/web/src/routes/cobros/$id.tsx
+++ b/apps/crm/apps/web/src/routes/cobros/$id.tsx
@@ -1298,6 +1298,10 @@ function RouteComponent() {
 											emailCliente={caso.emailContacto || ""}
 											metodoInicial="llamada"
 											variante="promesa"
+											montoSugerido={
+												Number(caso.montoEnMora || 0) +
+												Number(caso.cuotaMensual || 0)
+											}
 											cuotasDisponibles={cuotas
 												.filter(
 													(c: any) =>
@@ -1630,6 +1634,14 @@ function RouteComponent() {
 																).toLocaleDateString("es-GT")}
 															</div>
 														)}
+														{contacto.proximoPaso && (
+															<div className="mt-2 rounded bg-amber-50 p-2 text-sm">
+																<span className="font-medium">
+																	Próximo paso:{" "}
+																</span>
+																{contacto.proximoPaso}
+															</div>
+														)}
 														<div className="mt-2 flex items-center justify-between text-muted-foreground text-xs">
 															<span>
 																Por: {contacto.realizadoPor || "Sin asignar"}
@@ -1771,6 +1783,17 @@ function RouteComponent() {
 															{tieneRango && promesa.incluyeMora && (
 																<Badge variant="outline">+ Mora</Badge>
 															)}
+															{promesa.montoComprometido != null && (
+																<Badge variant="outline">
+																	Q
+																	{Number(
+																		promesa.montoComprometido,
+																	).toLocaleString("es-GT", {
+																		minimumFractionDigits: 2,
+																		maximumFractionDigits: 2,
+																	})}
+																</Badge>
+															)}
 															<span className="text-muted-foreground text-sm">
 																{fechaPrometida
 																	? formatFechaGT(fechaPrometida)
@@ -1797,6 +1820,14 @@ function RouteComponent() {
 														<div className="rounded bg-green-50 p-2 text-sm">
 															<span className="font-medium">Compromiso: </span>
 															{promesa.compromisosPago}
+														</div>
+													)}
+													{promesa.proximoPaso && (
+														<div className="mt-2 rounded bg-amber-50 p-2 text-sm">
+															<span className="font-medium">
+																Próximo paso:{" "}
+															</span>
+															{promesa.proximoPaso}
 														</div>
 													)}
 													<div className="mt-2 text-muted-foreground text-xs">

--- a/apps/crm/apps/web/src/routes/cobros/$id.tsx
+++ b/apps/crm/apps/web/src/routes/cobros/$id.tsx
@@ -1298,9 +1298,17 @@ function RouteComponent() {
 											emailCliente={caso.emailContacto || ""}
 											metodoInicial="llamada"
 											variante="promesa"
+											// Mismo criterio que el card "Total a Pagar" de arriba
+											// (líneas ~728-742): con convenio activo la mora se
+											// reemplaza por la cuota del convenio, no se suma a
+											// ella — si no, la sugerencia acá no coincide con lo
+											// que el asesor ve en pantalla (Codex, PR #1191).
 											montoSugerido={
-												Number(caso.montoEnMora || 0) +
-												Number(caso.cuotaMensual || 0)
+												caso.cuotaConvenio != null
+													? Number(caso.cuotaConvenio) +
+														Number(caso.cuotaMensual || 0)
+													: Number(caso.montoEnMora || 0) +
+														Number(caso.cuotaMensual || 0)
 											}
 											cuotasDisponibles={cuotas
 												.filter(


### PR DESCRIPTION
## Summary

CB-025 pide que el sistema registre "canal, fecha, hora, resultado, comentario, **próximo paso** y usuario" en cada gestión de cobranza. La investigación previa confirmó que canal/fecha/hora/resultado/comentario/usuario ya existían en `contactosCobros`, pero faltaba:

1. **Próximo paso** — solo existía una fecha (`fechaProximoContacto`, el *cuándo*), sin ningún campo que describiera *qué* hacer (llamar de nuevo, carta notarial, escalar a jurídico, etc.).
2. **Monto comprometido** — visto en el mock de Figma del flujo de promesa de pago, validado con Daniel Rodríguez en Slack: "lo del monto sí me parece buena idea y no lo veo complicado" (forma de pago quedó explícitamente fuera de alcance, va de la mano del link de pago y se revisará después de forma general).

Ambos campos son **opcionales e informativos** — no participan en `evaluarPromesa` (`lib/promesa-pago.ts`), así que `cumplida`/`incumplida` sigue derivándose exclusivamente de `cuotaInicio`/`cuotaFin`/`incluyeMora` contra cartera-back. Cero cambios al job nocturno `check-promesas-pago.ts` ni a sus tests.

## Cambios

**DB / schema**
- `apps/server/src/db/migrations/0029_cb025_monto_comprometido.sql` — migración hand-written, idempotente (`ADD COLUMN IF NOT EXISTS`), siguiendo la convención ya establecida en este módulo (ver header de `0026_cb020_promesa_pago_cuotas.sql`): **se aplica a mano, no vía `drizzle-kit push/migrate`** — el journal de Drizzle está congelado desde `0018` y los snapshots desde `0010`, correr `db:generate` reemitiría todo el historial desde `0011` como SQL nuevo.
- `db/schema/cobros.ts`:
  - `montoComprometido: decimal("monto_comprometido", { precision: 12, scale: 2 })`, nullable.
  - `proximoPaso: text("proximo_paso")`, nullable.
  - Comentario nuevo documentado en `estadoContactoEnum` (sin tocar el enum): el ticket deja pendiente el "catálogo final de resultados" como decisión de negocio, no técnica. Se documenta que agregar un valor al enum es seguro (`ALTER TYPE ... ADD VALUE`), pero quitar/renombrar uno existente requiere migrar la columna — si el catálogo final necesita eso, mejor migrar de enum nativo a texto + validación en TypeScript en ese momento.

**Server (`routers/cobros.ts`)**
- `createContactoCobrosSchema`: ambos campos opcionales, sin `.refine()` que los exija.
  - `montoComprometido: z.string().regex(/^\d+(\.\d{1,2})?$/).optional()` — mismo regex que los campos hermanos `montoAcordado`/`montoCuotaConvenio` de `createConvenioPago` en el mismo archivo, para no dejar pasar basura a una columna `numeric(12,2)` si el endpoint se llama fuera del modal (Postman, script, admin tool futura).
  - `proximoPaso: z.string().optional()` — texto libre a propósito, sin catálogo cerrado.
- `getHistorialContactos`: ambos campos agregados al `select` explícito (no hay spread, así que sin esto no se hubieran devuelto al frontend).
- `createContactoCobros` handler: sin cambios — ya hacía `.values({ ...input, ... })`.

**Web**
- `contacto-modal.tsx`:
  - Nuevo campo `CurrencyInput` "Monto comprometido (opcional)" dentro del bloque `¿Qué prometió pagar?` (solo variante `promesa`), con hint de sugerencia ("Debe Q… entre mora y cuota") calculado en el caller, sin queries nuevas.
  - Nuevo `Textarea` "¿Cuál es el próximo paso? (opcional)" en la sección de seguimiento, visible en **ambas variantes** (`completo` y `promesa`) — el AC de CB-025 aplica a cualquier gestión, no solo a promesas.
  - `mutationFn` normaliza `""` → `undefined` en ambos campos antes de enviar (una columna `numeric` no acepta string vacío).
- `routes/cobros/$id.tsx`:
  - Pasa `montoSugerido={montoEnMora + cuotaMensual}` al modal (mismos valores ya cargados para `montoAdeudado`, sin fetch adicional).
  - Renderiza el monto como badge y el próximo paso como bloque destacado, tanto en el Historial de Contactos general como en la tarjeta de Promesas de Pago.

**Tests**
- `cobros-contacto-schema.test.ts`: 5 casos nuevos (con/sin monto, con/sin próximo paso, formato de monto inválido → rechazado). `evaluarPromesa`/`promesa-pago.test.ts` no se tocan.

## Fuera de alcance (anotado, no incluido en este PR)

- **Forma de pago** — decisión explícita en Slack: va de la mano del link de pago, se trata después de forma general.
- **Catálogo final de resultados** y **definición de contacto efectivo** — pendiente de negocio, mencionado en la "Definición de listo" de CB-025. Documentado en código (`estadoContactoEnum`) para cuando se cierre esa decisión.
- **Checklist de cierre** y **sugerencia automática de próxima acción** (vistos en el mock de Figma) — requieren diseño propio, no forman parte de este alcance.
- **Timeline unificada** (promesas hoy se filtran fuera del Historial de Contactos general, `$id.tsx:541-543`) — cambio de render mayor, candidato a ticket separado.

## Test plan

- [x] `bun check-types` limpio (server + web)
- [x] `bun test apps/server/src/routers/cobros-contacto-schema.test.ts` — 12/12 pasan
- [x] Migración `0029` aplicada a mano en dev (Neon `ep-green-tree`) — confirmado, `getHistorialContactos` dejó de dar 500 tras aplicarla
- [ ] Probar en dev: registrar una promesa con monto → verificar badge en tarjeta "Promesas de Pago"
- [ ] Probar en dev: registrar una gestión (variante completa) con próximo paso → verificar que aparece en Historial de Contactos
- [ ] Confirmar que una promesa vieja (sin monto/próximo paso) se sigue renderizando sin errores

🤖 Generated with [Claude Code](https://claude.com/claude-code)