### PR TITLE
fix(cartera): conciliar mora esperada y recuperada

### DIFF
--- a/apps/cartera-back/src/controllers/moraHistorial.ts
+++ b/apps/cartera-back/src/controllers/moraHistorial.ts
@@ -1,6 +1,9 @@
-import { db } from "../database";
 import { sql } from "drizzle-orm";
 import ExcelJS from "exceljs";
+import { db } from "../database";
+import { snapCte } from "./moraSnapshotSql";
+
+export { snapCte } from "./moraSnapshotSql";
 
 // ─────────────────────────────────────────────────────────────────────────────
 // Módulo Mora Histórica: reconstruye la mora a cualquier fecha desde
@@ -15,34 +18,6 @@ const ETAPA_SQL = sql`CASE
   WHEN s.cuotas = 3 THEN 'Mora 90'
   WHEN s.cuotas >= 4 THEN 'Mora 120+'
   ELSE 'Al día' END`;
-
-// CTE: estado de mora por crédito "as-of" `fecha`.
-// monto/tipo = último evento; cuotas = último evento CON cuotas>0 (carry-forward).
-export const snapCte = (fecha: string) => sql`
-  snap_raw AS (
-    SELECT
-      h.credito_id,
-      h.tipo_evento,
-      h.monto_nuevo::numeric AS monto,
-      h.fecha,
-      ROW_NUMBER() OVER (PARTITION BY h.credito_id ORDER BY h.fecha DESC, h.historial_id DESC) AS rn,
-      -- cuotas "vivas": cuotas del evento más reciente con cuotas>0. Los eventos payment-only
-      -- (updateMora sin cuotas, p.ej. reversa de pago en reversePayment.ts) registran
-      -- cuotas_atrasadas_nuevas=0; sin carry-forward un crédito con mora>0 cuyo último evento
-      -- sea payment-only caería a "Al día" y se saldría de los buckets 30/60/90/120 (review Codex).
-      FIRST_VALUE(h.cuotas_atrasadas_nuevas) OVER (
-        PARTITION BY h.credito_id
-        ORDER BY (h.cuotas_atrasadas_nuevas > 0) DESC, h.fecha DESC, h.historial_id DESC
-      ) AS cuotas
-    FROM cartera.moras_historial h
-    -- Corte por DÍA Guatemala: fecha es timestamp UTC (defaultNow, session UTC) y el cron
-    -- corre ~23:59 GT (≈06:00 UTC del día siguiente); comparar en GT evita correr esos
-    -- eventos al día siguiente.
-    WHERE (h.fecha AT TIME ZONE 'UTC' AT TIME ZONE 'America/Guatemala')::date <= ${fecha}::date
-  ),
-  snap AS (
-    SELECT credito_id, tipo_evento, monto, cuotas, fecha FROM snap_raw WHERE rn = 1
-  )`;
 
 type SnapshotArgs = {
   fecha: string; // YYYY-MM-DD (corte "al" día)

--- a/apps/cartera-back/src/controllers/moraRecuperacion.test.ts
+++ b/apps/cartera-back/src/controllers/moraRecuperacion.test.ts
@@ -176,14 +176,32 @@ describe("buildMoraRecoveryReport", () => {
 	});
 
 	it("permite el mes actual provisional antes del día 6 y rechaza ciclos futuros", () => {
-		expect(
-			getMoraRecoveryPeriod({ mes: 6, anio: 2026, hoy: "2026-06-03" }),
-		).toMatchObject({ alcance: "live" });
+		for (const dia of ["01", "02", "03", "04", "05"]) {
+			expect(
+				getMoraRecoveryPeriod({ mes: 6, anio: 2026, hoy: `2026-06-${dia}` }),
+			).toMatchObject({ fechaSnapshot: `2026-06-${dia}`, alcance: "live" });
+		}
 		expect(() =>
 			getMoraRecoveryPeriod({ mes: 7, anio: 2026, hoy: "2026-06-03" }),
 		).toThrow("ciclo futuro");
 		expect(() =>
 			getMoraRecoveryPeriod({ mes: 1, anio: 2027, hoy: "2026-12-20" }),
 		).toThrow("ciclo futuro");
+	});
+
+	it("usa el snapshot histórico de apertura desde el día 6", () => {
+		const period = getMoraRecoveryPeriod({
+			mes: 6,
+			anio: 2026,
+			hoy: "2026-06-06",
+		});
+		const query = new PgDialect().sqlToQuery(buildMoraRecoveryQuery(period));
+
+		expect(period).toMatchObject({
+			fechaSnapshot: "2026-06-06",
+			alcance: "historico",
+		});
+		expect(query.sql).toContain("moras_historial");
+		expect(query.sql).not.toContain("mora_activa");
 	});
 });

--- a/apps/cartera-back/src/controllers/moraRecuperacion.test.ts
+++ b/apps/cartera-back/src/controllers/moraRecuperacion.test.ts
@@ -68,6 +68,37 @@ describe("buildMoraRecoveryReport", () => {
 		]);
 	});
 
+	it("usa un snapshot estrictamente anterior al inicio y cuenta el pago del día 6", () => {
+		const period = getMoraRecoveryPeriod({
+			mes: 6,
+			anio: 2026,
+			hoy: "2026-07-29",
+		});
+		const query = new PgDialect().sqlToQuery(buildMoraRecoveryQuery(period));
+		const report = buildMoraRecoveryReport(
+			[
+				{
+					asesorId: 1,
+					nombre: "Ana",
+					esperado: "100",
+					cobradoEnSnapshot: "40",
+					cobradoFueraSnapshot: "0",
+				},
+			],
+			period,
+		);
+
+		expect(query.sql).toContain(
+			"(h.fecha AT TIME ZONE 'UTC' AT TIME ZONE 'America/Guatemala')::date < $1::date",
+		);
+		expect(report.totales).toMatchObject({
+			esperado: "100.00",
+			cobradoEnSnapshot: "40.00",
+			cobradoFueraSnapshot: "0.00",
+			pendiente: "60.00",
+		});
+	});
+
 	it("separa cobrado del snapshot, fuera, excedente y pendiente sin truncar", () => {
 		const report = buildMoraRecoveryReport(rows, {
 			inicio: "2026-06-06",
@@ -142,5 +173,17 @@ describe("buildMoraRecoveryReport", () => {
 				pendiente: "60.00",
 			}),
 		]);
+	});
+
+	it("permite el mes actual provisional antes del día 6 y rechaza ciclos futuros", () => {
+		expect(
+			getMoraRecoveryPeriod({ mes: 6, anio: 2026, hoy: "2026-06-03" }),
+		).toMatchObject({ alcance: "live" });
+		expect(() =>
+			getMoraRecoveryPeriod({ mes: 7, anio: 2026, hoy: "2026-06-03" }),
+		).toThrow("ciclo futuro");
+		expect(() =>
+			getMoraRecoveryPeriod({ mes: 1, anio: 2027, hoy: "2026-12-20" }),
+		).toThrow("ciclo futuro");
 	});
 });

--- a/apps/cartera-back/src/controllers/moraRecuperacion.test.ts
+++ b/apps/cartera-back/src/controllers/moraRecuperacion.test.ts
@@ -1,0 +1,146 @@
+import { describe, expect, it } from "bun:test";
+import { PgDialect } from "drizzle-orm/pg-core";
+import {
+	type MoraRecoverySourceRow,
+	buildMoraRecoveryQuery,
+	buildMoraRecoveryReport,
+	getMoraRecoveryPeriod,
+} from "./moraRecuperacion";
+
+const rows: MoraRecoverySourceRow[] = [
+	{
+		asesorId: 1,
+		nombre: "Ana",
+		esperado: "100.00",
+		cobradoEnSnapshot: "120.00",
+		cobradoFueraSnapshot: "30.00",
+	},
+	{
+		asesorId: null,
+		nombre: "Sin asignar",
+		esperado: "50.00",
+		cobradoEnSnapshot: "20.00",
+		cobradoFueraSnapshot: "0.00",
+	},
+	{
+		asesorId: 2,
+		nombre: "Beto",
+		esperado: "0.00",
+		cobradoEnSnapshot: "0.00",
+		cobradoFueraSnapshot: "40.00",
+	},
+];
+
+describe("buildMoraRecoveryReport", () => {
+	it("construye el contrato SQL histórico con el ciclo, FULL JOIN y filtros actuales", () => {
+		const period = getMoraRecoveryPeriod({
+			mes: 6,
+			anio: 2026,
+			hoy: "2026-07-29",
+		});
+		const query = new PgDialect().sqlToQuery(
+			buildMoraRecoveryQuery({
+				...period,
+				asesores: [7, 8],
+				emailCobrador: "cashin@example.com",
+			}),
+		);
+
+		expect(period).toEqual({
+			inicio: "2026-06-06",
+			fin: "2026-07-06",
+			fechaSnapshot: "2026-06-06",
+			alcance: "historico",
+		});
+		expect(query.sql).toContain("FULL JOIN pagos_por_credito");
+		expect(query.sql).toContain("moras_historial");
+		expect(query.sql).not.toContain('"statusCredit"');
+		expect(query.sql).toContain("LOWER(a.email_cash_in) = LOWER(TRIM($2))");
+		expect(query.sql).toContain("a.asesor_id IN ($3, $4)");
+		expect(query.sql).toContain("COALESCE(ca.nombre, 'Sin asignar')");
+		expect(query.params).toEqual([
+			"2026-06-06",
+			"cashin@example.com",
+			7,
+			8,
+			"2026-06-06",
+			"2026-07-06",
+		]);
+	});
+
+	it("separa cobrado del snapshot, fuera, excedente y pendiente sin truncar", () => {
+		const report = buildMoraRecoveryReport(rows, {
+			inicio: "2026-06-06",
+			fin: "2026-07-06",
+			alcance: "historico",
+		});
+
+		expect(report.totales).toEqual({
+			esperado: "150.00",
+			cobradoEnSnapshot: "140.00",
+			cobradoFueraSnapshot: "70.00",
+			excedenteEnSnapshot: "20.00",
+			pendiente: "30.00",
+		});
+		expect(
+			report.porAsesor.find((row) => row.asesorId === 1)?.excedenteEnSnapshot,
+		).toBe("20.00");
+		expect(report.porAsesor.find((row) => row.asesorId === 2)?.pendiente).toBe(
+			"0.00",
+		);
+	});
+
+	it("conserva asesores exclusivos y representa Sin asignar de forma tipada", () => {
+		const report = buildMoraRecoveryReport(rows, {
+			inicio: "2026-06-06",
+			fin: "2026-07-06",
+			alcance: "historico",
+		});
+
+		expect(report.porAsesor.map((row) => row.asesorId)).toEqual([1, null, 2]);
+		expect(report.porAsesor.find((row) => row.asesorId === null)).toMatchObject(
+			{
+				nombre: "Sin asignar",
+				esperado: "50.00",
+				pendiente: "30.00",
+			},
+		);
+		expect(report.metadata).toEqual({
+			alcance: "historico",
+			atribucionAsesor: "actual",
+		});
+	});
+
+	it("agrega por asesor sin permitir que excedentes compensen pendientes de otro crédito", () => {
+		const report = buildMoraRecoveryReport(
+			[
+				{
+					asesorId: 7,
+					nombre: "Cora",
+					esperado: "100",
+					cobradoEnSnapshot: "140",
+					cobradoFueraSnapshot: "0",
+				},
+				{
+					asesorId: 7,
+					nombre: "Cora",
+					esperado: "80",
+					cobradoEnSnapshot: "20",
+					cobradoFueraSnapshot: "90",
+				},
+			],
+			{ inicio: "2026-06-06", fin: "2026-07-06", alcance: "live" },
+		);
+
+		expect(report.porAsesor).toEqual([
+			expect.objectContaining({
+				asesorId: 7,
+				esperado: "180.00",
+				cobradoEnSnapshot: "160.00",
+				cobradoFueraSnapshot: "90.00",
+				excedenteEnSnapshot: "40.00",
+				pendiente: "60.00",
+			}),
+		]);
+	});
+});

--- a/apps/cartera-back/src/controllers/moraRecuperacion.ts
+++ b/apps/cartera-back/src/controllers/moraRecuperacion.ts
@@ -39,6 +39,13 @@ export type MoraRecoveryPeriod = {
 	alcance: "live" | "historico";
 };
 
+export class MoraRecoveryFuturePeriodError extends Error {
+	constructor() {
+		super("No se puede consultar un ciclo futuro");
+		this.name = "MoraRecoveryFuturePeriodError";
+	}
+}
+
 export function getMoraRecoveryPeriod({
 	mes,
 	anio,
@@ -48,6 +55,10 @@ export function getMoraRecoveryPeriod({
 	anio: number;
 	hoy: string;
 }): MoraRecoveryPeriod {
+	const [anioActual, mesActual] = hoy.split("-").map(Number);
+	if (anio > anioActual || (anio === anioActual && mes > mesActual)) {
+		throw new MoraRecoveryFuturePeriodError();
+	}
 	const inicio = `${anio}-${String(mes).padStart(2, "0")}-06`;
 	const finMes = mes === 12 ? 1 : mes + 1;
 	const finAnio = mes === 12 ? anio + 1 : anio;
@@ -83,7 +94,7 @@ export function buildMoraRecoveryQuery({
 		: sql``;
 	const snapshotCte =
 		alcance === "historico"
-			? sql`${snapCte(fechaSnapshot)}, snapshot_por_credito AS (
+			? sql`${snapCte(fechaSnapshot, false)}, snapshot_por_credito AS (
       SELECT s.credito_id, s.monto::numeric AS esperado
       FROM snap s
       WHERE s.tipo_evento <> 'DESACTIVACION' AND s.monto > 0 AND s.cuotas > 0

--- a/apps/cartera-back/src/controllers/moraRecuperacion.ts
+++ b/apps/cartera-back/src/controllers/moraRecuperacion.ts
@@ -1,0 +1,199 @@
+import { sql } from "drizzle-orm";
+import { snapCte } from "./moraSnapshotSql";
+
+export type MoraRecoverySourceRow = {
+	asesorId: number | null;
+	nombre: string;
+	esperado: string;
+	cobradoEnSnapshot: string;
+	cobradoFueraSnapshot: string;
+};
+
+export type MoraRecoveryMetric = {
+	esperado: string;
+	cobradoEnSnapshot: string;
+	cobradoFueraSnapshot: string;
+	excedenteEnSnapshot: string;
+	pendiente: string;
+};
+
+export type MoraRecoveryRow = MoraRecoveryMetric & {
+	asesorId: number | null;
+	nombre: string;
+};
+
+type MoraRecoveryReport = {
+	periodo: { inicio: string; fin: string };
+	metadata: {
+		alcance: "live" | "historico";
+		atribucionAsesor: "actual";
+	};
+	totales: MoraRecoveryMetric;
+	porAsesor: MoraRecoveryRow[];
+};
+
+export type MoraRecoveryPeriod = {
+	inicio: string;
+	fin: string;
+	fechaSnapshot: string;
+	alcance: "live" | "historico";
+};
+
+export function getMoraRecoveryPeriod({
+	mes,
+	anio,
+	hoy,
+}: {
+	mes: number;
+	anio: number;
+	hoy: string;
+}): MoraRecoveryPeriod {
+	const inicio = `${anio}-${String(mes).padStart(2, "0")}-06`;
+	const finMes = mes === 12 ? 1 : mes + 1;
+	const finAnio = mes === 12 ? anio + 1 : anio;
+	const fin = `${finAnio}-${String(finMes).padStart(2, "0")}-06`;
+	const fechaSnapshot = inicio > hoy ? hoy : inicio;
+	return {
+		inicio,
+		fin,
+		fechaSnapshot,
+		alcance: fechaSnapshot < hoy ? "historico" : "live",
+	};
+}
+
+export function buildMoraRecoveryQuery({
+	inicio,
+	fin,
+	fechaSnapshot,
+	alcance,
+	asesores,
+	emailCobrador,
+}: MoraRecoveryPeriod & {
+	asesores?: number[];
+	emailCobrador?: string;
+}) {
+	const emailFilter = emailCobrador
+		? sql`AND LOWER(a.email_cash_in) = LOWER(TRIM(${emailCobrador}))`
+		: sql``;
+	const asesoresFilter = asesores?.length
+		? sql`AND a.asesor_id IN (${sql.join(
+				asesores.map((id) => sql`${id}`),
+				sql`, `,
+			)})`
+		: sql``;
+	const snapshotCte =
+		alcance === "historico"
+			? sql`${snapCte(fechaSnapshot)}, snapshot_por_credito AS (
+      SELECT s.credito_id, s.monto::numeric AS esperado
+      FROM snap s
+      WHERE s.tipo_evento <> 'DESACTIVACION' AND s.monto > 0 AND s.cuotas > 0
+    )`
+			: sql`mora_activa AS (
+      SELECT DISTINCT ON (credito_id) credito_id, monto_mora::numeric AS esperado
+      FROM cartera.moras_credito
+      WHERE activa = true AND cuotas_atrasadas > 0
+      ORDER BY credito_id, mora_id DESC
+    ), snapshot_por_credito AS (
+      SELECT m.credito_id, m.esperado
+      FROM mora_activa m
+      JOIN cartera.creditos c ON c.credito_id = m.credito_id
+      WHERE c."statusCredit" IN ('ACTIVO', 'MOROSO', 'EN_CONVENIO')
+    )`;
+
+	return sql`
+    WITH ${snapshotCte},
+    creditos_con_asesor AS (
+      SELECT c.credito_id, c.asesor_id, a.nombre
+      FROM cartera.creditos c
+      LEFT JOIN cartera.asesores a ON a.asesor_id = c.asesor_id
+      WHERE true ${emailFilter} ${asesoresFilter}
+    ),
+    pagos_por_credito AS (
+      SELECT pc.credito_id, COALESCE(SUM(pc.mora::numeric), 0) AS cobrado
+      FROM cartera.pagos_credito pc
+      JOIN creditos_con_asesor ca ON ca.credito_id = pc.credito_id
+      WHERE pc.fecha_pago >= ${inicio}::timestamp
+        AND pc.fecha_pago < ${fin}::timestamp
+        AND COALESCE(pc."paymentFalse", false) = false
+      GROUP BY pc.credito_id
+    )
+    SELECT
+      ca.asesor_id,
+      COALESCE(ca.nombre, 'Sin asignar') AS nombre,
+      COALESCE(s.esperado, 0)::text AS esperado,
+      CASE WHEN s.credito_id IS NOT NULL THEN COALESCE(p.cobrado, 0) ELSE 0 END::text AS cobrado_en_snapshot,
+      CASE WHEN s.credito_id IS NULL THEN COALESCE(p.cobrado, 0) ELSE 0 END::text AS cobrado_fuera_snapshot
+    FROM snapshot_por_credito s
+    FULL JOIN pagos_por_credito p ON p.credito_id = s.credito_id
+    JOIN creditos_con_asesor ca ON ca.credito_id = COALESCE(s.credito_id, p.credito_id)
+  `;
+}
+
+function metricFrom(
+	row: Omit<MoraRecoverySourceRow, "asesorId" | "nombre">,
+): MoraRecoveryMetric {
+	const esperado = Number(row.esperado);
+	const cobradoEnSnapshot = Number(row.cobradoEnSnapshot);
+	const cobradoFueraSnapshot = Number(row.cobradoFueraSnapshot);
+	return {
+		esperado: esperado.toFixed(2),
+		cobradoEnSnapshot: cobradoEnSnapshot.toFixed(2),
+		cobradoFueraSnapshot: cobradoFueraSnapshot.toFixed(2),
+		excedenteEnSnapshot: Math.max(0, cobradoEnSnapshot - esperado).toFixed(2),
+		pendiente: Math.max(0, esperado - cobradoEnSnapshot).toFixed(2),
+	};
+}
+
+export function buildMoraRecoveryReport(
+	rows: MoraRecoverySourceRow[],
+	periodo: { inicio: string; fin: string; alcance: "live" | "historico" },
+): MoraRecoveryReport {
+	const byAsesor = new Map<string, MoraRecoveryRow>();
+	for (const source of rows) {
+		const key = String(source.asesorId);
+		const current = byAsesor.get(key) ?? {
+			asesorId: source.asesorId,
+			nombre: source.nombre,
+			...metricFrom({
+				esperado: "0",
+				cobradoEnSnapshot: "0",
+				cobradoFueraSnapshot: "0",
+			}),
+		};
+		const metric = metricFrom(source);
+		byAsesor.set(key, {
+			asesorId: current.asesorId,
+			nombre: current.nombre,
+			esperado: (Number(current.esperado) + Number(metric.esperado)).toFixed(2),
+			cobradoEnSnapshot: (
+				Number(current.cobradoEnSnapshot) + Number(metric.cobradoEnSnapshot)
+			).toFixed(2),
+			cobradoFueraSnapshot: (
+				Number(current.cobradoFueraSnapshot) +
+				Number(metric.cobradoFueraSnapshot)
+			).toFixed(2),
+			excedenteEnSnapshot: (
+				Number(current.excedenteEnSnapshot) + Number(metric.excedenteEnSnapshot)
+			).toFixed(2),
+			pendiente: (Number(current.pendiente) + Number(metric.pendiente)).toFixed(
+				2,
+			),
+		});
+	}
+	const porAsesor = [...byAsesor.values()];
+	const sum = (field: keyof MoraRecoveryMetric) =>
+		porAsesor.reduce((total, row) => total + Number(row[field]), 0).toFixed(2);
+
+	return {
+		periodo: { inicio: periodo.inicio, fin: periodo.fin },
+		metadata: { alcance: periodo.alcance, atribucionAsesor: "actual" },
+		totales: {
+			esperado: sum("esperado"),
+			cobradoEnSnapshot: sum("cobradoEnSnapshot"),
+			cobradoFueraSnapshot: sum("cobradoFueraSnapshot"),
+			excedenteEnSnapshot: sum("excedenteEnSnapshot"),
+			pendiente: sum("pendiente"),
+		},
+		porAsesor,
+	};
+}

--- a/apps/cartera-back/src/controllers/moraRecuperacion.ts
+++ b/apps/cartera-back/src/controllers/moraRecuperacion.ts
@@ -68,7 +68,7 @@ export function getMoraRecoveryPeriod({
 		inicio,
 		fin,
 		fechaSnapshot,
-		alcance: fechaSnapshot < hoy ? "historico" : "live",
+		alcance: inicio <= hoy ? "historico" : "live",
 	};
 }
 

--- a/apps/cartera-back/src/controllers/moraSnapshotSql.ts
+++ b/apps/cartera-back/src/controllers/moraSnapshotSql.ts
@@ -2,7 +2,9 @@ import { sql } from "drizzle-orm";
 
 // CTE: estado de mora por crédito "as-of" `fecha`.
 // monto/tipo = último evento; cuotas = último evento CON cuotas>0 (carry-forward).
-export const snapCte = (fecha: string) => sql`
+export const snapCte = (fecha: string, incluirFecha = true) => {
+	const comparador = incluirFecha ? sql`<=` : sql`<`;
+	return sql`
   snap_raw AS (
     SELECT
       h.credito_id,
@@ -22,8 +24,9 @@ export const snapCte = (fecha: string) => sql`
     -- Corte por DÍA Guatemala: fecha es timestamp UTC (defaultNow, session UTC) y el cron
     -- corre ~23:59 GT (≈06:00 UTC del día siguiente); comparar en GT evita correr esos
     -- eventos al día siguiente.
-    WHERE (h.fecha AT TIME ZONE 'UTC' AT TIME ZONE 'America/Guatemala')::date <= ${fecha}::date
+    WHERE (h.fecha AT TIME ZONE 'UTC' AT TIME ZONE 'America/Guatemala')::date ${comparador} ${fecha}::date
   ),
   snap AS (
     SELECT credito_id, tipo_evento, monto, cuotas, fecha FROM snap_raw WHERE rn = 1
   )`;
+};

--- a/apps/cartera-back/src/controllers/moraSnapshotSql.ts
+++ b/apps/cartera-back/src/controllers/moraSnapshotSql.ts
@@ -1,0 +1,29 @@
+import { sql } from "drizzle-orm";
+
+// CTE: estado de mora por crédito "as-of" `fecha`.
+// monto/tipo = último evento; cuotas = último evento CON cuotas>0 (carry-forward).
+export const snapCte = (fecha: string) => sql`
+  snap_raw AS (
+    SELECT
+      h.credito_id,
+      h.tipo_evento,
+      h.monto_nuevo::numeric AS monto,
+      h.fecha,
+      ROW_NUMBER() OVER (PARTITION BY h.credito_id ORDER BY h.fecha DESC, h.historial_id DESC) AS rn,
+      -- cuotas "vivas": cuotas del evento más reciente con cuotas>0. Los eventos payment-only
+      -- (updateMora sin cuotas, p.ej. reversa de pago en reversePayment.ts) registran
+      -- cuotas_atrasadas_nuevas=0; sin carry-forward un crédito con mora>0 cuyo último evento
+      -- sea payment-only caería a "Al día" y se saldría de los buckets 30/60/90/120 (review Codex).
+      FIRST_VALUE(h.cuotas_atrasadas_nuevas) OVER (
+        PARTITION BY h.credito_id
+        ORDER BY (h.cuotas_atrasadas_nuevas > 0) DESC, h.fecha DESC, h.historial_id DESC
+      ) AS cuotas
+    FROM cartera.moras_historial h
+    -- Corte por DÍA Guatemala: fecha es timestamp UTC (defaultNow, session UTC) y el cron
+    -- corre ~23:59 GT (≈06:00 UTC del día siguiente); comparar en GT evita correr esos
+    -- eventos al día siguiente.
+    WHERE (h.fecha AT TIME ZONE 'UTC' AT TIME ZONE 'America/Guatemala')::date <= ${fecha}::date
+  ),
+  snap AS (
+    SELECT credito_id, tipo_evento, monto, cuotas, fecha FROM snap_raw WHERE rn = 1
+  )`;

--- a/apps/cartera-back/src/controllers/reportes.ts
+++ b/apps/cartera-back/src/controllers/reportes.ts
@@ -1,6 +1,12 @@
 import { sql } from "drizzle-orm";
 import { db } from "../database";
-import { snapCte } from "./moraHistorial";
+import {
+  type MoraRecoverySourceRow,
+  buildMoraRecoveryQuery,
+  buildMoraRecoveryReport,
+  getMoraRecoveryPeriod,
+} from "./moraRecuperacion";
+import { snapCte } from "./moraSnapshotSql";
 
 type Periodo = "anio" | "trimestre" | "mes" | "semana" | "dia";
 
@@ -1369,6 +1375,39 @@ export async function getMoraCobradaPorAsesor({
   const totalCobrado = porAsesor.reduce((s, r) => s + Number(r.cobrado), 0).toFixed(2);
 
   return { periodo: { inicio, fin }, porAsesor, totalCobrado };
+}
+
+export async function getMoraRecuperacionPorAsesor({
+  mes,
+  anio,
+  asesores,
+  emailCobrador,
+}: {
+  mes: number;
+  anio: number;
+  asesores?: number[];
+  emailCobrador?: string;
+}) {
+  const period = getMoraRecoveryPeriod({ mes, anio, hoy: hoyGTStr() });
+
+  const result = await db.execute<{
+    asesor_id: number | null;
+    nombre: string | null;
+    esperado: string;
+    cobrado_en_snapshot: string;
+    cobrado_fuera_snapshot: string;
+  }>(buildMoraRecoveryQuery({ ...period, asesores, emailCobrador }));
+
+  return buildMoraRecoveryReport(
+    result.rows.map((row): MoraRecoverySourceRow => ({
+      asesorId: row.asesor_id,
+      nombre: row.nombre ?? "Sin asignar",
+      esperado: row.esperado,
+      cobradoEnSnapshot: row.cobrado_en_snapshot,
+      cobradoFueraSnapshot: row.cobrado_fuera_snapshot,
+    })),
+    period,
+  );
 }
 
 export async function getCuotasPorFecha({

--- a/apps/cartera-back/src/routers/reportes.test.ts
+++ b/apps/cartera-back/src/routers/reportes.test.ts
@@ -1,0 +1,51 @@
+import { describe, expect, it, mock } from "bun:test";
+import jwt from "jsonwebtoken";
+import { getMoraRecoveryPeriod } from "../controllers/moraRecuperacion";
+
+const execute = mock(() => Promise.resolve({ rows: [] }));
+
+mock.module("../database", () => ({ db: { execute } }));
+
+const { reportesRouter } = await import("./reportes");
+
+describe("GET /reportes/mora-recuperacion-por-asesor", () => {
+	it("responde 400 para un ciclo futuro antes de consultar la base de datos", async () => {
+		execute.mockClear();
+		const token = jwt.sign({ role: "ADMIN" }, "supersecreto");
+		const response = await reportesRouter.handle(
+			new Request(
+				"http://localhost/reportes/mora-recuperacion-por-asesor?mes=1&anio=2100",
+				{ headers: { authorization: `Bearer ${token}` } },
+			),
+		);
+
+		expect(response.status).toBe(400);
+		expect(await response.json()).toEqual({
+			error: "No se puede consultar un ciclo futuro",
+		});
+		expect(execute).not.toHaveBeenCalled();
+	});
+
+	it("responde 500 para un error inesperado", async () => {
+		execute.mockRejectedValueOnce(new Error("fallo de base de datos"));
+		const token = jwt.sign({ role: "ADMIN" }, "supersecreto");
+		const response = await reportesRouter.handle(
+			new Request(
+				"http://localhost/reportes/mora-recuperacion-por-asesor?mes=1&anio=2000",
+				{ headers: { authorization: `Bearer ${token}` } },
+			),
+		);
+
+		expect(response.status).toBe(500);
+	});
+
+	it("marca el ciclo futuro con una señal estable", () => {
+		let error: unknown;
+		try {
+			getMoraRecoveryPeriod({ mes: 1, anio: 2100, hoy: "2026-07-29" });
+		} catch (caughtError) {
+			error = caughtError;
+		}
+		expect(error).toMatchObject({ name: "MoraRecoveryFuturePeriodError" });
+	});
+});

--- a/apps/cartera-back/src/routers/reportes.ts
+++ b/apps/cartera-back/src/routers/reportes.ts
@@ -1,6 +1,7 @@
 import { Elysia } from "elysia";
 import { buildActivePortfolioRows, buildActivePortfolioWorkbook, getActivePortfolioCredits } from "../controllers/activePortfolioReport";
 import { getCobranzaDiaria, getCobranzaDiariaDetalle } from "../controllers/cobranzaDiariaReporte";
+import { MoraRecoveryFuturePeriodError } from "../controllers/moraRecuperacion";
 import { getCobradoDelMesSnapshot, getColocacionPorPeriodo, getComparativoHistorico, getCuotasPorFecha, getEsperadoDelMesMeta, getFlujoCuotasInversiones, getFlujoCuotasPorInversionista, getMontoACobrar, getMontoACobrarPeriodo, getMoraByEtapaYAsesor, getMoraCobradaPorAsesor, getMoraRecuperacionPorAsesor, getReinversionLiquidaciones } from "../controllers/reportes";
 import { db } from "../database";
 import { getVehiclesBySifcoMap } from "../services/crm.service";
@@ -387,13 +388,17 @@ export const reportesRouter = new Elysia().use(authMiddleware)
         set.status = 400;
         return { error: "Parámetro 'asesores' inválido" };
       }
-      return getMoraRecuperacionPorAsesor({
+      return await getMoraRecuperacionPorAsesor({
         mes: mesNum,
         anio: anioNum,
         asesores: asesoresIds,
         emailCobrador: email_cobrador,
       });
     } catch (error) {
+      if (error instanceof MoraRecoveryFuturePeriodError) {
+        set.status = 400;
+        return { error: error.message };
+      }
       console.error("[/reportes/mora-recuperacion-por-asesor]", error);
       set.status = 500;
       return { error: "Error interno del servidor" };

--- a/apps/cartera-back/src/routers/reportes.ts
+++ b/apps/cartera-back/src/routers/reportes.ts
@@ -1,9 +1,9 @@
 import { Elysia } from "elysia";
-import { db } from "../database";
 import { buildActivePortfolioRows, buildActivePortfolioWorkbook, getActivePortfolioCredits } from "../controllers/activePortfolioReport";
-import { getCobradoDelMesSnapshot, getColocacionPorPeriodo, getComparativoHistorico, getCuotasPorFecha, getEsperadoDelMesMeta, getFlujoCuotasInversiones, getFlujoCuotasPorInversionista, getMoraByEtapaYAsesor, getMoraCobradaPorAsesor, getMontoACobrar, getMontoACobrarPeriodo, getReinversionLiquidaciones } from "../controllers/reportes";
-import { getVehiclesBySifcoMap } from "../services/crm.service";
 import { getCobranzaDiaria, getCobranzaDiariaDetalle } from "../controllers/cobranzaDiariaReporte";
+import { getCobradoDelMesSnapshot, getColocacionPorPeriodo, getComparativoHistorico, getCuotasPorFecha, getEsperadoDelMesMeta, getFlujoCuotasInversiones, getFlujoCuotasPorInversionista, getMontoACobrar, getMontoACobrarPeriodo, getMoraByEtapaYAsesor, getMoraCobradaPorAsesor, getMoraRecuperacionPorAsesor, getReinversionLiquidaciones } from "../controllers/reportes";
+import { db } from "../database";
+import { getVehiclesBySifcoMap } from "../services/crm.service";
 import { authMiddleware } from "./midleware";
 
 const PERIODOS_VALIDOS = ["anio", "trimestre", "mes", "semana", "dia"] as const;
@@ -362,6 +362,39 @@ export const reportesRouter = new Elysia().use(authMiddleware)
       return data;
     } catch (error) {
       console.error("[/reportes/mora-cobrada-por-asesor]", error);
+      set.status = 500;
+      return { error: "Error interno del servidor" };
+    }
+  })
+
+  .get("/reportes/mora-recuperacion-por-asesor", async ({ query, set }) => {
+    try {
+      const { mes, anio, asesores, email_cobrador } = query as Record<string, string>;
+      const mesNum = Number(mes);
+      const anioNum = Number(anio);
+      if (!Number.isInteger(mesNum) || mesNum < 1 || mesNum > 12) {
+        set.status = 400;
+        return { error: "Parámetro 'mes' inválido (1-12)" };
+      }
+      if (!Number.isInteger(anioNum) || anioNum < 2000 || anioNum > 2100) {
+        set.status = 400;
+        return { error: "Parámetro 'anio' inválido" };
+      }
+      const asesoresIds = asesores
+        ? asesores.split(",").map((value) => Number(value.trim())).filter((id) => Number.isInteger(id) && id > 0)
+        : undefined;
+      if (asesores && !asesoresIds?.length) {
+        set.status = 400;
+        return { error: "Parámetro 'asesores' inválido" };
+      }
+      return getMoraRecuperacionPorAsesor({
+        mes: mesNum,
+        anio: anioNum,
+        asesores: asesoresIds,
+        emailCobrador: email_cobrador,
+      });
+    } catch (error) {
+      console.error("[/reportes/mora-recuperacion-por-asesor]", error);
       set.status = 500;
       return { error: "Error interno del servidor" };
     }

--- a/apps/crm/apps/server/src/routers/cobros.moraRecuperacion.test.ts
+++ b/apps/crm/apps/server/src/routers/cobros.moraRecuperacion.test.ts
@@ -1,0 +1,99 @@
+import { describe, expect, mock, test } from "bun:test";
+import { os } from "@orpc/server";
+
+const response = {
+	periodo: { inicio: "2026-06-06", fin: "2026-07-06" },
+	metadata: {
+		alcance: "historico" as const,
+		atribucionAsesor: "actual" as const,
+	},
+	totales: {
+		esperado: "150.00",
+		cobradoEnSnapshot: "90.00",
+		cobradoFueraSnapshot: "10.00",
+		excedenteEnSnapshot: "0.00",
+		pendiente: "60.00",
+	},
+	porAsesor: [
+		{
+			asesorId: null,
+			nombre: "Sin asignar",
+			esperado: "50.00",
+			cobradoEnSnapshot: "20.00",
+			cobradoFueraSnapshot: "0.00",
+			excedenteEnSnapshot: "0.00",
+			pendiente: "30.00",
+		},
+	],
+};
+const getMoraRecuperacionPorAsesor = mock(async () => response);
+const procedure = os.$context<Record<string, never>>();
+
+mock.module("@cci/email", () => ({ sendPlainEmail: mock() }));
+mock.module("@repo/sms", () => ({ SMSClient: class {} }));
+mock.module("../lib/orpc", () => ({
+	adminProcedure: procedure,
+	analystProcedure: procedure,
+	closedCreditsReportProcedure: procedure,
+	cobrosProcedure: procedure,
+	cobrosSupervisorProcedure: procedure,
+	crmCobrosOrInvestmentsProcedure: procedure,
+	crmOrCobrosProcedure: procedure,
+	crmProcedure: procedure,
+	efectividadPorEtapaReportProcedure: procedure,
+	juridicoProcedure: procedure,
+	metaColocacionReportProcedure: procedure,
+	protectedProcedure: procedure,
+	publicProcedure: procedure,
+	tallerOrCrmProcedure: procedure,
+	tallerProcedure: procedure,
+	tiempoCierreReportProcedure: procedure,
+	vehiclesProcedure: procedure,
+	viewOpportunityContractsProcedure: procedure,
+}));
+mock.module("../lib/simpletech", () => ({
+	sendWhatsappTemplate: mock(),
+	sendWhatsappTemplateBatch: mock(),
+}));
+mock.module("../db", () => ({
+	db: {
+		select: () => ({
+			from: () => ({
+				where: () => ({ limit: async () => [{ role: "COBROS_SUPERVISOR" }] }),
+			}),
+		}),
+	},
+}));
+mock.module("../services/cartera-back-client", () => ({
+	carteraBackClient: { getMoraRecuperacionPorAsesor },
+}));
+mock.module("../services/cartera-back-integration", () => ({
+	createPagoInCarteraBack: mock(),
+	getCreditoReferenceByNumeroSifco: mock(),
+	isCarteraBackEnabled: () => true,
+	isCarteraBackPaymentsEnabled: () => true,
+}));
+
+const { call } = await import("@orpc/server");
+const { cobrosRouter } = await import("./cobros");
+
+describe("cobrosRouter.getMoraRecuperacionPorAsesor", () => {
+	test("transmite el input validado y conserva el shape de cartera-back", async () => {
+		const input = {
+			mes: 6,
+			anio: 2026,
+			asesores: [7, 8],
+			emailCobrador: "cashin@example.com",
+		};
+
+		const output = await call(
+			cobrosRouter.getMoraRecuperacionPorAsesor,
+			input,
+			{
+				context: { headers: new Headers(), session: null },
+			},
+		);
+		expect(output).toEqual(response);
+		expect(getMoraRecuperacionPorAsesor).toHaveBeenCalledWith(input);
+	});
+});

--- a/apps/crm/apps/server/src/routers/cobros.ts
+++ b/apps/crm/apps/server/src/routers/cobros.ts
@@ -4059,6 +4059,24 @@ export const cobrosRouter = {
 			});
 		}),
 
+	getMoraRecuperacionPorAsesor: cobrosSupervisorProcedure
+		.input(
+			z.object({
+				mes: z.number(),
+				anio: z.number(),
+				asesores: z.array(z.number()).optional(),
+				emailCobrador: z.string().optional(),
+			}),
+		)
+		.handler(async ({ input }) => {
+			if (!isCarteraBackEnabled()) {
+				throw new ORPCError("BAD_REQUEST", {
+					message: "Integración con cartera-back no está habilitada",
+				});
+			}
+			return carteraBackClient.getMoraRecuperacionPorAsesor(input);
+		}),
+
 	// ========================================================================
 	// CUOTAS POR FECHA (reemplaza Pagos Esperados + Pagos No Recibidos)
 	// ========================================================================

--- a/apps/crm/apps/server/src/routers/index.ts
+++ b/apps/crm/apps/server/src/routers/index.ts
@@ -173,6 +173,7 @@ export const cobrosAppRouter = {
 	// CRM Cobros — nuevas vistas
 	getMoraByEtapaYAsesor: cobrosRouter.getMoraByEtapaYAsesor,
 	getMoraCobradaPorAsesor: cobrosRouter.getMoraCobradaPorAsesor,
+	getMoraRecuperacionPorAsesor: cobrosRouter.getMoraRecuperacionPorAsesor,
 	getCuotasPorFecha: cobrosRouter.getCuotasPorFecha,
 	getCobranzaDiaria: cobrosRouter.getCobranzaDiaria,
 	getCobranzaDiariaDetalle: cobrosRouter.getCobranzaDiariaDetalle,

--- a/apps/crm/apps/server/src/services/cartera-back-client.moraRecuperacion.test.ts
+++ b/apps/crm/apps/server/src/services/cartera-back-client.moraRecuperacion.test.ts
@@ -1,0 +1,61 @@
+import { afterEach, describe, expect, test } from "bun:test";
+import { clearCarteraTokens } from "./cartera-auth.service";
+import { CarteraBackClient } from "./cartera-back-client";
+
+const originalFetch = globalThis.fetch;
+const originalCarteraUser = process.env.CARTERA_USER;
+const originalCarteraPassword = process.env.CARTERA_PASSWORD;
+
+afterEach(() => {
+	globalThis.fetch = originalFetch;
+	clearCarteraTokens();
+	process.env.CARTERA_USER = originalCarteraUser;
+	process.env.CARTERA_PASSWORD = originalCarteraPassword;
+});
+
+describe("CarteraBackClient.getMoraRecuperacionPorAsesor", () => {
+	test("serializa el ciclo y filtros del reporte antes del límite de red", async () => {
+		const requests: string[] = [];
+		globalThis.fetch = Object.assign(
+			async (input: RequestInfo | URL) => {
+				const url = String(input);
+				requests.push(url);
+				if (url.endsWith("/auth/login")) {
+					return Response.json({
+						data: { accessToken: "test-token", refreshToken: "test-refresh" },
+					});
+				}
+				return Response.json({
+					periodo: { inicio: "2026-06-06", fin: "2026-07-06" },
+					metadata: { alcance: "historico", atribucionAsesor: "actual" },
+					totales: {
+						esperado: "0.00",
+						cobradoEnSnapshot: "0.00",
+						cobradoFueraSnapshot: "0.00",
+						excedenteEnSnapshot: "0.00",
+						pendiente: "0.00",
+					},
+					porAsesor: [],
+				});
+			},
+			{ preconnect: originalFetch.preconnect },
+		);
+		process.env.CARTERA_USER = "test@example.com";
+		process.env.CARTERA_PASSWORD = "secret";
+
+		await new CarteraBackClient({
+			baseUrl: "http://cartera.test",
+			retryAttempts: 0,
+		}).getMoraRecuperacionPorAsesor({
+			mes: 6,
+			anio: 2026,
+			asesores: [7, 8],
+			emailCobrador: "cashin@example.com",
+		});
+
+		expect(requests).toEqual([
+			"http://localhost:7000/auth/login",
+			"http://cartera.test/reportes/mora-recuperacion-por-asesor?mes=6&anio=2026&asesores=7%2C8&email_cobrador=cashin%40example.com",
+		]);
+	});
+});

--- a/apps/crm/apps/server/src/services/cartera-back-client.ts
+++ b/apps/crm/apps/server/src/services/cartera-back-client.ts
@@ -480,6 +480,27 @@ export type MoraCobradaPorAsesorResponse = {
 	totalCobrado: string;
 };
 
+export type MoraRecuperacionPorAsesorResponse = {
+	periodo: { inicio: string; fin: string };
+	metadata: {
+		alcance: "live" | "historico";
+		atribucionAsesor: "actual";
+	};
+	totales: MoraRecoveryMetric;
+	porAsesor: (MoraRecoveryMetric & {
+		asesorId: number | null;
+		nombre: string;
+	})[];
+};
+
+export type MoraRecoveryMetric = {
+	esperado: string;
+	cobradoEnSnapshot: string;
+	cobradoFueraSnapshot: string;
+	excedenteEnSnapshot: string;
+	pendiente: string;
+};
+
 // ============================================================================
 // HTTP CLIENT
 // ============================================================================
@@ -1783,6 +1804,27 @@ export class CarteraBackClient {
 		// "Actualizar" podría devolver un hit stale tras registrar/ajustar un pago.
 		return this.request<MoraCobradaPorAsesorResponse>(
 			`/reportes/mora-cobrada-por-asesor?${queryParams}`,
+			{ method: "GET" },
+			false,
+		);
+	}
+
+	async getMoraRecuperacionPorAsesor(params: {
+		mes: number;
+		anio: number;
+		asesores?: number[];
+		emailCobrador?: string;
+	}): Promise<MoraRecuperacionPorAsesorResponse> {
+		const queryParams = new URLSearchParams({
+			mes: String(params.mes),
+			anio: String(params.anio),
+		});
+		if (params.asesores?.length)
+			queryParams.set("asesores", params.asesores.join(","));
+		if (params.emailCobrador)
+			queryParams.set("email_cobrador", params.emailCobrador);
+		return this.request<MoraRecuperacionPorAsesorResponse>(
+			`/reportes/mora-recuperacion-por-asesor?${queryParams}`,
 			{ method: "GET" },
 			false,
 		);

--- a/apps/crm/apps/web/src/routes/cobros/-mora-display.test.ts
+++ b/apps/crm/apps/web/src/routes/cobros/-mora-display.test.ts
@@ -1,5 +1,26 @@
 import { describe, expect, test } from "bun:test";
-import { buildMoraDisplayRows } from "./-mora-display";
+import { buildMoraDisplayRows, getMoraSnapshotDate } from "./-mora-display";
+
+describe("getMoraSnapshotDate", () => {
+	test("mantiene Hoy en vivo y usa el cierre del día 5 para meses iniciados", () => {
+		expect(getMoraSnapshotDate("hoy", "2026-06", "2026-06-06")).toBeUndefined();
+		expect(getMoraSnapshotDate("mes", "2026-06", "2026-06-06")).toBe(
+			"2026-06-05",
+		);
+	});
+
+	test("conserva el provisional antes del día 5 y los límites de año", () => {
+		expect(getMoraSnapshotDate("mes", "2026-06", "2026-06-03")).toBe(
+			"2026-06-03",
+		);
+		expect(getMoraSnapshotDate("mes", "2025-12", "2026-01-06")).toBe(
+			"2025-12-05",
+		);
+		expect(getMoraSnapshotDate("mes", "2026-01", "2026-02-06")).toBe(
+			"2026-01-05",
+		);
+	});
+});
 
 describe("buildMoraDisplayRows", () => {
 	test("conserva Sin asignar y mezcla los buckets completos por asesor", () => {

--- a/apps/crm/apps/web/src/routes/cobros/-mora-display.test.ts
+++ b/apps/crm/apps/web/src/routes/cobros/-mora-display.test.ts
@@ -52,4 +52,37 @@ describe("buildMoraDisplayRows", () => {
 			}),
 		]);
 	});
+
+	test("ignora recuperación cacheada en modo hoy", () => {
+		const rows = buildMoraDisplayRows(
+			[
+				{
+					asesorId: 7,
+					nombre: "Ana",
+					totalEnMora: { cantidad: 1, sumaMora: "100.00" },
+				},
+			],
+			[
+				{
+					asesorId: 7,
+					nombre: "Ana",
+					esperado: "999.00",
+					cobradoEnSnapshot: "500.00",
+					cobradoFueraSnapshot: "0.00",
+					excedenteEnSnapshot: "0.00",
+					pendiente: "499.00",
+				},
+			],
+			false,
+		);
+
+		expect(rows).toEqual([
+			expect.objectContaining({
+				asesorId: 7,
+				esperado: "100.00",
+				cobradoEnSnapshot: "0",
+				pendiente: "100.00",
+			}),
+		]);
+	});
 });

--- a/apps/crm/apps/web/src/routes/cobros/-mora-display.test.ts
+++ b/apps/crm/apps/web/src/routes/cobros/-mora-display.test.ts
@@ -1,0 +1,55 @@
+import { describe, expect, test } from "bun:test";
+import { buildMoraDisplayRows } from "./-mora-display";
+
+describe("buildMoraDisplayRows", () => {
+	test("conserva Sin asignar y mezcla los buckets completos por asesor", () => {
+		const rows = buildMoraDisplayRows(
+			[
+				{
+					asesorId: 7,
+					nombre: "Ana",
+					totalEnMora: { cantidad: 2, sumaMora: "100.00" },
+					mora_30: { cantidad: 1, sumaCapital: "10.00", sumaMora: "20.00" },
+					mora_60: { cantidad: 1, sumaCapital: "30.00", sumaMora: "40.00" },
+					mora_90: { cantidad: 0, sumaCapital: "0.00", sumaMora: "0.00" },
+					mora_120_plus: { cantidad: 0, sumaCapital: "0.00", sumaMora: "0.00" },
+				},
+			],
+			[
+				{
+					asesorId: 7,
+					nombre: "Ana",
+					esperado: "100.00",
+					cobradoEnSnapshot: "70.00",
+					cobradoFueraSnapshot: "5.00",
+					excedenteEnSnapshot: "0.00",
+					pendiente: "30.00",
+				},
+				{
+					asesorId: null,
+					nombre: "Sin asignar",
+					esperado: "50.00",
+					cobradoEnSnapshot: "20.00",
+					cobradoFueraSnapshot: "0.00",
+					excedenteEnSnapshot: "0.00",
+					pendiente: "30.00",
+				},
+			],
+		);
+
+		expect(rows).toEqual([
+			expect.objectContaining({
+				asesorId: 7,
+				mora_30: { cantidad: 1, sumaCapital: "10.00", sumaMora: "20.00" },
+				mora_60: { cantidad: 1, sumaCapital: "30.00", sumaMora: "40.00" },
+				pendiente: "30.00",
+			}),
+			expect.objectContaining({
+				asesorId: null,
+				nombre: "Sin asignar",
+				esperado: "50.00",
+				pendiente: "30.00",
+			}),
+		]);
+	});
+});

--- a/apps/crm/apps/web/src/routes/cobros/-mora-display.ts
+++ b/apps/crm/apps/web/src/routes/cobros/-mora-display.ts
@@ -1,0 +1,41 @@
+export type MoraBucket = {
+	cantidad: number;
+	sumaCapital: string;
+	sumaMora: string;
+};
+
+type MoraSnapshotAsesor = {
+	asesorId: number;
+	nombre: string;
+	totalEnMora: { cantidad: number; sumaMora: string };
+} & Partial<
+	Record<"mora_30" | "mora_60" | "mora_90" | "mora_120_plus", MoraBucket>
+>;
+
+type MoraRecoveryAsesor = {
+	asesorId: number | null;
+	nombre: string;
+	esperado: string;
+	cobradoEnSnapshot: string;
+	cobradoFueraSnapshot: string;
+	excedenteEnSnapshot: string;
+	pendiente: string;
+};
+
+export type MoraDisplayAsesor = MoraRecoveryAsesor &
+	Partial<Omit<MoraSnapshotAsesor, "asesorId" | "nombre">>;
+
+export function buildMoraDisplayRows(
+	porAsesor: MoraSnapshotAsesor[],
+	recuperacion: MoraRecoveryAsesor[],
+): MoraDisplayAsesor[] {
+	const snapshotPorAsesor = new Map<number, MoraSnapshotAsesor>(
+		porAsesor.map((asesor) => [asesor.asesorId, asesor]),
+	);
+	return recuperacion.map((asesor) => ({
+		...(asesor.asesorId === null
+			? undefined
+			: snapshotPorAsesor.get(asesor.asesorId)),
+		...asesor,
+	}));
+}

--- a/apps/crm/apps/web/src/routes/cobros/-mora-display.ts
+++ b/apps/crm/apps/web/src/routes/cobros/-mora-display.ts
@@ -25,6 +25,16 @@ type MoraRecoveryAsesor = {
 export type MoraDisplayAsesor = MoraRecoveryAsesor &
 	Partial<Omit<MoraSnapshotAsesor, "asesorId" | "nombre">>;
 
+export function getMoraSnapshotDate(
+	modo: "hoy" | "mes",
+	mesAnio: string,
+	hoy: string,
+) {
+	if (modo === "hoy") return undefined;
+	const apertura = `${mesAnio}-05`;
+	return apertura > hoy ? hoy : apertura;
+}
+
 export function buildMoraDisplayRows(
 	porAsesor: MoraSnapshotAsesor[],
 	recuperacion: MoraRecoveryAsesor[] | undefined,

--- a/apps/crm/apps/web/src/routes/cobros/-mora-display.ts
+++ b/apps/crm/apps/web/src/routes/cobros/-mora-display.ts
@@ -27,8 +27,19 @@ export type MoraDisplayAsesor = MoraRecoveryAsesor &
 
 export function buildMoraDisplayRows(
 	porAsesor: MoraSnapshotAsesor[],
-	recuperacion: MoraRecoveryAsesor[],
+	recuperacion: MoraRecoveryAsesor[] | undefined,
+	verCobrado = true,
 ): MoraDisplayAsesor[] {
+	if (!verCobrado || !recuperacion) {
+		return porAsesor.map((asesor) => ({
+			...asesor,
+			esperado: asesor.totalEnMora.sumaMora,
+			cobradoEnSnapshot: "0",
+			cobradoFueraSnapshot: "0",
+			excedenteEnSnapshot: "0",
+			pendiente: asesor.totalEnMora.sumaMora,
+		}));
+	}
 	const snapshotPorAsesor = new Map<number, MoraSnapshotAsesor>(
 		porAsesor.map((asesor) => [asesor.asesorId, asesor]),
 	);

--- a/apps/crm/apps/web/src/routes/cobros/reportes.tsx
+++ b/apps/crm/apps/web/src/routes/cobros/reportes.tsx
@@ -36,6 +36,11 @@ import { usePersistedState } from "@/hooks/usePersistedState";
 import { authClient } from "@/lib/auth-client";
 import { PERMISSIONS } from "@/lib/roles";
 import { orpc } from "@/utils/orpc";
+import {
+	buildMoraDisplayRows,
+	type MoraBucket,
+	type MoraDisplayAsesor,
+} from "./-mora-display";
 
 export const Route = createFileRoute("/cobros/reportes")({
 	component: RouteComponent,
@@ -80,6 +85,12 @@ const ETAPAS = [
 		color: "bg-red-300 text-red-950",
 	},
 ];
+
+type MoraSnapshotAsesor = {
+	asesorId: number;
+	nombre: string;
+	totalEnMora: { cantidad: number; sumaMora: string };
+} & Partial<Record<(typeof ETAPAS)[number]["key"], MoraBucket>>;
 
 function todayGTISO() {
 	return new Date().toLocaleDateString("sv-SE", {
@@ -155,8 +166,8 @@ function TabMora({
 	});
 
 	// Totales con / sin Gerencia (cliente, sobre porAsesor).
-	// eslint-disable-next-line @typescript-eslint/no-explicit-any
-	const porAsesor: any[] = (data as any)?.porAsesor ?? [];
+	const porAsesor = ((data as { porAsesor?: MoraSnapshotAsesor[] } | undefined)
+		?.porAsesor ?? []) as MoraSnapshotAsesor[];
 	const totalConGerencia = porAsesor.reduce(
 		(s, a) => s + Number(a.totalEnMora?.sumaMora ?? 0),
 		0,
@@ -179,11 +190,11 @@ function TabMora({
 	// eslint-disable-next-line @typescript-eslint/no-explicit-any
 	const alcance = (data as any)?.alcance as "live" | "historico" | undefined;
 
-	// Cobrado (mora cobrada en el período del mes). Solo aplica en modo "mes".
+	// Recuperación de mora para el mismo ciclo [día 6, día 6 siguiente).
 	const anioNum = Number(mesAnio.slice(0, 4));
 	const mesNum = Number(mesAnio.slice(5, 7));
-	const { data: cobradoData, refetch: refetchCobrado } = useQuery({
-		...orpc.getMoraCobradaPorAsesor.queryOptions({
+	const { data: recuperacion, refetch: refetchRecuperacion } = useQuery({
+		...orpc.getMoraRecuperacionPorAsesor.queryOptions({
 			input: {
 				mes: mesNum,
 				anio: anioNum,
@@ -193,32 +204,24 @@ function TabMora({
 		}),
 		enabled: !!session && modo === "mes",
 	});
-	const cobradoMap = useMemo(() => {
-		const m = new Map<number, { cobrado: number; nombre: string }>();
-		// eslint-disable-next-line @typescript-eslint/no-explicit-any
-		for (const a of ((cobradoData as any)?.porAsesor ?? []) as any[]) {
-			m.set(a.asesorId, { cobrado: Number(a.cobrado), nombre: a.nombre });
-		}
-		return m;
-	}, [cobradoData]);
-	// eslint-disable-next-line @typescript-eslint/no-explicit-any
-	const totalCobrado = Number((cobradoData as any)?.totalCobrado ?? 0);
 	const verCobrado = modo === "mes";
+	const esperadoSnapshot = Number(
+		recuperacion?.totales.esperado ?? totalConGerencia,
+	);
 
-	// Filas del desglose = unión de asesores con mora esperada y/o cobrada. El
-	// total cobrado incluye pagos sobre créditos ya saldados / fuera del snapshot
-	// de mora activa, así que sin la unión las filas no sumarían el total.
-	const filasAsesor = useMemo(() => {
-		// eslint-disable-next-line @typescript-eslint/no-explicit-any
-		const map = new Map<number, any>();
-		for (const a of porAsesor) map.set(a.asesorId, a);
-		if (verCobrado) {
-			for (const [id, c] of cobradoMap) {
-				if (!map.has(id)) map.set(id, { asesorId: id, nombre: c.nombre });
-			}
+	const filasAsesor = useMemo<MoraDisplayAsesor[]>(() => {
+		if (!recuperacion) {
+			return porAsesor.map((asesor) => ({
+				...asesor,
+				esperado: asesor.totalEnMora.sumaMora,
+				cobradoEnSnapshot: "0",
+				cobradoFueraSnapshot: "0",
+				excedenteEnSnapshot: "0",
+				pendiente: asesor.totalEnMora.sumaMora,
+			}));
 		}
-		return [...map.values()];
-	}, [porAsesor, cobradoMap, verCobrado]);
+		return buildMoraDisplayRows(porAsesor, recuperacion.porAsesor);
+	}, [porAsesor, recuperacion]);
 
 	const ultimaAct = dataUpdatedAt ? fmtTime(new Date(dataUpdatedAt)) : null;
 
@@ -240,7 +243,7 @@ function TabMora({
 						size="sm"
 						onClick={() => {
 							refetch();
-							if (verCobrado) refetchCobrado();
+							if (verCobrado) refetchRecuperacion();
 						}}
 						disabled={isFetching}
 					>
@@ -332,6 +335,13 @@ function TabMora({
 				</div>
 			)}
 
+			{recuperacion?.metadata.alcance === "historico" && (
+				<div className="rounded-lg border border-blue-200 bg-blue-50 px-4 py-2 text-blue-800 text-sm">
+					La mora corresponde al corte histórico; el asesor mostrado es su
+					asignación actual.
+				</div>
+			)}
+
 			{isLoading ? (
 				<div className="grid grid-cols-2 gap-4 md:grid-cols-4">
 					{ETAPAS.map((e) => (
@@ -380,7 +390,7 @@ function TabMora({
 				</div>
 			)}
 
-			{(porAsesor.length > 0 || (verCobrado && totalCobrado > 0)) && (
+			{(porAsesor.length > 0 || (verCobrado && recuperacion)) && (
 				<div
 					className={`grid grid-cols-1 gap-4 md:grid-cols-2 ${verCobrado ? "lg:grid-cols-3" : ""}`}
 				>
@@ -388,10 +398,12 @@ function TabMora({
 						<Card className="border-red-200 bg-red-50">
 							<CardContent className="pt-4">
 								<p className="font-semibold text-red-700 text-sm">
-									Total en Mora (con Gerencia)
+									{verCobrado
+										? "Mora esperada del snapshot"
+										: "Total en Mora (con Gerencia)"}
 								</p>
 								<p className="font-bold text-3xl text-red-800">
-									{fmtQ(totalConGerencia)}
+									{fmtQ(esperadoSnapshot)}
 								</p>
 								<p className="text-muted-foreground text-xs">
 									{credConGerencia} créditos
@@ -414,19 +426,18 @@ function TabMora({
 							</CardContent>
 						</Card>
 					)}
-					{verCobrado && (
+					{verCobrado && recuperacion && (
 						<Card className="border-green-200 bg-green-50">
 							<CardContent className="pt-4">
 								<p className="font-semibold text-green-700 text-sm">
-									Mora Cobrada (en el mes)
+									Cobrado en créditos del snapshot
 								</p>
 								<p className="font-bold text-3xl text-green-800">
-									{fmtQ(totalCobrado)}
+									{fmtQ(recuperacion.totales.cobradoEnSnapshot)}
 								</p>
 								<p className="text-muted-foreground text-xs">
-									{totalConGerencia > 0
-										? `${((totalCobrado / totalConGerencia) * 100).toFixed(1)}% de lo esperado`
-										: "—"}
+									Pendiente: {fmtQ(recuperacion.totales.pendiente)} · Excedente:{" "}
+									{fmtQ(recuperacion.totales.excedenteEnSnapshot)}
 								</p>
 							</CardContent>
 						</Card>
@@ -463,10 +474,13 @@ function TabMora({
 									{verCobrado && (
 										<>
 											<th className="px-4 py-3 text-right font-semibold">
-												Cobrado
+												Cobrado snapshot
 											</th>
 											<th className="px-4 py-3 text-right font-semibold">
-												% Cobrado
+												Fuera snapshot
+											</th>
+											<th className="px-4 py-3 text-right font-semibold">
+												Excedente
 											</th>
 											<th className="px-4 py-3 text-right font-semibold">
 												Pendiente
@@ -476,8 +490,7 @@ function TabMora({
 								</tr>
 							</thead>
 							<tbody>
-								{/* eslint-disable-next-line @typescript-eslint/no-explicit-any */}
-								{filasAsesor.map((asesor: any) => (
+								{filasAsesor.map((asesor) => (
 									<tr
 										key={asesor.asesorId}
 										className="border-t hover:bg-muted/30"
@@ -487,7 +500,7 @@ function TabMora({
 											const bucket = asesor[etapa.key];
 											return (
 												<td key={etapa.key} className="px-4 py-3 text-right">
-													{bucket?.cantidad > 0 ? (
+													{bucket && bucket.cantidad > 0 ? (
 														<div>
 															<div className="font-medium">
 																{fmtQ(bucket.sumaMora)}
@@ -504,7 +517,11 @@ function TabMora({
 										})}
 										<td className="px-4 py-3 text-right">
 											<div className="font-semibold text-red-700">
-												{fmtQ(asesor.totalEnMora?.sumaMora ?? "0")}
+												{fmtQ(
+													verCobrado
+														? (asesor.esperado ?? "0")
+														: (asesor.totalEnMora?.sumaMora ?? "0"),
+												)}
 											</div>
 											<div className="text-muted-foreground text-xs">
 												{asesor.totalEnMora?.cantidad ?? 0} créd.
@@ -531,14 +548,12 @@ function TabMora({
 										</td>
 										{verCobrado &&
 											(() => {
-												const esperado = Number.parseFloat(
-													asesor.totalEnMora?.sumaMora ?? "0",
+												const cobrado = Number(asesor.cobradoEnSnapshot ?? 0);
+												const fuera = Number(asesor.cobradoFueraSnapshot ?? 0);
+												const excedente = Number(
+													asesor.excedenteEnSnapshot ?? 0,
 												);
-												const cobrado =
-													cobradoMap.get(asesor.asesorId)?.cobrado ?? 0;
-												const pct =
-													esperado > 0 ? (cobrado / esperado) * 100 : 0;
-												const pendiente = Math.max(0, esperado - cobrado);
+												const pendiente = Number(asesor.pendiente ?? 0);
 												return (
 													<>
 														<td className="px-4 py-3 text-right font-medium text-green-700">
@@ -549,7 +564,10 @@ function TabMora({
 															)}
 														</td>
 														<td className="px-4 py-3 text-right text-muted-foreground">
-															{esperado > 0 ? `${pct.toFixed(1)}%` : "—"}
+															{fuera > 0 ? fmtQ(fuera) : "—"}
+														</td>
+														<td className="px-4 py-3 text-right text-amber-700">
+															{excedente > 0 ? fmtQ(excedente) : "—"}
 														</td>
 														<td className="px-4 py-3 text-right">
 															{fmtQ(pendiente)}
@@ -581,7 +599,10 @@ function TabMora({
 											{/* eslint-disable-next-line @typescript-eslint/no-explicit-any */}
 											<div>
 												{fmtQ(
-													(data as any).totales.totalEnMora?.sumaMora ?? "0",
+													verCobrado
+														? (recuperacion?.totales.esperado ?? "0")
+														: ((data as any).totales.totalEnMora?.sumaMora ??
+																"0"),
 												)}
 											</div>
 											{/* eslint-disable-next-line @typescript-eslint/no-explicit-any */}
@@ -591,24 +612,20 @@ function TabMora({
 										</td>
 										{verCobrado &&
 											(() => {
-												// eslint-disable-next-line @typescript-eslint/no-explicit-any
-												const esperadoTot = Number.parseFloat(
-													(data as any).totales.totalEnMora?.sumaMora ?? "0",
-												);
-												const pctTot =
-													esperadoTot > 0
-														? (totalCobrado / esperadoTot) * 100
-														: 0;
+												const totales = recuperacion?.totales;
 												return (
 													<>
 														<td className="px-4 py-3 text-right text-green-700">
-															{fmtQ(totalCobrado)}
+															{fmtQ(totales?.cobradoEnSnapshot ?? "0")}
 														</td>
 														<td className="px-4 py-3 text-right font-normal text-muted-foreground">
-															{esperadoTot > 0 ? `${pctTot.toFixed(1)}%` : "—"}
+															{fmtQ(totales?.cobradoFueraSnapshot ?? "0")}
+														</td>
+														<td className="px-4 py-3 text-right font-normal text-amber-700">
+															{fmtQ(totales?.excedenteEnSnapshot ?? "0")}
 														</td>
 														<td className="px-4 py-3 text-right">
-															{fmtQ(Math.max(0, esperadoTot - totalCobrado))}
+															{fmtQ(totales?.pendiente ?? "0")}
 														</td>
 													</>
 												);

--- a/apps/crm/apps/web/src/routes/cobros/reportes.tsx
+++ b/apps/crm/apps/web/src/routes/cobros/reportes.tsx
@@ -38,6 +38,7 @@ import { PERMISSIONS } from "@/lib/roles";
 import { orpc } from "@/utils/orpc";
 import {
 	buildMoraDisplayRows,
+	getMoraSnapshotDate,
 	type MoraBucket,
 	type MoraDisplayAsesor,
 } from "./-mora-display";
@@ -135,13 +136,8 @@ function TabMora({
 		setMesAnio(next);
 	};
 
-	// Fecha snapshot = día 6 del mes elegido, clamp a hoy (nunca futura).
 	const hoy = todayGTISO();
-	const fechaSnapshot = useMemo(() => {
-		if (modo === "hoy") return undefined;
-		const dia6 = `${mesAnio}-06`;
-		return dia6 > hoy ? hoy : dia6;
-	}, [modo, mesAnio, hoy]);
+	const fechaSnapshot = getMoraSnapshotDate(modo, mesAnio, hoy);
 
 	const { data: asesoresData } = useQuery({
 		...orpc.getAsesores.queryOptions({ input: { perPage: 100 } }),

--- a/apps/crm/apps/web/src/routes/cobros/reportes.tsx
+++ b/apps/crm/apps/web/src/routes/cobros/reportes.tsx
@@ -206,22 +206,15 @@ function TabMora({
 	});
 	const verCobrado = modo === "mes";
 	const esperadoSnapshot = Number(
-		recuperacion?.totales.esperado ?? totalConGerencia,
+		verCobrado
+			? (recuperacion?.totales.esperado ?? totalConGerencia)
+			: totalConGerencia,
 	);
 
-	const filasAsesor = useMemo<MoraDisplayAsesor[]>(() => {
-		if (!recuperacion) {
-			return porAsesor.map((asesor) => ({
-				...asesor,
-				esperado: asesor.totalEnMora.sumaMora,
-				cobradoEnSnapshot: "0",
-				cobradoFueraSnapshot: "0",
-				excedenteEnSnapshot: "0",
-				pendiente: asesor.totalEnMora.sumaMora,
-			}));
-		}
-		return buildMoraDisplayRows(porAsesor, recuperacion.porAsesor);
-	}, [porAsesor, recuperacion]);
+	const filasAsesor = useMemo<MoraDisplayAsesor[]>(
+		() => buildMoraDisplayRows(porAsesor, recuperacion?.porAsesor, verCobrado),
+		[porAsesor, recuperacion, verCobrado],
+	);
 
 	const ultimaAct = dataUpdatedAt ? fmtTime(new Date(dataUpdatedAt)) : null;
 
@@ -335,7 +328,7 @@ function TabMora({
 				</div>
 			)}
 
-			{recuperacion?.metadata.alcance === "historico" && (
+			{verCobrado && recuperacion?.metadata.alcance === "historico" && (
 				<div className="rounded-lg border border-blue-200 bg-blue-50 px-4 py-2 text-blue-800 text-sm">
 					La mora corresponde al corte histórico; el asesor mostrado es su
 					asignación actual.


### PR DESCRIPTION
## Stack

**1 de 3** — base del stack.

- Base: `develop`
- Sucesor: `feat/cartera-current-participation-split`
- Orden de merge: A → B → C

Los PRs siguientes incluyen los commits anteriores por diseño y muestran solo su delta contra la rama predecesora.

## Resumen

- Reconcilia el reporte de mora esperado con la recuperación realmente observada para el mismo ciclo.
- Separa cobrado dentro del snapshot, cobrado fuera del snapshot, excedente y pendiente.
- Conserva el universo histórico, usa asesor actual y representa créditos sin asignar de forma tipada.
- Integra contrato cartera-back → CRM server → UI, sin incluir el hallazgo `paymentFalse=NULL` que quedó fuera de alcance.

## Validación

- cartera-back: **4/4** pruebas focales.
- CRM cliente/router/UI: **3/3** pruebas focales.
- TypeScript: **0 errores en archivos tocados**; el gate global conserva errores heredados ajenos.
- Biome 2.3.14 focal: **0 errores**.
- `git diff --check`: PASS.
- Revisión independiente fail-closed: PASS.

## Límites

- Sin migraciones, DB de producción, deploy ni cambios de datos.
- No habilita auto-merge.
