### PR TITLE
fix(carteraFront): badge "Capital Aplicado" para pagos capital_validated

### DIFF
--- a/apps/carteraFront/src/private/cartera/components/paymentsTable.tsx
+++ b/apps/carteraFront/src/private/cartera/components/paymentsTable.tsx
@@ -461,6 +461,12 @@ const handleFacturarPago = (pagoId: number, e?: React.MouseEvent) => {
         bgColor: "bg-orange-100",
         icon: <RotateCcw className="w-4 h-4" />,
       },
+      capital_validated: {
+        label: "Capital Aplicado",
+        color: "text-cyan-700",
+        bgColor: "bg-cyan-100",
+        icon: <Check className="w-4 h-4" />,
+      },
     };
 
     return configs[status] || configs.no_required;


### PR DESCRIPTION
## Problema

Reporte de conta: al validar un abono a capital (o una cancelación que pasa por ese flujo), el pago queda en la página **Pagos con Inversionistas** con la etiqueta **"No requiere"** en lugar de mostrarse como validado, aunque en la DB el pago sí queda `capital_validated` (ej. pago 146189 del crédito insoluto-7).

## Causa

El mapa de badges de `getValidationStatusConfig` en `paymentsTable.tsx` no tiene entrada para `capital_validated`, y el fallback `configs[status] || configs.no_required` pinta cualquier estado desconocido como "No requiere". El resto del componente sí trata `capital_validated` como validado (menú "Ya Validado", filtros), por lo que era solo un bug visual.

## Fix

Se agrega la entrada `capital_validated` al mapa de badges con la etiqueta **"Capital Aplicado"** y color cyan, el mismo nombre y color que ya usa el dropdown de "Estado Validación" para ese estado. Cubre vista móvil y escritorio (ambas usan la misma función).

Typecheck de `carteraFront` en verde.

🤖 Generated with [Claude Code](https://claude.com/claude-code)