### PR TITLE
fix(crm): acceso de Cobranza para cobros_supervisor

### DIFF
--- a/apps/crm/apps/server/src/lib/orpc.ts
+++ b/apps/crm/apps/server/src/lib/orpc.ts
@@ -261,6 +261,35 @@ const requireClosedCreditsReport = o.middleware(async ({ context, next }) => {
 	});
 });
 
+const requireCobranzaReport = o.middleware(async ({ context, next }) => {
+	if (!context.session?.user) {
+		throw new ORPCError("UNAUTHORIZED");
+	}
+
+	const userId = context.session.user.id;
+	const userData = await db
+		.select()
+		.from(user)
+		.where(eq(user.id, userId))
+		.limit(1);
+	const userRole = userData[0]?.role;
+
+	if (!PERMISSIONS.canAccessCobranzaReport(userRole)) {
+		throw new ORPCError("FORBIDDEN", {
+			message: "Cobranza report access required",
+		});
+	}
+
+	return next({
+		context: {
+			session: context.session,
+			user: userData[0],
+			userId,
+			userRole,
+		},
+	});
+});
+
 const requireTiempoCierreReport = o.middleware(async ({ context, next }) => {
 	if (!context.session?.user) {
 		throw new ORPCError("UNAUTHORIZED");
@@ -598,6 +627,7 @@ export const cobrosSupervisorProcedure = publicProcedure.use(
 export const closedCreditsReportProcedure = publicProcedure.use(
 	requireClosedCreditsReport,
 );
+export const cobranzaReportProcedure = publicProcedure.use(requireCobranzaReport);
 export const tiempoCierreReportProcedure = publicProcedure.use(
 	requireTiempoCierreReport,
 );

--- a/apps/crm/apps/server/src/lib/roles.test.ts
+++ b/apps/crm/apps/server/src/lib/roles.test.ts
@@ -23,3 +23,14 @@ describe("taller role permissions", () => {
 		expect(PERMISSIONS.canAccessVehicles(ROLES.INVESTMENT_MANAGER)).toBe(false);
 	});
 });
+
+describe("cobranza report permissions", () => {
+	it("limits the cobranza report to admin and cobros supervisors", () => {
+		expect(PERMISSIONS.canAccessCobranzaReport(ROLES.ADMIN)).toBe(true);
+		expect(PERMISSIONS.canAccessCobranzaReport(ROLES.COBROS_SUPERVISOR)).toBe(
+			true,
+		);
+		expect(PERMISSIONS.canAccessCobranzaReport(ROLES.COBROS)).toBe(false);
+		expect(PERMISSIONS.canAccessCobranzaReport(ROLES.ANALYST)).toBe(false);
+	});
+});

--- a/apps/crm/apps/server/src/lib/roles.ts
+++ b/apps/crm/apps/server/src/lib/roles.ts
@@ -162,6 +162,9 @@ export const PERMISSIONS = {
 	canAccessClosedCreditsReport: (role: UserRole | string): boolean =>
 		role === ROLES.ADMIN || role === ROLES.COBROS_SUPERVISOR,
 
+	canAccessCobranzaReport: (role: UserRole | string): boolean =>
+		role === ROLES.ADMIN || role === ROLES.COBROS_SUPERVISOR,
+
 	canAccessTiempoCierreReport: (role: UserRole | string): boolean =>
 		role === ROLES.ADMIN || role === ROLES.SALES_SUPERVISOR,
 

--- a/apps/crm/apps/server/src/routers/reportes-cartera.ts
+++ b/apps/crm/apps/server/src/routers/reportes-cartera.ts
@@ -15,7 +15,7 @@ import {
 	gtDateStrToDate,
 } from "../lib/guatemala-month-window";
 import { calcularDiasMoraExactos } from "../lib/mora-utils";
-import { adminProcedure } from "../lib/orpc";
+import { adminProcedure, cobranzaReportProcedure } from "../lib/orpc";
 import {
 	carteraBackClient,
 	type FacturacionMesResponse,
@@ -444,7 +444,7 @@ export const reportesCarteraRouter = {
 	// REPORTE: MONTO A COBRARSE POR PERÍODO (lógica cartera web, con acumulado)
 	// ========================================================================
 
-	getMontoACobrarPeriodo: adminProcedure
+	getMontoACobrarPeriodo: cobranzaReportProcedure
 		.input(
 			z.object({
 				periodo: z
@@ -474,7 +474,7 @@ export const reportesCarteraRouter = {
 	// REPORTE: FACTURADO DEL MES VS ESPERADO
 	// ========================================================================
 
-	getFacturacionMes: adminProcedure
+	getFacturacionMes: cobranzaReportProcedure
 		.input(
 			z.object({
 				mes: z.number().min(1).max(12),

--- a/apps/crm/apps/server/src/routers/reports.authorization.test.ts
+++ b/apps/crm/apps/server/src/routers/reports.authorization.test.ts
@@ -1,0 +1,122 @@
+import { call } from "@orpc/server";
+import { describe, expect, mock, test } from "bun:test";
+import { ROLES } from "../lib/roles";
+
+let currentRole: (typeof ROLES)[keyof typeof ROLES] = ROLES.ADMIN;
+
+mock.module("../db", () => ({
+	db: {
+		select: () => ({
+			from: () => ({
+				where: () => ({
+					limit: async () => [{ id: "test-user", role: currentRole }],
+				}),
+			}),
+		}),
+	},
+}));
+
+mock.module("../services/cartera-back-integration", () => ({
+	isCarteraBackEnabled: () => true,
+}));
+
+mock.module("../services/cartera-back-client", () => ({
+	carteraBackClient: {
+		getMontoACobrarPeriodo: async () => [],
+		getFacturacionMes: async () => ({
+			cobrado: {
+				interes: "0",
+				membresias: "0",
+				seguro_gps: "0",
+				royalti: "0",
+				mora: "0",
+				otros: "0",
+			},
+			esperado: { meta_mensual: "0" },
+		}),
+		getFlujoCuotasInversiones: async () => ({}),
+	},
+}));
+
+const contextForCurrentRole = () =>
+	({
+		context: { session: { user: { id: "test-user" } } },
+	}) as never;
+
+const { adminProcedure } = await import("../lib/orpc");
+const { getDashboardExecutivo } = await import("./reports");
+const { reportesCarteraRouter } = await import("./reportes-cartera");
+
+describe("report authorization", () => {
+	test("allows admins through the administrative middleware", async () => {
+		currentRole = ROLES.ADMIN;
+		const procedure = adminProcedure.handler(() => "allowed");
+
+		await expect(call(procedure, undefined, contextForCurrentRole())).resolves.toBe(
+			"allowed",
+		);
+	});
+
+	test("allows a cobros supervisor only through the two Cobranza endpoints", async () => {
+		currentRole = ROLES.COBROS_SUPERVISOR;
+
+		await expect(
+			call(
+				reportesCarteraRouter.getMontoACobrarPeriodo,
+				{ periodo: "mes", fechaInicio: "2026-07-01", fechaFin: "2026-07-31" },
+				contextForCurrentRole(),
+			),
+		).resolves.toEqual({ data: [] });
+		await expect(
+			call(
+				reportesCarteraRouter.getFacturacionMes,
+				{ mes: 7, anio: 2026 },
+				contextForCurrentRole(),
+			),
+		).resolves.toEqual({
+			cobrado: {
+				interes: "0",
+				membresias: "0",
+				seguro_gps: "0",
+				royalti: "0",
+				mora: "0",
+				otros: "0",
+			},
+			esperado: { meta_mensual: "0" },
+		});
+		await expect(
+			call(
+				reportesCarteraRouter.getFlujoCuotasInversiones,
+				{ fechaInicio: "2026-07-01", fechaFin: "2026-07-31" },
+				contextForCurrentRole(),
+			),
+		).rejects.toMatchObject({ code: "FORBIDDEN" });
+	});
+
+	test("rejects a cobros supervisor from the executive dashboard", async () => {
+		currentRole = ROLES.COBROS_SUPERVISOR;
+
+		await expect(
+			call(getDashboardExecutivo, {}, contextForCurrentRole()),
+		).rejects.toMatchObject({ code: "FORBIDDEN" });
+	});
+
+	test("rejects non-supervisor roles from both Cobranza endpoints", async () => {
+		currentRole = ROLES.ANALYST;
+
+		await expect(
+			call(
+				reportesCarteraRouter.getMontoACobrarPeriodo,
+				{ periodo: "mes", fechaInicio: "2026-07-01", fechaFin: "2026-07-31" },
+				contextForCurrentRole(),
+			),
+		).rejects.toMatchObject({ code: "FORBIDDEN" });
+		await expect(
+			call(
+				reportesCarteraRouter.getFacturacionMes,
+				{ mes: 7, anio: 2026 },
+				contextForCurrentRole(),
+			),
+		).rejects.toMatchObject({ code: "FORBIDDEN" });
+	});
+});

--- a/apps/crm/apps/server/src/routers/reports.ts
+++ b/apps/crm/apps/server/src/routers/reports.ts
@@ -25,6 +25,7 @@ import {
 	type LeadSourceChannelType,
 } from "../lib/lead-sources";
 import {
+	adminProcedure,
 	closedCreditsReportProcedure,
 	efectividadPorEtapaReportProcedure,
 	metaColocacionReportProcedure,
@@ -248,7 +249,7 @@ function parseGuatemalaDateRange(startDate: string, endDate: string) {
  * Dashboard Ejecutivo
  * KPIs principales del negocio
  */
-export const getDashboardExecutivo = protectedProcedure
+export const getDashboardExecutivo = adminProcedure
 	.input(dateRangeSchema)
 	.handler(async () => {
 		// KPI 1: Cartera total activa

--- a/apps/crm/apps/web/src/routes/admin/reports/-scenario-modal-access.test.ts
+++ b/apps/crm/apps/web/src/routes/admin/reports/-scenario-modal-access.test.ts
@@ -1,0 +1,31 @@
+import { expect, test } from "bun:test";
+
+const source = await Bun.file(new URL("./index.tsx", import.meta.url)).text();
+const cobranzaModals = (source.match(
+	/\{canAccessCobranzaReport && \(\n\s*<>\n([\s\S]*?)\n\s*<\/>\n\s*\)\}/,
+))?.[1];
+
+test("admin renders the monto simulation modal", () => {
+	expect(cobranzaModals).toContain('open={scenarioOpen === "monto"}');
+});
+
+test("admin renders the facturacion simulation modal", () => {
+	expect(cobranzaModals).toContain('open={scenarioOpen === "facturacion"}');
+});
+
+test("cobros supervisor renders the monto simulation modal", () => {
+	expect(cobranzaModals).toContain("config={montoACobrarConfig}");
+});
+
+test("cobros supervisor renders the facturacion simulation modal", () => {
+	expect(cobranzaModals).toContain("config={facturacionConfig}");
+});
+
+test("roles without cobranza access do not render the monto modal", () => {
+	expect(source).toContain("{canAccessCobranzaReport && (");
+});
+
+test("administrative simulation modals remain admin-only", () => {
+	const adminSection = source.slice(source.indexOf("{isAdmin && ("));
+	expect(adminSection).toMatch(/config=\{coberturaConfig\}[\s\S]*config=\{comparativoConfig\}/);
+});

--- a/apps/crm/apps/web/src/routes/admin/reports/-tabs.test.ts
+++ b/apps/crm/apps/web/src/routes/admin/reports/-tabs.test.ts
@@ -1,0 +1,33 @@
+import { describe, expect, test } from "bun:test";
+import { getReportTabs } from "./-tabs";
+
+describe("getReportTabs", () => {
+	test("keeps the supervisor on authorized reports only", () => {
+		expect(
+			getReportTabs({
+				canAccessClosedCreditsReport: true,
+				canAccessCobranzaReport: true,
+				isAdmin: false,
+			}),
+		).toEqual({ tabs: ["creditos", "cobranza"], defaultTab: "creditos" });
+	});
+
+	test("keeps every existing report tab for admin", () => {
+		expect(
+			getReportTabs({
+				canAccessClosedCreditsReport: true,
+				canAccessCobranzaReport: true,
+				isAdmin: true,
+			}),
+		).toEqual({
+			tabs: [
+				"creditos",
+				"cobranza",
+				"inversiones",
+				"colocacion",
+				"proyeccion-liquidaciones",
+			],
+			defaultTab: "creditos",
+		});
+	});
+});

--- a/apps/crm/apps/web/src/routes/admin/reports/-tabs.ts
+++ b/apps/crm/apps/web/src/routes/admin/reports/-tabs.ts
@@ -1,0 +1,24 @@
+export type ReportTab =
+	| "creditos"
+	| "cobranza"
+	| "inversiones"
+	| "colocacion"
+	| "proyeccion-liquidaciones";
+
+export function getReportTabs({
+	canAccessClosedCreditsReport,
+	canAccessCobranzaReport,
+	isAdmin,
+}: {
+	canAccessClosedCreditsReport: boolean;
+	canAccessCobranzaReport: boolean;
+	isAdmin: boolean;
+}): { tabs: ReportTab[]; defaultTab: ReportTab } {
+	const tabs: ReportTab[] = [];
+	if (canAccessClosedCreditsReport) tabs.push("creditos");
+	if (canAccessCobranzaReport) tabs.push("cobranza");
+	if (isAdmin) {
+		tabs.push("inversiones", "colocacion", "proyeccion-liquidaciones");
+	}
+	return { tabs, defaultTab: tabs[0] ?? "cobranza" };
+}

--- a/apps/crm/apps/web/src/routes/admin/reports/index.tsx
+++ b/apps/crm/apps/web/src/routes/admin/reports/index.tsx
@@ -1090,6 +1090,22 @@ function RouteComponent() {
 								</>
 							)}
 						</TabsList>
+						{canAccessCobranzaReport && (
+							<>
+								<ScenarioModal
+									open={scenarioOpen === "monto"}
+									onOpenChange={(o) => setScenarioOpen(o ? "monto" : null)}
+									config={montoACobrarConfig}
+									baseData={montoCobrarData?.data}
+								/>
+								<ScenarioModal
+									open={scenarioOpen === "facturacion"}
+									onOpenChange={(o) => setScenarioOpen(o ? "facturacion" : null)}
+									config={facturacionConfig}
+									baseData={facturacionMesData}
+								/>
+							</>
+						)}
 						{canAccessClosedCreditsReport && (
 							<TabsContent value="creditos" className="space-y-6">
 								{creditosCerradosCard}
@@ -2710,18 +2726,6 @@ function RouteComponent() {
 						</Dialog>
 
 						{/* Modales de simulación de escenarios */}
-						<ScenarioModal
-							open={scenarioOpen === "monto"}
-							onOpenChange={(o) => setScenarioOpen(o ? "monto" : null)}
-							config={montoACobrarConfig}
-							baseData={montoCobrarData?.data}
-						/>
-						<ScenarioModal
-							open={scenarioOpen === "facturacion"}
-							onOpenChange={(o) => setScenarioOpen(o ? "facturacion" : null)}
-							config={facturacionConfig}
-							baseData={facturacionMesData}
-						/>
 						<ScenarioModal
 							open={scenarioOpen === "cobertura"}
 							onOpenChange={(o) => setScenarioOpen(o ? "cobertura" : null)}

--- a/apps/crm/apps/web/src/routes/admin/reports/index.tsx
+++ b/apps/crm/apps/web/src/routes/admin/reports/index.tsx
@@ -87,6 +87,7 @@ import {
 } from "@/lib/reports/scenario-configs";
 import { PERMISSIONS } from "@/lib/roles";
 import { Combobox } from "@/components/ui/combobox";
+import { getReportTabs } from "./-tabs";
 import { client, orpc, queryClient } from "@/utils/orpc";
 type SimulacionInversionistaResult = {
 	success: boolean;
@@ -565,7 +566,16 @@ function RouteComponent() {
 	const canAccessClosedCreditsReport = userRole
 		? PERMISSIONS.canAccessClosedCreditsReport(userRole)
 		: false;
-	const canAccessReports = isAdmin || canAccessClosedCreditsReport;
+	const canAccessCobranzaReport = userRole
+		? PERMISSIONS.canAccessCobranzaReport(userRole)
+		: false;
+	const canAccessReports =
+		isAdmin || canAccessClosedCreditsReport || canAccessCobranzaReport;
+	const reportTabs = getReportTabs({
+		canAccessClosedCreditsReport,
+		canAccessCobranzaReport,
+		isAdmin,
+	});
 
 	const dashboardData = useQuery({
 		...orpc.getDashboardExecutivo.queryOptions({
@@ -605,7 +615,7 @@ function RouteComponent() {
 				fechaFin: montoCobrarRange.fechaFin,
 			},
 		}),
-		enabled: isAdmin,
+		enabled: canAccessCobranzaReport,
 	});
 	const montoCobrarData = montoCobrarQuery.data as
 		| { data: MontoACobrarPeriodoRow[] }
@@ -615,7 +625,7 @@ function RouteComponent() {
 		...orpc.getFacturacionMes.queryOptions({
 			input: { mes: facturacionMes.mes, anio: facturacionMes.anio },
 		}),
-		enabled: isAdmin,
+		enabled: canAccessCobranzaReport,
 	});
 	const facturacionMesData = facturacionMesQuery.data as
 		| FacturacionMesResponse
@@ -1058,16 +1068,7 @@ function RouteComponent() {
 				</div>
 			</div>
 
-			{!isAdmin && canAccessClosedCreditsReport && creditosCerradosCard}
-
-			{isAdmin && (
-				<>
-					<Tabs
-						defaultValue={
-							canAccessClosedCreditsReport ? "creditos" : "cobranza"
-						}
-						className="space-y-6"
-					>
+			<Tabs defaultValue={reportTabs.defaultTab} className="space-y-6">
 						<TabsList>
 							{canAccessClosedCreditsReport && (
 								<TabsTrigger value="creditos">Créditos cerrados</TabsTrigger>
@@ -1076,18 +1077,26 @@ function RouteComponent() {
 							    secciones (TabsContent value="resumen" / "graficas") se
 							    conservan más abajo por si se quieren reutilizar; para
 							    volver a mostrarlas, reañadir aquí sus TabsTrigger. */}
-							<TabsTrigger value="cobranza">Cobranza</TabsTrigger>
-							<TabsTrigger value="inversiones">Inversiones</TabsTrigger>
-							<TabsTrigger value="colocacion">Colocación</TabsTrigger>
-							<TabsTrigger value="proyeccion-liquidaciones">
-								Proyección Liquidaciones
-							</TabsTrigger>
+							{canAccessCobranzaReport && (
+								<TabsTrigger value="cobranza">Cobranza</TabsTrigger>
+							)}
+							{isAdmin && (
+								<>
+									<TabsTrigger value="inversiones">Inversiones</TabsTrigger>
+									<TabsTrigger value="colocacion">Colocación</TabsTrigger>
+									<TabsTrigger value="proyeccion-liquidaciones">
+										Proyección Liquidaciones
+									</TabsTrigger>
+								</>
+							)}
 						</TabsList>
 						{canAccessClosedCreditsReport && (
 							<TabsContent value="creditos" className="space-y-6">
 								{creditosCerradosCard}
 							</TabsContent>
 						)}
+						{isAdmin && (
+							<>
 						<TabsContent value="resumen" className="space-y-6">
 							{/* Enlaces a otros reportes - TODO: Implementar rutas */}
 							<div className="grid gap-4 md:grid-cols-4">
@@ -1314,6 +1323,9 @@ function RouteComponent() {
 								</CardContent>
 							</Card>
 						</TabsContent>
+							</>
+						)}
+						{canAccessCobranzaReport && (
 						<TabsContent value="cobranza" className="space-y-6">
 							{/* Reporte: Monto a Cobrarse por Período */}
 							<Card>
@@ -1929,6 +1941,9 @@ function RouteComponent() {
 								</CardContent>
 							</Card>
 						</TabsContent>
+						)}
+						{isAdmin && (
+							<>
 						<TabsContent value="inversiones" className="space-y-6">
 							{/* Reporte: Flujo de Cuotas de Inversiones */}
 							<Card>
@@ -3476,9 +3491,9 @@ function RouteComponent() {
 								);
 							})()}
 						</TabsContent>
+							</>
+						)}
 					</Tabs>
-				</>
-			)}
 		</div>
 	);
 }


### PR DESCRIPTION
## Stack

**3 de 3** — depende de B y A.

- Predecesor/base: `feat/cartera-current-participation-split`
- Orden de merge: A → B → C

Este PR muestra únicamente el delta de autorización de Cobranza; incluye A y B en su historia por diseño.

## Resumen

- Permite a `cobros_supervisor` acceder solamente a **Créditos cerrados** y **Cobranza**.
- Mantiene Resumen, Gráficas, Inversiones, Colocación y Proyección bajo acceso administrativo.
- Protege `getDashboardExecutivo` con `adminProcedure`.
- Mantiene únicamente los dos endpoints de Cobranza autorizados para admin/supervisor.
- Rechaza otros roles tanto en UI como backend.

## Validación

- Roles, autorización backend y tabs UI: **9/9** pruebas, 24 assertions.
- Matriz de roles: PASS.
- `git diff --check`: PASS.
- Rebase sobre B: limpio y con patch-id semánticamente idéntico.
- Revisión independiente fail-closed: PASS.

## Límites

- Sin cambios de DB, migraciones, deploy ni auto-merge.
