### PR TITLE
feat(cartera): split Inv./CUBE por participación actual

### DIFF
--- a/apps/cartera-back/src/controllers/monto-a-cobrar-participacion.test.ts
+++ b/apps/cartera-back/src/controllers/monto-a-cobrar-participacion.test.ts
@@ -1,0 +1,73 @@
+import { describe, expect, test } from "bun:test";
+import {
+	agregarParticipacionExterna,
+	splitMontoSegunParticipacionActual,
+} from "./monto-a-cobrar-participacion";
+
+describe("splitMontoSegunParticipacionActual", () => {
+	test("asigna 0% externo completamente a CUBE", () => {
+		expect(splitMontoSegunParticipacionActual(100, 12, 0)).toEqual({
+			valido: true,
+			capitalInv: 0,
+			capitalCube: 100,
+			interesIvaInv: 0,
+			interesIvaCube: 12,
+		});
+	});
+
+	test("asigna 100% externo completamente a Inv.", () => {
+		expect(splitMontoSegunParticipacionActual(100, 12, 1)).toEqual({
+			valido: true,
+			capitalInv: 100,
+			capitalCube: 0,
+			interesIvaInv: 12,
+			interesIvaCube: 0,
+		});
+	});
+
+	test("redondea Inv. por crédito y conserva CUBE por diferencia", () => {
+		const split = splitMontoSegunParticipacionActual(100.01, 10.01, 0.3333);
+
+		expect(split).toEqual({
+			valido: true,
+			capitalInv: 33.33,
+			capitalCube: 66.68,
+			interesIvaInv: 3.34,
+			interesIvaCube: 6.67,
+		});
+		if (split.valido) {
+			expect(split.capitalInv + split.capitalCube).toBe(100.01);
+			expect(split.interesIvaInv + split.interesIvaCube).toBe(10.01);
+		}
+	});
+
+	test("calcula CUBE como diferencia exacta sin redondearlo de nuevo", () => {
+		const split = splitMontoSegunParticipacionActual(100.019, 10.019, 0.5);
+
+		expect(split).toMatchObject({ valido: true, capitalInv: 50.01, interesIvaInv: 5.01 });
+		if (split.valido) {
+			expect(split.capitalCube).toBeCloseTo(50.009, 10);
+			expect(split.interesIvaCube).toBeCloseTo(5.009, 10);
+		}
+	});
+
+	test("excluye del split una participación agregada inválida", () => {
+		expect(splitMontoSegunParticipacionActual(100, 12, 1.01)).toEqual({
+			valido: false,
+			capitalInv: 0,
+			capitalCube: 0,
+			interesIvaInv: 0,
+			interesIvaCube: 0,
+		});
+	});
+});
+
+test("agrega múltiples participaciones externas sin duplicar la base", () => {
+	expect(agregarParticipacionExterna([25, 25, 50])).toBe(1);
+	const split = splitMontoSegunParticipacionActual(
+		200,
+		20,
+		agregarParticipacionExterna([25, 25]),
+	);
+	expect(split).toMatchObject({ capitalInv: 100, capitalCube: 100 });
+});

--- a/apps/cartera-back/src/controllers/monto-a-cobrar-participacion.ts
+++ b/apps/cartera-back/src/controllers/monto-a-cobrar-participacion.ts
@@ -1,0 +1,52 @@
+type SplitValido = {
+	valido: true;
+	capitalInv: number;
+	capitalCube: number;
+	interesIvaInv: number;
+	interesIvaCube: number;
+};
+
+type SplitInvalido = {
+	valido: false;
+	capitalInv: 0;
+	capitalCube: 0;
+	interesIvaInv: 0;
+	interesIvaCube: 0;
+};
+
+const redondearMoneda = (monto: number) => Number(monto.toFixed(2));
+
+export function agregarParticipacionExterna(porcentajes: number[]): number {
+	return porcentajes.reduce((total, porcentaje) => total + porcentaje / 100, 0);
+}
+
+export function splitMontoSegunParticipacionActual(
+	capital: number,
+	interesIva: number,
+	participacionExternaActual: number,
+): SplitValido | SplitInvalido {
+	if (
+		participacionExternaActual < 0 ||
+		participacionExternaActual > 1
+	) {
+		return {
+			valido: false,
+			capitalInv: 0,
+			capitalCube: 0,
+			interesIvaInv: 0,
+			interesIvaCube: 0,
+		};
+	}
+
+	const capitalInv = redondearMoneda(capital * participacionExternaActual);
+	const interesIvaInv = redondearMoneda(
+		interesIva * participacionExternaActual,
+	);
+	return {
+		valido: true,
+		capitalInv,
+		capitalCube: capital - capitalInv,
+		interesIvaInv,
+		interesIvaCube: interesIva - interesIvaInv,
+	};
+}

--- a/apps/cartera-back/src/controllers/reportes.participacion.test.ts
+++ b/apps/cartera-back/src/controllers/reportes.participacion.test.ts
@@ -1,0 +1,11 @@
+import { expect, test } from "bun:test";
+
+test("la CTE de participación usa el porcentaje autoritativo de créditos_inversionistas", async () => {
+	const source = await Bun.file(new URL("./reportes.ts", import.meta.url)).text();
+
+	expect(source).toContain(
+		"ci.porcentaje_participacion_inversionista::numeric / 100",
+	);
+	expect(source).not.toContain("ci.porcentaje::numeric / 100");
+	expect(source).toContain("FILTER (WHERE i.permite_distribucion = false)");
+});

--- a/apps/cartera-back/src/controllers/reportes.ts
+++ b/apps/cartera-back/src/controllers/reportes.ts
@@ -132,6 +132,14 @@ export async function getMontoACobrarPeriodo({
         AND pc.fecha_vencimiento::date >= ${fechaInicio}::date
         AND pc.fecha_vencimiento::date <= ${fechaFin}::date
     ),
+    participacion_externa_actual AS (
+      SELECT
+        ci.credito_id,
+        COALESCE(SUM(ci.porcentaje_participacion_inversionista::numeric / 100) FILTER (WHERE i.permite_distribucion = false), 0) AS participacion_externa_actual
+      FROM cartera.creditos_inversionistas ci
+      INNER JOIN cartera.inversionistas i ON i.inversionista_id = ci.inversionista_id
+      GROUP BY ci.credito_id
+    ),
     per_credito AS (
       SELECT
         p.fecha_venc::date                                             AS bucket,
@@ -142,6 +150,7 @@ export async function getMontoACobrarPeriodo({
         COALESCE(c.seguro_10_cuotas::numeric, 0)                       AS seguro,
         COALESCE(c.gps::numeric, 0)                                    AS gps,
         COALESCE(c.membresias_pago::numeric, 0)                        AS mem,
+        COALESCE(MAX(pea.participacion_externa_actual), 0)             AS participacion_externa_actual,
         COALESCE(cap_anterior.total_restante, c.capital::numeric)       AS cap_ant,
         MAX(mora_real.cuotas_atrasadas)                                 AS cuotas_atrasadas,
         CASE WHEN MAX(mora_real.cuotas_atrasadas) > 0
@@ -151,6 +160,7 @@ export async function getMontoACobrarPeriodo({
       INNER JOIN cartera.creditos c ON p.credito_id = c.credito_id
       INNER JOIN cartera.usuarios u ON c.usuario_id = u.usuario_id
       INNER JOIN cartera.asesores a ON c.asesor_id = a.asesor_id
+      LEFT JOIN participacion_externa_actual pea ON pea.credito_id = c.credito_id
       LEFT JOIN LATERAL (
         SELECT COALESCE(mh.monto_nuevo, 0) AS monto_mora
         FROM cartera.moras_historial mh
@@ -300,9 +310,24 @@ export async function getMontoACobrarPeriodo({
         MAX(acum_seguro)                        AS acum_seguro,
         MAX(acum_gps)                           AS acum_gps,
         MAX(acum_mem)                           AS acum_mem,
+        MAX(participacion_externa_actual)       AS participacion_externa_actual,
         COUNT(*)::int                           AS cuotas_count
       FROM calc_acum
       GROUP BY DATE_TRUNC(${pg}, bucket::timestamp), credito_id
+    ),
+    split_participacion_actual AS (
+      SELECT
+        pbc.*,
+        (participacion_externa_actual < 0 OR participacion_externa_actual > 1) AS participacion_invalida,
+        ROUND((CASE WHEN NOT excluido_factura THEN exp_capital ELSE 0 END) * participacion_externa_actual, 2) AS capital_inv_participacion_actual,
+        (CASE WHEN NOT excluido_factura THEN exp_capital ELSE 0 END) - ROUND((CASE WHEN NOT excluido_factura THEN exp_capital ELSE 0 END) * participacion_externa_actual, 2) AS capital_cube_participacion_actual,
+        ROUND((CASE WHEN NOT excluido_factura THEN interes + iva ELSE 0 END) * participacion_externa_actual, 2) AS interes_iva_inv_participacion_actual,
+        (CASE WHEN NOT excluido_factura THEN interes + iva ELSE 0 END) - ROUND((CASE WHEN NOT excluido_factura THEN interes + iva ELSE 0 END) * participacion_externa_actual, 2) AS interes_iva_cube_participacion_actual,
+        ROUND((CASE WHEN excluido_mora THEN 0 WHEN cuotas_atrasadas > 0 THEN LEAST(acum_capital, cap_ant) ELSE exp_capital END) * participacion_externa_actual, 2) AS acum_capital_inv_participacion_actual,
+        (CASE WHEN excluido_mora THEN 0 WHEN cuotas_atrasadas > 0 THEN LEAST(acum_capital, cap_ant) ELSE exp_capital END) - ROUND((CASE WHEN excluido_mora THEN 0 WHEN cuotas_atrasadas > 0 THEN LEAST(acum_capital, cap_ant) ELSE exp_capital END) * participacion_externa_actual, 2) AS acum_capital_cube_participacion_actual,
+        ROUND((CASE WHEN excluido_mora THEN 0 WHEN cuotas_atrasadas > 0 THEN acum_interes + acum_iva ELSE interes + iva END) * participacion_externa_actual, 2) AS acum_interes_iva_inv_participacion_actual,
+        (CASE WHEN excluido_mora THEN 0 WHEN cuotas_atrasadas > 0 THEN acum_interes + acum_iva ELSE interes + iva END) - ROUND((CASE WHEN excluido_mora THEN 0 WHEN cuotas_atrasadas > 0 THEN acum_interes + acum_iva ELSE interes + iva END) * participacion_externa_actual, 2) AS acum_interes_iva_cube_participacion_actual
+      FROM per_bucket_credit pbc
     ),
     -- Interés a inversionistas: lo efectivamente distribuido a inversionistas EXTERNOS
     -- (inversionistas.permite_distribucion = false → se ignoran los nuestros), tomado de
@@ -321,7 +346,7 @@ export async function getMontoACobrarPeriodo({
       GROUP BY DATE_TRUNC(${pg}, (pci.fecha_pago AT TIME ZONE 'America/Guatemala')::timestamp)
     )
     SELECT
-      COALESCE(per_bucket_credit.bucket, ip.pagos_bucket) AS bucket,
+      COALESCE(split_participacion_actual.bucket, ip.pagos_bucket) AS bucket,
       COALESCE(SUM(cuotas_count), 0)::int                                                        AS cuotas_count,
       COALESCE(SUM(CASE WHEN NOT excluido_factura THEN exp_capital ELSE 0 END), 0)               AS total_cuota,
       COALESCE(SUM(CASE WHEN NOT excluido_factura THEN interes     ELSE 0 END), 0)               AS total_interes,
@@ -360,14 +385,25 @@ export async function getMontoACobrarPeriodo({
       -- Interés a inversionistas (lo distribuido a externos). Por período: lo pagado en ese
       -- bucket. Acumulado: suma corrida hasta el bucket (el último bucket = gran total).
       COALESCE(MAX(ip.total_interes_inversionista), 0)                                            AS total_interes_inversionista,
-      COALESCE(SUM(COALESCE(MAX(ip.total_interes_inversionista), 0)) OVER (ORDER BY COALESCE(per_bucket_credit.bucket, ip.pagos_bucket)), 0)   AS acum_total_interes_inversionista
+      COALESCE(SUM(COALESCE(MAX(ip.total_interes_inversionista), 0)) OVER (ORDER BY COALESCE(split_participacion_actual.bucket, ip.pagos_bucket)), 0)   AS acum_total_interes_inversionista,
     -- FULL JOIN: el resultado se arma desde la unión de buckets de ambas fuentes, para que un
     -- período con pagos a inversionistas pero SIN cuotas pendientes (posible en vista
     -- día/semana) no se pierda ni subestime la columna.
-    FROM per_bucket_credit
-    FULL JOIN inv_pagos_por_bucket ip ON ip.pagos_bucket = per_bucket_credit.bucket
-    GROUP BY COALESCE(per_bucket_credit.bucket, ip.pagos_bucket)
-    ORDER BY COALESCE(per_bucket_credit.bucket, ip.pagos_bucket) ASC
+      COALESCE(SUM(capital_inv_participacion_actual) FILTER (WHERE NOT participacion_invalida), 0) AS capital_inv_participacion_actual,
+      COALESCE(SUM(capital_cube_participacion_actual) FILTER (WHERE NOT participacion_invalida), 0) AS capital_cube_participacion_actual,
+      COALESCE(SUM(interes_iva_inv_participacion_actual) FILTER (WHERE NOT participacion_invalida), 0) AS interes_iva_inv_participacion_actual,
+      COALESCE(SUM(interes_iva_cube_participacion_actual) FILTER (WHERE NOT participacion_invalida), 0) AS interes_iva_cube_participacion_actual,
+      COALESCE(SUM(acum_capital_inv_participacion_actual) FILTER (WHERE NOT participacion_invalida), 0) AS acum_capital_inv_participacion_actual,
+      COALESCE(SUM(acum_capital_cube_participacion_actual) FILTER (WHERE NOT participacion_invalida), 0) AS acum_capital_cube_participacion_actual,
+      COALESCE(SUM(acum_interes_iva_inv_participacion_actual) FILTER (WHERE NOT participacion_invalida), 0) AS acum_interes_iva_inv_participacion_actual,
+      COALESCE(SUM(acum_interes_iva_cube_participacion_actual) FILTER (WHERE NOT participacion_invalida), 0) AS acum_interes_iva_cube_participacion_actual,
+      COUNT(credito_id) FILTER (WHERE participacion_invalida)::int AS creditos_participacion_invalida,
+      COALESCE(SUM(cuotas_count) FILTER (WHERE participacion_invalida), 0)::int AS cuotas_participacion_invalida,
+      true AS participacion_actual
+    FROM split_participacion_actual
+    FULL JOIN inv_pagos_por_bucket ip ON ip.pagos_bucket = split_participacion_actual.bucket
+    GROUP BY COALESCE(split_participacion_actual.bucket, ip.pagos_bucket)
+    ORDER BY COALESCE(split_participacion_actual.bucket, ip.pagos_bucket) ASC
   `);
 
   return result.rows;

--- a/apps/cartera-back/src/controllers/reportes.ts
+++ b/apps/cartera-back/src/controllers/reportes.ts
@@ -329,6 +329,10 @@ export async function getMontoACobrarPeriodo({
         (CASE WHEN excluido_mora THEN 0 WHEN cuotas_atrasadas > 0 THEN acum_interes + acum_iva ELSE interes + iva END) - ROUND((CASE WHEN excluido_mora THEN 0 WHEN cuotas_atrasadas > 0 THEN acum_interes + acum_iva ELSE interes + iva END) * participacion_externa_actual, 2) AS acum_interes_iva_cube_participacion_actual
       FROM per_bucket_credit pbc
     ),
+    participacion_invalida_rango AS (
+      SELECT COUNT(DISTINCT credito_id) FILTER (WHERE participacion_invalida)::int AS creditos_participacion_invalida_rango
+      FROM split_participacion_actual
+    ),
     -- Interés a inversionistas: lo efectivamente distribuido a inversionistas EXTERNOS
     -- (inversionistas.permite_distribucion = false → se ignoran los nuestros), tomado de
     -- pagos_credito_inversionistas como interés + IVA (abono_interes + abono_iva_12),
@@ -398,10 +402,12 @@ export async function getMontoACobrarPeriodo({
       COALESCE(SUM(acum_interes_iva_inv_participacion_actual) FILTER (WHERE NOT participacion_invalida), 0) AS acum_interes_iva_inv_participacion_actual,
       COALESCE(SUM(acum_interes_iva_cube_participacion_actual) FILTER (WHERE NOT participacion_invalida), 0) AS acum_interes_iva_cube_participacion_actual,
       COUNT(credito_id) FILTER (WHERE participacion_invalida)::int AS creditos_participacion_invalida,
+      COALESCE(MAX(pir.creditos_participacion_invalida_rango), 0)::int AS creditos_participacion_invalida_rango,
       COALESCE(SUM(cuotas_count) FILTER (WHERE participacion_invalida), 0)::int AS cuotas_participacion_invalida,
       true AS participacion_actual
     FROM split_participacion_actual
     FULL JOIN inv_pagos_por_bucket ip ON ip.pagos_bucket = split_participacion_actual.bucket
+    CROSS JOIN participacion_invalida_rango pir
     GROUP BY COALESCE(split_participacion_actual.bucket, ip.pagos_bucket)
     ORDER BY COALESCE(split_participacion_actual.bucket, ip.pagos_bucket) ASC
   `);

--- a/apps/crm/apps/server/src/services/cartera-back-client.ts
+++ b/apps/crm/apps/server/src/services/cartera-back-client.ts
@@ -328,6 +328,17 @@ export type MontoACobrarPeriodoRow = {
 	acum_total_membresias: string;
 	total_interes_inversionista: string;
 	acum_total_interes_inversionista: string;
+	capital_inv_participacion_actual: string;
+	capital_cube_participacion_actual: string;
+	interes_iva_inv_participacion_actual: string;
+	interes_iva_cube_participacion_actual: string;
+	acum_capital_inv_participacion_actual: string;
+	acum_capital_cube_participacion_actual: string;
+	acum_interes_iva_inv_participacion_actual: string;
+	acum_interes_iva_cube_participacion_actual: string;
+	creditos_participacion_invalida: number;
+	cuotas_participacion_invalida: number;
+	participacion_actual: boolean;
 };
 
 export type FlujoCuotasRubro = {

--- a/apps/crm/apps/server/src/services/cartera-back-client.ts
+++ b/apps/crm/apps/server/src/services/cartera-back-client.ts
@@ -337,6 +337,7 @@ export type MontoACobrarPeriodoRow = {
 	acum_interes_iva_inv_participacion_actual: string;
 	acum_interes_iva_cube_participacion_actual: string;
 	creditos_participacion_invalida: number;
+	creditos_participacion_invalida_rango?: number;
 	cuotas_participacion_invalida: number;
 	participacion_actual: boolean;
 };

--- a/apps/crm/apps/web/src/lib/reports/monto-a-cobrar.test.ts
+++ b/apps/crm/apps/web/src/lib/reports/monto-a-cobrar.test.ts
@@ -70,6 +70,7 @@ test("totaliza el split sin modificar el total original", () => {
 				interes_iva_inv_participacion_actual: "5",
 				interes_iva_cube_participacion_actual: "7",
 				creditos_participacion_invalida: 1,
+				creditos_participacion_invalida_rango: 1,
 				cuotas_participacion_invalida: 2,
 			},
 		],
@@ -83,6 +84,93 @@ test("totaliza el split sin modificar el total original", () => {
 		interesIvaCube: 7,
 		creditosInvalidos: 1,
 		cuotasInvalidas: 2,
+	});
+});
+
+test("usa el conteo distinct del rango y conserva las cuotas entre buckets", () => {
+	const rows = [
+		{
+			capital_inv_participacion_actual: "0",
+			capital_cube_participacion_actual: "0",
+			interes_iva_inv_participacion_actual: "0",
+			interes_iva_cube_participacion_actual: "0",
+			creditos_participacion_invalida: 1,
+			creditos_participacion_invalida_rango: 1,
+			cuotas_participacion_invalida: 1,
+		},
+		{
+			capital_inv_participacion_actual: "0",
+			capital_cube_participacion_actual: "0",
+			interes_iva_inv_participacion_actual: "0",
+			interes_iva_cube_participacion_actual: "0",
+			creditos_participacion_invalida: 1,
+			creditos_participacion_invalida_rango: 1,
+			cuotas_participacion_invalida: 2,
+		},
+		{
+			capital_inv_participacion_actual: "0",
+			capital_cube_participacion_actual: "0",
+			interes_iva_inv_participacion_actual: "0",
+			interes_iva_cube_participacion_actual: "0",
+			creditos_participacion_invalida: 1,
+			creditos_participacion_invalida_rango: 1,
+			cuotas_participacion_invalida: 3,
+		},
+	];
+
+	for (const acumulado of [false, true]) {
+		expect(getMontoACobrarParticipacionTotals(rows, acumulado)).toMatchObject({
+			creditosInvalidos: 1,
+			cuotasInvalidas: 6,
+		});
+	}
+});
+
+test("usa dos créditos distintos del conteo escalar del rango", () => {
+	const rows = [
+		{
+			capital_inv_participacion_actual: "0",
+			capital_cube_participacion_actual: "0",
+			interes_iva_inv_participacion_actual: "0",
+			interes_iva_cube_participacion_actual: "0",
+			creditos_participacion_invalida: 1,
+			creditos_participacion_invalida_rango: 2,
+			cuotas_participacion_invalida: 1,
+		},
+	];
+
+	expect(getMontoACobrarParticipacionTotals(rows, false)).toMatchObject({
+		creditosInvalidos: 2,
+	});
+});
+
+test("conserva el fallback legacy cuando el conteo del rango no existe", () => {
+	const rows = [
+		{
+			capital_inv_participacion_actual: "0",
+			capital_cube_participacion_actual: "0",
+			interes_iva_inv_participacion_actual: "0",
+			interes_iva_cube_participacion_actual: "0",
+			creditos_participacion_invalida: 1,
+			cuotas_participacion_invalida: 1,
+		},
+		{
+			capital_inv_participacion_actual: "0",
+			capital_cube_participacion_actual: "0",
+			interes_iva_inv_participacion_actual: "0",
+			interes_iva_cube_participacion_actual: "0",
+			creditos_participacion_invalida: 1,
+			cuotas_participacion_invalida: 2,
+		},
+	];
+
+	expect(getMontoACobrarParticipacionTotals(rows, false)).toMatchObject({
+		creditosInvalidos: 2,
+		cuotasInvalidas: 3,
+	});
+	expect(getMontoACobrarParticipacionTotals(rows, true)).toMatchObject({
+		creditosInvalidos: 1,
+		cuotasInvalidas: 3,
 	});
 });
 

--- a/apps/crm/apps/web/src/lib/reports/monto-a-cobrar.test.ts
+++ b/apps/crm/apps/web/src/lib/reports/monto-a-cobrar.test.ts
@@ -65,6 +65,7 @@ test("totaliza el split sin modificar el total original", () => {
 	const totals = getMontoACobrarParticipacionTotals(
 		[
 			{
+				cuotas_count: 1,
 				capital_inv_participacion_actual: "10",
 				capital_cube_participacion_actual: "90",
 				interes_iva_inv_participacion_actual: "5",
@@ -90,6 +91,7 @@ test("totaliza el split sin modificar el total original", () => {
 test("usa el conteo distinct del rango y conserva las cuotas entre buckets", () => {
 	const rows = [
 		{
+			cuotas_count: 1,
 			capital_inv_participacion_actual: "0",
 			capital_cube_participacion_actual: "0",
 			interes_iva_inv_participacion_actual: "0",
@@ -99,6 +101,7 @@ test("usa el conteo distinct del rango y conserva las cuotas entre buckets", () 
 			cuotas_participacion_invalida: 1,
 		},
 		{
+			cuotas_count: 2,
 			capital_inv_participacion_actual: "0",
 			capital_cube_participacion_actual: "0",
 			interes_iva_inv_participacion_actual: "0",
@@ -108,6 +111,7 @@ test("usa el conteo distinct del rango y conserva las cuotas entre buckets", () 
 			cuotas_participacion_invalida: 2,
 		},
 		{
+			cuotas_count: 3,
 			capital_inv_participacion_actual: "0",
 			capital_cube_participacion_actual: "0",
 			interes_iva_inv_participacion_actual: "0",
@@ -129,6 +133,7 @@ test("usa el conteo distinct del rango y conserva las cuotas entre buckets", () 
 test("usa dos créditos distintos del conteo escalar del rango", () => {
 	const rows = [
 		{
+			cuotas_count: 1,
 			capital_inv_participacion_actual: "0",
 			capital_cube_participacion_actual: "0",
 			interes_iva_inv_participacion_actual: "0",
@@ -147,6 +152,7 @@ test("usa dos créditos distintos del conteo escalar del rango", () => {
 test("conserva el fallback legacy cuando el conteo del rango no existe", () => {
 	const rows = [
 		{
+			cuotas_count: 1,
 			capital_inv_participacion_actual: "0",
 			capital_cube_participacion_actual: "0",
 			interes_iva_inv_participacion_actual: "0",
@@ -155,6 +161,7 @@ test("conserva el fallback legacy cuando el conteo del rango no existe", () => {
 			cuotas_participacion_invalida: 1,
 		},
 		{
+			cuotas_count: 2,
 			capital_inv_participacion_actual: "0",
 			capital_cube_participacion_actual: "0",
 			interes_iva_inv_participacion_actual: "0",
@@ -177,6 +184,7 @@ test("conserva el fallback legacy cuando el conteo del rango no existe", () => {
 test("el acumulado usa el último período y no suma valores ya acumulados", () => {
 	const rows = [
 		{
+			cuotas_count: 1,
 			capital_inv_participacion_actual: "10",
 			capital_cube_participacion_actual: "90",
 			interes_iva_inv_participacion_actual: "5",
@@ -185,6 +193,7 @@ test("el acumulado usa el último período y no suma valores ya acumulados", () 
 			cuotas_participacion_invalida: 1,
 		},
 		{
+			cuotas_count: 2,
 			capital_inv_participacion_actual: "20",
 			capital_cube_participacion_actual: "180",
 			interes_iva_inv_participacion_actual: "10",
@@ -201,5 +210,37 @@ test("el acumulado usa el último período y no suma valores ya acumulados", () 
 	expect(getMontoACobrarParticipacionTotals(rows, true)).toMatchObject({
 		capitalInv: 20,
 		capitalCube: 180,
+	});
+});
+
+test("el acumulado conserva el split ante un último bucket solo de pagos", () => {
+	const rows = [
+		{
+			cuotas_count: 1,
+			capital_inv_participacion_actual: "20",
+			capital_cube_participacion_actual: "180",
+			interes_iva_inv_participacion_actual: "10",
+			interes_iva_cube_participacion_actual: "90",
+			creditos_participacion_invalida: 0,
+			creditos_participacion_invalida_rango: 0,
+			cuotas_participacion_invalida: 0,
+		},
+		{
+			cuotas_count: 0,
+			capital_inv_participacion_actual: "0",
+			capital_cube_participacion_actual: "0",
+			interes_iva_inv_participacion_actual: "0",
+			interes_iva_cube_participacion_actual: "0",
+			creditos_participacion_invalida: 0,
+			creditos_participacion_invalida_rango: 0,
+			cuotas_participacion_invalida: 0,
+		},
+	];
+
+	expect(getMontoACobrarParticipacionTotals(rows, true)).toMatchObject({
+		capitalInv: 20,
+		capitalCube: 180,
+		interesIvaInv: 10,
+		interesIvaCube: 90,
 	});
 });

--- a/apps/crm/apps/web/src/lib/reports/monto-a-cobrar.test.ts
+++ b/apps/crm/apps/web/src/lib/reports/monto-a-cobrar.test.ts
@@ -1,0 +1,117 @@
+import { describe, expect, test } from "bun:test";
+import {
+	fillMissingMontoACobrarPeriods,
+	getMontoACobrarParticipacionTotals,
+} from "./monto-a-cobrar";
+
+describe("fillMissingMontoACobrarPeriods", () => {
+	test("rellena buckets diarios faltantes incluyendo el split y metadata", () => {
+		const rows = fillMissingMontoACobrarPeriods(
+			[
+				{
+					bucket: "2026-07-01",
+					cuotas_count: 1,
+					total_cuota: "100",
+					total_interes: "10",
+					total_iva: "1.2",
+					total_seguro: "0",
+					total_gps: "0",
+					total_membresias: "0",
+					total_mora: "0",
+					mora_count: 0,
+					total_credits: 1,
+					credits_con_mora: 0,
+					acum_total_cuota: "100",
+					acum_total_interes: "10",
+					acum_total_iva: "1.2",
+					acum_total_seguro: "0",
+					acum_total_gps: "0",
+					acum_total_membresias: "0",
+					total_interes_inversionista: "0",
+					acum_total_interes_inversionista: "0",
+					capital_inv_participacion_actual: "50",
+					capital_cube_participacion_actual: "50",
+					interes_iva_inv_participacion_actual: "5.6",
+					interes_iva_cube_participacion_actual: "5.6",
+					acum_capital_inv_participacion_actual: "50",
+					acum_capital_cube_participacion_actual: "50",
+					acum_interes_iva_inv_participacion_actual: "5.6",
+					acum_interes_iva_cube_participacion_actual: "5.6",
+					creditos_participacion_invalida: 0,
+					cuotas_participacion_invalida: 0,
+					participacion_actual: true,
+				},
+			],
+			"dia",
+			"2026-07-01",
+			"2026-07-02",
+		);
+
+		expect(rows).toHaveLength(2);
+		expect(rows[1]).toMatchObject({
+			bucket: "2026-07-02",
+			capital_inv_participacion_actual: "0",
+			capital_cube_participacion_actual: "0",
+			interes_iva_inv_participacion_actual: "0",
+			interes_iva_cube_participacion_actual: "0",
+			creditos_participacion_invalida: 0,
+			cuotas_participacion_invalida: 0,
+			participacion_actual: true,
+		});
+	});
+});
+
+test("totaliza el split sin modificar el total original", () => {
+	const totals = getMontoACobrarParticipacionTotals(
+		[
+			{
+				capital_inv_participacion_actual: "10",
+				capital_cube_participacion_actual: "90",
+				interes_iva_inv_participacion_actual: "5",
+				interes_iva_cube_participacion_actual: "7",
+				creditos_participacion_invalida: 1,
+				cuotas_participacion_invalida: 2,
+			},
+		],
+		false,
+	);
+
+	expect(totals).toEqual({
+		capitalInv: 10,
+		capitalCube: 90,
+		interesIvaInv: 5,
+		interesIvaCube: 7,
+		creditosInvalidos: 1,
+		cuotasInvalidas: 2,
+	});
+});
+
+test("el acumulado usa el último período y no suma valores ya acumulados", () => {
+	const rows = [
+		{
+			capital_inv_participacion_actual: "10",
+			capital_cube_participacion_actual: "90",
+			interes_iva_inv_participacion_actual: "5",
+			interes_iva_cube_participacion_actual: "45",
+			creditos_participacion_invalida: 1,
+			cuotas_participacion_invalida: 1,
+		},
+		{
+			capital_inv_participacion_actual: "20",
+			capital_cube_participacion_actual: "180",
+			interes_iva_inv_participacion_actual: "10",
+			interes_iva_cube_participacion_actual: "90",
+			creditos_participacion_invalida: 2,
+			cuotas_participacion_invalida: 2,
+		},
+	];
+
+	expect(getMontoACobrarParticipacionTotals(rows, false)).toMatchObject({
+		capitalInv: 30,
+		capitalCube: 270,
+	});
+	expect(getMontoACobrarParticipacionTotals(rows, true)).toMatchObject({
+		capitalInv: 20,
+		capitalCube: 180,
+	});
+});

--- a/apps/crm/apps/web/src/lib/reports/monto-a-cobrar.ts
+++ b/apps/crm/apps/web/src/lib/reports/monto-a-cobrar.ts
@@ -28,6 +28,7 @@ export type MontoACobrarParticipacionRow = {
 	acum_interes_iva_inv_participacion_actual: string;
 	acum_interes_iva_cube_participacion_actual: string;
 	creditos_participacion_invalida: number;
+	creditos_participacion_invalida_rango?: number;
 	cuotas_participacion_invalida: number;
 	participacion_actual: boolean;
 };
@@ -109,6 +110,7 @@ export function getMontoACobrarParticipacionTotals(
 			| "interes_iva_inv_participacion_actual"
 			| "interes_iva_cube_participacion_actual"
 			| "creditos_participacion_invalida"
+			| "creditos_participacion_invalida_rango"
 			| "cuotas_participacion_invalida"
 		>
 	>,
@@ -116,14 +118,29 @@ export function getMontoACobrarParticipacionTotals(
 ): ParticipacionTotals {
 	const last = rows.at(-1);
 	const numeric = (value: string) => Number.parseFloat(value) || 0;
+	const creditosInvalidosRango = rows.find(
+		(row) => row.creditos_participacion_invalida_rango !== undefined,
+	)?.creditos_participacion_invalida_rango;
+	const creditosInvalidosLegacy = acumulado && last
+		? last.creditos_participacion_invalida
+		: rows.reduce(
+				(total, row) => total + row.creditos_participacion_invalida,
+				0,
+			);
+	const creditosInvalidos =
+		creditosInvalidosRango ?? creditosInvalidosLegacy;
+	const cuotasInvalidas = rows.reduce(
+		(total, row) => total + row.cuotas_participacion_invalida,
+		0,
+	);
 	if (acumulado && last) {
 		return {
 			capitalInv: numeric(last.capital_inv_participacion_actual),
 			capitalCube: numeric(last.capital_cube_participacion_actual),
 			interesIvaInv: numeric(last.interes_iva_inv_participacion_actual),
 			interesIvaCube: numeric(last.interes_iva_cube_participacion_actual),
-			creditosInvalidos: last.creditos_participacion_invalida,
-			cuotasInvalidas: last.cuotas_participacion_invalida,
+			creditosInvalidos,
+			cuotasInvalidas,
 		};
 	}
 	return rows.reduce<ParticipacionTotals>(
@@ -137,10 +154,8 @@ export function getMontoACobrarParticipacionTotals(
 			interesIvaCube:
 				total.interesIvaCube +
 				numeric(row.interes_iva_cube_participacion_actual),
-			creditosInvalidos:
-				total.creditosInvalidos + row.creditos_participacion_invalida,
-			cuotasInvalidas:
-				total.cuotasInvalidas + row.cuotas_participacion_invalida,
+			creditosInvalidos,
+			cuotasInvalidas,
 		}),
 		{
 			capitalInv: 0,

--- a/apps/crm/apps/web/src/lib/reports/monto-a-cobrar.ts
+++ b/apps/crm/apps/web/src/lib/reports/monto-a-cobrar.ts
@@ -1,0 +1,154 @@
+export type MontoACobrarParticipacionRow = {
+	bucket: string;
+	cuotas_count: number;
+	total_cuota: string;
+	total_interes: string;
+	total_iva: string;
+	total_seguro: string;
+	total_gps: string;
+	total_membresias: string;
+	total_mora: string;
+	mora_count: number;
+	total_credits: number;
+	credits_con_mora: number;
+	acum_total_cuota: string;
+	acum_total_interes: string;
+	acum_total_iva: string;
+	acum_total_seguro: string;
+	acum_total_gps: string;
+	acum_total_membresias: string;
+	total_interes_inversionista: string;
+	acum_total_interes_inversionista: string;
+	capital_inv_participacion_actual: string;
+	capital_cube_participacion_actual: string;
+	interes_iva_inv_participacion_actual: string;
+	interes_iva_cube_participacion_actual: string;
+	acum_capital_inv_participacion_actual: string;
+	acum_capital_cube_participacion_actual: string;
+	acum_interes_iva_inv_participacion_actual: string;
+	acum_interes_iva_cube_participacion_actual: string;
+	creditos_participacion_invalida: number;
+	cuotas_participacion_invalida: number;
+	participacion_actual: boolean;
+};
+
+type ParticipacionTotals = {
+	capitalInv: number;
+	capitalCube: number;
+	interesIvaInv: number;
+	interesIvaCube: number;
+	creditosInvalidos: number;
+	cuotasInvalidas: number;
+};
+
+const emptyRow = (bucket: string): MontoACobrarParticipacionRow => ({
+	bucket,
+	cuotas_count: 0,
+	total_cuota: "0",
+	total_interes: "0",
+	total_iva: "0",
+	total_seguro: "0",
+	total_gps: "0",
+	total_membresias: "0",
+	total_mora: "0",
+	mora_count: 0,
+	total_credits: 0,
+	credits_con_mora: 0,
+	acum_total_cuota: "0",
+	acum_total_interes: "0",
+	acum_total_iva: "0",
+	acum_total_seguro: "0",
+	acum_total_gps: "0",
+	acum_total_membresias: "0",
+	total_interes_inversionista: "0",
+	acum_total_interes_inversionista: "0",
+	capital_inv_participacion_actual: "0",
+	capital_cube_participacion_actual: "0",
+	interes_iva_inv_participacion_actual: "0",
+	interes_iva_cube_participacion_actual: "0",
+	acum_capital_inv_participacion_actual: "0",
+	acum_capital_cube_participacion_actual: "0",
+	acum_interes_iva_inv_participacion_actual: "0",
+	acum_interes_iva_cube_participacion_actual: "0",
+	creditos_participacion_invalida: 0,
+	cuotas_participacion_invalida: 0,
+	participacion_actual: true,
+});
+
+export function fillMissingMontoACobrarPeriods(
+	data: MontoACobrarParticipacionRow[],
+	periodo: "anio" | "trimestre" | "mes" | "semana" | "dia",
+	fechaInicio: string,
+	fechaFin: string,
+): MontoACobrarParticipacionRow[] {
+	if (periodo !== "semana" && periodo !== "dia") return data;
+	const toKey = (d: Date) =>
+		`${d.getFullYear()}-${String(d.getMonth() + 1).padStart(2, "0")}-${String(d.getDate()).padStart(2, "0")}`;
+	const rows = new Map(data.map((row) => [row.bucket.slice(0, 10), row]));
+	const start = new Date(`${fechaInicio}T12:00:00`);
+	const end = new Date(`${fechaFin}T12:00:00`);
+	const dates: Date[] = [];
+	const current = new Date(start);
+	if (periodo === "semana") {
+		const day = current.getDay();
+		current.setDate(current.getDate() + (day === 0 ? -6 : 1 - day));
+	}
+	while (current <= end) {
+		dates.push(new Date(current));
+		current.setDate(current.getDate() + (periodo === "dia" ? 1 : 7));
+	}
+	return dates.map((date) => rows.get(toKey(date)) ?? emptyRow(toKey(date)));
+}
+
+export function getMontoACobrarParticipacionTotals(
+	rows: Array<
+		Pick<
+			MontoACobrarParticipacionRow,
+			| "capital_inv_participacion_actual"
+			| "capital_cube_participacion_actual"
+			| "interes_iva_inv_participacion_actual"
+			| "interes_iva_cube_participacion_actual"
+			| "creditos_participacion_invalida"
+			| "cuotas_participacion_invalida"
+		>
+	>,
+	acumulado: boolean,
+): ParticipacionTotals {
+	const last = rows.at(-1);
+	const numeric = (value: string) => Number.parseFloat(value) || 0;
+	if (acumulado && last) {
+		return {
+			capitalInv: numeric(last.capital_inv_participacion_actual),
+			capitalCube: numeric(last.capital_cube_participacion_actual),
+			interesIvaInv: numeric(last.interes_iva_inv_participacion_actual),
+			interesIvaCube: numeric(last.interes_iva_cube_participacion_actual),
+			creditosInvalidos: last.creditos_participacion_invalida,
+			cuotasInvalidas: last.cuotas_participacion_invalida,
+		};
+	}
+	return rows.reduce<ParticipacionTotals>(
+		(total, row) => ({
+			capitalInv:
+				total.capitalInv + numeric(row.capital_inv_participacion_actual),
+			capitalCube:
+				total.capitalCube + numeric(row.capital_cube_participacion_actual),
+			interesIvaInv:
+				total.interesIvaInv + numeric(row.interes_iva_inv_participacion_actual),
+			interesIvaCube:
+				total.interesIvaCube +
+				numeric(row.interes_iva_cube_participacion_actual),
+			creditosInvalidos:
+				total.creditosInvalidos + row.creditos_participacion_invalida,
+			cuotasInvalidas:
+				total.cuotasInvalidas + row.cuotas_participacion_invalida,
+		}),
+		{
+			capitalInv: 0,
+			capitalCube: 0,
+			interesIvaInv: 0,
+			interesIvaCube: 0,
+			creditosInvalidos: 0,
+			cuotasInvalidas: 0,
+		},
+	);
+}

--- a/apps/crm/apps/web/src/lib/reports/monto-a-cobrar.ts
+++ b/apps/crm/apps/web/src/lib/reports/monto-a-cobrar.ts
@@ -105,6 +105,7 @@ export function getMontoACobrarParticipacionTotals(
 	rows: Array<
 		Pick<
 			MontoACobrarParticipacionRow,
+			| "cuotas_count"
 			| "capital_inv_participacion_actual"
 			| "capital_cube_participacion_actual"
 			| "interes_iva_inv_participacion_actual"
@@ -116,7 +117,7 @@ export function getMontoACobrarParticipacionTotals(
 	>,
 	acumulado: boolean,
 ): ParticipacionTotals {
-	const last = rows.at(-1);
+	const last = rows.findLast((row) => row.cuotas_count > 0);
 	const numeric = (value: string) => Number.parseFloat(value) || 0;
 	const creditosInvalidosRango = rows.find(
 		(row) => row.creditos_participacion_invalida_rango !== undefined,

--- a/apps/crm/apps/web/src/lib/reports/scenario.ts
+++ b/apps/crm/apps/web/src/lib/reports/scenario.ts
@@ -105,6 +105,17 @@ export type MontoACobrarPeriodoRow = {
 	acum_total_membresias: string;
 	total_interes_inversionista: string;
 	acum_total_interes_inversionista: string;
+	capital_inv_participacion_actual: string;
+	capital_cube_participacion_actual: string;
+	interes_iva_inv_participacion_actual: string;
+	interes_iva_cube_participacion_actual: string;
+	acum_capital_inv_participacion_actual: string;
+	acum_capital_cube_participacion_actual: string;
+	acum_interes_iva_inv_participacion_actual: string;
+	acum_interes_iva_cube_participacion_actual: string;
+	creditos_participacion_invalida: number;
+	cuotas_participacion_invalida: number;
+	participacion_actual: boolean;
 };
 
 export type FacturacionMesRubro = {

--- a/apps/crm/apps/web/src/lib/reports/scenario.ts
+++ b/apps/crm/apps/web/src/lib/reports/scenario.ts
@@ -114,6 +114,7 @@ export type MontoACobrarPeriodoRow = {
 	acum_interes_iva_inv_participacion_actual: string;
 	acum_interes_iva_cube_participacion_actual: string;
 	creditos_participacion_invalida: number;
+	creditos_participacion_invalida_rango?: number;
 	cuotas_participacion_invalida: number;
 	participacion_actual: boolean;
 };

--- a/apps/crm/apps/web/src/routes/admin/reports/-index.participacion.test.ts
+++ b/apps/crm/apps/web/src/routes/admin/reports/-index.participacion.test.ts
@@ -1,0 +1,10 @@
+import { expect, test } from "bun:test";
+
+test("el pie pasa acumulado al helper del split", async () => {
+	const source = await Bun.file(new URL("./index.tsx", import.meta.url)).text();
+	const footer = source.slice(source.indexOf("const splitTotals"));
+
+	expect(footer).toMatch(
+		/getMontoACobrarParticipacionTotals\([\s\S]*?\),\s*a,\s*\)/,
+	);
+});

--- a/apps/crm/apps/web/src/routes/admin/reports/index.tsx
+++ b/apps/crm/apps/web/src/routes/admin/reports/index.tsx
@@ -69,6 +69,7 @@ import {
 import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs";
 import { authClient } from "@/lib/auth-client";
 import { shouldRedirectToLogin } from "@/lib/auth-session";
+import { getMontoACobrarParticipacionTotals } from "@/lib/reports/monto-a-cobrar";
 import type {
 	ComparativoHistoricoRow,
 	FacturacionMesResponse,
@@ -413,6 +414,17 @@ function fillMissingPeriods(
 				acum_total_membresias: "0",
 				total_interes_inversionista: "0",
 				acum_total_interes_inversionista: "0",
+				capital_inv_participacion_actual: "0",
+				capital_cube_participacion_actual: "0",
+				interes_iva_inv_participacion_actual: "0",
+				interes_iva_cube_participacion_actual: "0",
+				acum_capital_inv_participacion_actual: "0",
+				acum_capital_cube_participacion_actual: "0",
+				acum_interes_iva_inv_participacion_actual: "0",
+				acum_interes_iva_cube_participacion_actual: "0",
+				creditos_participacion_invalida: 0,
+				cuotas_participacion_invalida: 0,
+				participacion_actual: true,
 			}
 		);
 	});
@@ -1311,9 +1323,9 @@ function RouteComponent() {
 											<CalendarDays className="h-5 w-5 text-blue-500" />
 											<div>
 												<CardTitle>Monto a Cobrarse por Período</CardTitle>
-												<CardDescription>
-													Cuotas pendientes desglosadas por rubro (capital,
-													interés, seguro, etc.)
+													<CardDescription>
+														Cuotas pendientes desglosadas por rubro (capital,
+														interés, seguro, etc.). Según participación actual.
 												</CardDescription>
 											</div>
 										</div>
@@ -1391,6 +1403,17 @@ function RouteComponent() {
 									)}
 									{!!montoCobrarData?.data.length && (
 										<>
+											{(() => {
+												const totals = getMontoACobrarParticipacionTotals(
+													montoCobrarData.data,
+													false,
+												);
+												return totals.creditosInvalidos > 0 ? (
+													<p className="rounded-md border border-amber-300 bg-amber-50 px-3 py-2 text-amber-900 text-sm dark:bg-amber-950/30 dark:text-amber-200">
+														Participación actual inválida en {totals.creditosInvalidos} crédito(s) y {totals.cuotasInvalidas} cuota(s); sus montos no se incluyen en el desglose Inv./CUBE.
+													</p>
+												) : null;
+											})()}
 											{/* Gráfica de barras apiladas */}
 											<ResponsiveContainer width="100%" height={350}>
 												<BarChart
@@ -1496,9 +1519,13 @@ function RouteComponent() {
 															<TableHead className="text-right">
 																Membresías
 															</TableHead>
-															<TableHead className="text-right">
-																Interés Inv. (referencia)
-															</TableHead>
+																	<TableHead className="text-right">
+																		Interés Inv. pagado (referencia)
+																	</TableHead>
+																	<TableHead className="text-right">Capital Inv.</TableHead>
+																	<TableHead className="text-right">Capital CUBE</TableHead>
+																	<TableHead className="text-right">Interés + IVA Inv.</TableHead>
+																	<TableHead className="text-right">Interés + IVA CUBE</TableHead>
 															<TableHead className="text-right">
 																Total Mora
 															</TableHead>
@@ -1533,9 +1560,13 @@ function RouteComponent() {
 															const membresias = a
 																? row.acum_total_membresias
 																: row.total_membresias;
-															const interesInversionista = a
-																? row.acum_total_interes_inversionista
-																: row.total_interes_inversionista;
+																	const interesInversionista = a
+																		? row.acum_total_interes_inversionista
+																		: row.total_interes_inversionista;
+																	const capitalInv = a ? row.acum_capital_inv_participacion_actual : row.capital_inv_participacion_actual;
+																	const capitalCube = a ? row.acum_capital_cube_participacion_actual : row.capital_cube_participacion_actual;
+																	const interesIvaInv = a ? row.acum_interes_iva_inv_participacion_actual : row.interes_iva_inv_participacion_actual;
+																	const interesIvaCube = a ? row.acum_interes_iva_cube_participacion_actual : row.interes_iva_cube_participacion_actual;
 															const total =
 																Number.parseFloat(cuota) +
 																Number.parseFloat(interes) +
@@ -1575,6 +1606,10 @@ function RouteComponent() {
 																	<TableCell className="text-right">
 																		{formatCurrency(interesInversionista)}
 																	</TableCell>
+																	<TableCell className="text-right">{formatCurrency(capitalInv)}</TableCell>
+																	<TableCell className="text-right">{formatCurrency(capitalCube)}</TableCell>
+																	<TableCell className="text-right">{formatCurrency(interesIvaInv)}</TableCell>
+																	<TableCell className="text-right">{formatCurrency(interesIvaCube)}</TableCell>
 																	<TableCell className="text-right">
 																		<div>{formatCurrency(row.total_mora)}</div>
 																		<div
@@ -1626,13 +1661,24 @@ function RouteComponent() {
 																val("acum_total_seguro") +
 																val("acum_total_gps") +
 																val("acum_total_membresias");
-															const totalCred =
-																a && lastRow
-																	? lastRow.cuotas_count
-																	: rows.reduce(
-																			(acc, r) => acc + r.cuotas_count,
-																			0,
-																		);
+																	const totalCred =
+																		a && lastRow
+																			? lastRow.cuotas_count
+																			: rows.reduce(
+																					(acc, r) => acc + r.cuotas_count,
+																					0,
+																				);
+																	const splitTotals = getMontoACobrarParticipacionTotals(
+																		rows.map((row) => ({
+																			capital_inv_participacion_actual: a ? row.acum_capital_inv_participacion_actual : row.capital_inv_participacion_actual,
+																			capital_cube_participacion_actual: a ? row.acum_capital_cube_participacion_actual : row.capital_cube_participacion_actual,
+																			interes_iva_inv_participacion_actual: a ? row.acum_interes_iva_inv_participacion_actual : row.interes_iva_inv_participacion_actual,
+																			interes_iva_cube_participacion_actual: a ? row.acum_interes_iva_cube_participacion_actual : row.interes_iva_cube_participacion_actual,
+																			creditos_participacion_invalida: row.creditos_participacion_invalida,
+																			cuotas_participacion_invalida: row.cuotas_participacion_invalida,
+																		})),
+																		a,
+																	);
 															return (
 																<TableRow className="border-t-2 bg-muted/50 font-bold">
 																	<TableCell>Total</TableCell>
@@ -1688,10 +1734,14 @@ function RouteComponent() {
 																			val(
 																				a
 																					? "acum_total_interes_inversionista"
-																					: "total_interes_inversionista",
-																			),
-																		)}
-																	</TableCell>
+																							: "total_interes_inversionista",
+																						),
+																					)}
+																				</TableCell>
+																				<TableCell className="text-right">{formatCurrency(splitTotals.capitalInv)}</TableCell>
+																				<TableCell className="text-right">{formatCurrency(splitTotals.capitalCube)}</TableCell>
+																				<TableCell className="text-right">{formatCurrency(splitTotals.interesIvaInv)}</TableCell>
+																				<TableCell className="text-right">{formatCurrency(splitTotals.interesIvaCube)}</TableCell>
 																	<TableCell className="text-right">
 																		{formatCurrency(val("total_mora"))}
 																	</TableCell>

--- a/apps/crm/apps/web/src/routes/admin/reports/index.tsx
+++ b/apps/crm/apps/web/src/routes/admin/reports/index.tsx
@@ -1675,6 +1675,7 @@ function RouteComponent() {
 																			interes_iva_inv_participacion_actual: a ? row.acum_interes_iva_inv_participacion_actual : row.interes_iva_inv_participacion_actual,
 																			interes_iva_cube_participacion_actual: a ? row.acum_interes_iva_cube_participacion_actual : row.interes_iva_cube_participacion_actual,
 																			creditos_participacion_invalida: row.creditos_participacion_invalida,
+																			creditos_participacion_invalida_rango: row.creditos_participacion_invalida_rango,
 																			cuotas_participacion_invalida: row.cuotas_participacion_invalida,
 																		})),
 																		a,

--- a/apps/crm/apps/web/src/routes/admin/reports/index.tsx
+++ b/apps/crm/apps/web/src/routes/admin/reports/index.tsx
@@ -1670,6 +1670,7 @@ function RouteComponent() {
 																				);
 																	const splitTotals = getMontoACobrarParticipacionTotals(
 																		rows.map((row) => ({
+																			cuotas_count: row.cuotas_count,
 																			capital_inv_participacion_actual: a ? row.acum_capital_inv_participacion_actual : row.capital_inv_participacion_actual,
 																			capital_cube_participacion_actual: a ? row.acum_capital_cube_participacion_actual : row.capital_cube_participacion_actual,
 																			interes_iva_inv_participacion_actual: a ? row.acum_interes_iva_inv_participacion_actual : row.interes_iva_inv_participacion_actual,


### PR DESCRIPTION
## Stack

**2 de 3** — depende de A.

- Predecesor/base: `fix/cartera-mora-report-consistency`
- Sucesor: `fix/crm-cobranza-tab-cobros-supervisor`
- Orden de merge: A → B → C

Este PR muestra únicamente el delta de participación actual; incluye A en su historia por diseño.

## Resumen

- Agrega split Inv./CUBE al reporte `Monto a cobrarse` usando participación **actual**.
- Fuente: `creditos_inversionistas.porcentaje_participacion_inversionista` y externos con `permite_distribucion = false`.
- Sin relación externa: 100% CUBE.
- Participaciones fuera de 0–100% quedan como `PARTICIPACION_INVALIDA`, sin normalización y sin contaminar el split.
- Redondea Inv. por crédito y calcula CUBE por diferencia.
- Conserva totales originales; el split no se suma otra vez ni altera la gráfica de rubros originales.
- Corrige acumulados usando la última fila acumulada.

## Validación

- cartera-back: **7/7** pruebas focales.
- CRM: **21/21** pruebas focales y de escenario.
- `git diff --check`: PASS.
- Rebase sobre A: limpio y con patch-id semánticamente idéntico.
- Revisión independiente previa fail-closed: PASS.

## Límites

- Participación actual, no histórica.
- Sin migraciones, backfill, cambios de datos, deploy ni auto-merge.
