### PR TITLE
feat(cobros): CB-010 — Reducción de recordatorios a clientes que pagan bien

### DIFF
--- a/apps/cartera-back/src/controllers/comportamientoPago.ts
+++ b/apps/cartera-back/src/controllers/comportamientoPago.ts
@@ -1,0 +1,183 @@
+import { db } from "../database";
+import { SQL_CARTERA_SCHEMA } from "../database/db/schema";
+import { sql } from "drizzle-orm";
+
+// ─────────────────────────────────────────────────────────────────────────────
+// CB-010 · Comportamiento de pago — racha de cuotas pagadas AL DÍA por crédito.
+// Solo lectura: el CRM lo consume con su job diario de elegibilidad para la
+// reducción de recordatorios premora (la tabla y el módulo del gerente viven
+// allá; cartera-back solo responde el dato de pago que solo existe aquí).
+//
+// "Al día" = una cuota YA VENCIDA cuyo pago cubriente entró en fecha:
+//   fecha_pago <= fecha_vencimiento.
+// "Cubriente" = mismo predicado que premora/procesarMoras (pago real,
+// validado, monto_aplicado > 0) — así las etiquetas de pagado no inflan la
+// racha con pagos falsos o sin plata.
+//
+// La RACHA es el número de cuotas ya vencidas pagadas al día contando desde la
+// más reciente (mayor numero_cuota) hacia atrás, hasta el primer atraso. Un
+// atraso = cuota vencida pagada TARDE o cuota vencida SIN pago cubriente (mora
+// hoy). Elegible (>=4) lo decide el CRM; aquí solo devolvemos la racha cruda.
+// ─────────────────────────────────────────────────────────────────────────────
+
+// Pago que realmente cubre una cuota (espejo de pagoCubriente en
+// cuotasProximas.ts / latefee.ts — mantener alineados). Dos formas del MISMO
+// predicado: la fecha (MIN, escalar) para clasificar al día vs tarde, y el
+// EXISTS (SELECT 1) para el NOT EXISTS de "cuota aún sin pagar".
+const filtroPagoCubriente = (cuotaIdCol: ReturnType<typeof sql.raw>) => sql`
+    pc.cuota_id = ${cuotaIdCol}
+    AND pc."paymentFalse" = false
+    AND pc.pagado = true
+    AND pc.validation_status IN ('validated', 'no_required')
+    AND COALESCE(pc.monto_aplicado, 0) > 0`;
+
+const pagoCubrienteFecha = (cuotaIdCol: ReturnType<typeof sql.raw>) => sql`
+  SELECT MIN(pc.fecha_pago::date)
+  FROM ${SQL_CARTERA_SCHEMA}.pagos_credito pc
+  WHERE ${filtroPagoCubriente(cuotaIdCol)}`;
+
+const pagoCubrienteExiste = (cuotaIdCol: ReturnType<typeof sql.raw>) => sql`
+  SELECT 1
+  FROM ${SQL_CARTERA_SCHEMA}.pagos_credito pc
+  WHERE ${filtroPagoCubriente(cuotaIdCol)}`;
+
+export interface ComportamientoPagoRow {
+  credito_id: number;
+  numero_credito_sifco: string;
+  racha: number;
+  ultima_cuota_evaluada: number;
+  total_vencidas: number;
+  // Datos del crédito para el módulo del gerente (nombre del titular, cuota
+  // mensual y próxima fecha de pago). El nombre SIEMPRE de cartera (usuarios),
+  // que lo tiene para TODO crédito — el CRM solo lo tiene si nació por su funnel.
+  cliente: string | null;
+  cuota_mensual: string;
+  proxima_fecha_pago: string | null;
+}
+
+export interface ComportamientoPagoResponse {
+  success: true;
+  total: number;
+  data: ComportamientoPagoRow[];
+  // Presentes solo cuando se pidió paginación (el job del CRM la usa para
+  // recorrer toda la cartera de a lotes). Sin per_page van todas las filas.
+  page?: number;
+  perPage?: number;
+  totalPages?: number;
+}
+
+export async function getComportamientoPago(
+  opts: { sifcos?: string[]; page?: number; perPage?: number } = {},
+): Promise<ComportamientoPagoResponse> {
+  const hoyGT = sql`(now() AT TIME ZONE 'America/Guatemala')::date`;
+
+  // Filtro opcional por SIFCO (pruebas quirúrgicas / recálculo puntual). Sin él
+  // se evalúa TODA la cartera activa (el job diario del CRM refresca todo).
+  const filtroSifco =
+    opts.sifcos && opts.sifcos.length > 0
+      ? sql`AND c.numero_credito_sifco = ANY(${opts.sifcos})`
+      : sql``;
+
+  // Paginación OPCIONAL (el job del CRM la usa: la cartera activa puede ser de
+  // miles). Sin per_page → todas las filas (una sola pasada, comportamiento
+  // clásico). COUNT(*) OVER() da el total exacto en la misma consulta.
+  const paginar = opts.perPage != null && opts.perPage > 0;
+  const page = Math.max(1, opts.page ?? 1);
+  const perPage = paginar ? (opts.perPage as number) : 0;
+  const offset = paginar ? (page - 1) * perPage : 0;
+  const limitOffset = paginar
+    ? sql`LIMIT ${perPage} OFFSET ${offset}`
+    : sql``;
+  const totalWindow = paginar
+    ? sql`, COUNT(*) OVER()::int AS _total`
+    : sql``;
+
+  const res = await db.execute<any>(sql`
+    WITH vencidas AS (
+      -- Cuotas YA vencidas (< hoy GT; la que vence hoy aún no cuenta) de
+      -- créditos ACTIVOS, con la fecha del pago cubriente más temprano.
+      SELECT
+        c.credito_id,
+        c.numero_credito_sifco,
+        cu.numero_cuota,
+        cu.fecha_vencimiento::date AS venc,
+        (${pagoCubrienteFecha(sql.raw("cu.cuota_id"))}) AS fecha_pago_cubriente
+      FROM ${SQL_CARTERA_SCHEMA}.cuotas_credito cu
+      INNER JOIN ${SQL_CARTERA_SCHEMA}.creditos c ON c.credito_id = cu.credito_id
+      WHERE cu.fecha_vencimiento::date < ${hoyGT}
+        AND c."statusCredit" = 'ACTIVO'
+        ${filtroSifco}
+    ),
+    clasificadas AS (
+      SELECT
+        credito_id,
+        numero_credito_sifco,
+        numero_cuota,
+        (fecha_pago_cubriente IS NOT NULL AND fecha_pago_cubriente <= venc)
+          AS al_dia
+      FROM vencidas
+    ),
+    -- La cuota vencida más RECIENTE (mayor numero_cuota) que NO está al día:
+    -- rompe la racha. Todo lo que esté por encima es al día por definición.
+    rotas AS (
+      SELECT credito_id, MAX(numero_cuota) AS ultima_rota
+      FROM clasificadas
+      WHERE al_dia = false
+      GROUP BY credito_id
+    ),
+    agg AS (
+      SELECT
+        cl.credito_id,
+        cl.numero_credito_sifco,
+        COUNT(*) FILTER (
+          WHERE cl.al_dia
+            AND (r.ultima_rota IS NULL OR cl.numero_cuota > r.ultima_rota)
+        )::int AS racha,
+        MAX(cl.numero_cuota)::int AS ultima_cuota_evaluada,
+        COUNT(*)::int AS total_vencidas
+      FROM clasificadas cl
+      LEFT JOIN rotas r ON r.credito_id = cl.credito_id
+      GROUP BY cl.credito_id, cl.numero_credito_sifco
+    )
+    SELECT
+      agg.credito_id,
+      agg.numero_credito_sifco,
+      agg.racha,
+      agg.ultima_cuota_evaluada,
+      agg.total_vencidas,
+      u.nombre AS cliente,
+      ROUND(c.cuota::numeric, 2)::text AS cuota_mensual,
+      -- Próxima fecha de pago = la cuota SIN pagar (sin pago cubriente) que
+      -- vence primero. Para un crédito al día es su siguiente cuota futura.
+      (SELECT MIN(cx.fecha_vencimiento::date)::text
+        FROM ${SQL_CARTERA_SCHEMA}.cuotas_credito cx
+        WHERE cx.credito_id = agg.credito_id
+          AND cx.pagado = false
+          AND NOT EXISTS (${pagoCubrienteExiste(sql.raw("cx.cuota_id"))})
+      ) AS proxima_fecha_pago
+      ${totalWindow}
+    FROM agg
+    INNER JOIN ${SQL_CARTERA_SCHEMA}.creditos c ON c.credito_id = agg.credito_id
+    INNER JOIN ${SQL_CARTERA_SCHEMA}.usuarios u ON u.usuario_id = c.usuario_id
+    ORDER BY agg.racha DESC, agg.numero_credito_sifco ASC
+    ${limitOffset}
+  `);
+
+  const rows = (res.rows as Array<ComportamientoPagoRow & { _total?: number }>) ?? [];
+
+  if (!paginar) {
+    return { success: true, total: rows.length, data: rows };
+  }
+
+  const total = Number(rows[0]?._total ?? 0);
+  // `_total` es de la ventana de conteo, no del modelo — se quita de cada fila.
+  const data = rows.map(({ _total, ...row }) => row);
+  return {
+    success: true,
+    total,
+    page,
+    perPage,
+    totalPages: Math.max(1, Math.ceil(total / perPage)),
+    data,
+  };
+}

--- a/apps/cartera-back/src/controllers/comportamientoPago.ts
+++ b/apps/cartera-back/src/controllers/comportamientoPago.ts
@@ -47,8 +47,12 @@ const filtroPagoCubriente = (cuotaIdCol: ReturnType<typeof sql.raw>) => sql`
 // primer abono parcial (quizá anterior al vencimiento) y clasificaría "al día"
 // una cuota que en realidad se terminó de pagar TARDE. El MAX es la fecha real
 // de completado y es la dirección conservadora para la elegibilidad.
+// fecha_pago es timestamp UTC naive → se convierte al DÍA GT antes del ::date
+// (review Codex P2), mismo patrón que payments.ts/reports.ts y consistente con
+// hoyGT; si no, un pago de la noche del último día de gracia (GT) caería al día
+// UTC siguiente y rompería la racha por error.
 const pagoCubrienteFecha = (cuotaIdCol: ReturnType<typeof sql.raw>) => sql`
-  SELECT MAX(pc.fecha_pago::date)
+  SELECT MAX((pc.fecha_pago AT TIME ZONE 'UTC' AT TIME ZONE 'America/Guatemala')::date)
   FROM ${SQL_CARTERA_SCHEMA}.pagos_credito pc
   WHERE ${filtroPagoCubriente(cuotaIdCol)}`;
 

--- a/apps/cartera-back/src/controllers/comportamientoPago.ts
+++ b/apps/cartera-back/src/controllers/comportamientoPago.ts
@@ -8,17 +8,27 @@ import { sql } from "drizzle-orm";
 // reducción de recordatorios premora (la tabla y el módulo del gerente viven
 // allá; cartera-back solo responde el dato de pago que solo existe aquí).
 //
-// "Al día" = una cuota YA VENCIDA cuyo pago cubriente entró en fecha:
-//   fecha_pago <= fecha_vencimiento.
+// "Al día" = una cuota cuyo pago cubriente entró DENTRO de la gracia:
+//   fecha_pago <= fecha_vencimiento + DIAS_GRACIA.
 // "Cubriente" = mismo predicado que premora/procesarMoras (pago real,
 // validado, monto_aplicado > 0) — así las etiquetas de pagado no inflan la
 // racha con pagos falsos o sin plata.
 //
-// La RACHA es el número de cuotas ya vencidas pagadas al día contando desde la
+// GRACIA (confirmada por negocio): 2 días. Una cuota solo se EVALÚA una vez
+// pasada su ventana de gracia (venc + 2 < hoy); dentro de la gracia es como una
+// cuota aún no vencida (no cuenta ni rompe), así un cliente puntual no se cae de
+// elegibles por ir 1 día pasado su vencimiento.
+//
+// La RACHA es el número de cuotas ya evaluadas pagadas al día contando desde la
 // más reciente (mayor numero_cuota) hacia atrás, hasta el primer atraso. Un
-// atraso = cuota vencida pagada TARDE o cuota vencida SIN pago cubriente (mora
-// hoy). Elegible (>=4) lo decide el CRM; aquí solo devolvemos la racha cruda.
+// atraso = cuota pagada TARDE (después de la gracia) o cuota SIN pago cubriente
+// ya pasada la gracia (mora). Elegible (>=4) lo decide el CRM; aquí devolvemos
+// la racha cruda.
 // ─────────────────────────────────────────────────────────────────────────────
+
+// Días de gracia después del vencimiento que todavía cuentan como "al día".
+// Confirmado por negocio (Gerente de Cobros). Cambiar aquí si se ajusta.
+const DIAS_GRACIA = 2;
 
 // Pago que realmente cubre una cuota (espejo de pagoCubriente en
 // cuotasProximas.ts / latefee.ts — mantener alineados). Dos formas del MISMO
@@ -94,8 +104,10 @@ export async function getComportamientoPago(
 
   const res = await db.execute<any>(sql`
     WITH vencidas AS (
-      -- Cuotas YA vencidas (< hoy GT; la que vence hoy aún no cuenta) de
-      -- créditos ACTIVOS, con la fecha del pago cubriente más temprano.
+      -- Cuotas ya pasadas de su GRACIA (venc + DIAS_GRACIA < hoy GT) de créditos
+      -- ACTIVOS, con la fecha del pago cubriente más temprano. Una cuota dentro
+      -- de su gracia (o que vence hoy/futura) aún no se evalúa: no cuenta ni
+      -- rompe la racha.
       SELECT
         c.credito_id,
         c.numero_credito_sifco,
@@ -104,7 +116,7 @@ export async function getComportamientoPago(
         (${pagoCubrienteFecha(sql.raw("cu.cuota_id"))}) AS fecha_pago_cubriente
       FROM ${SQL_CARTERA_SCHEMA}.cuotas_credito cu
       INNER JOIN ${SQL_CARTERA_SCHEMA}.creditos c ON c.credito_id = cu.credito_id
-      WHERE cu.fecha_vencimiento::date < ${hoyGT}
+      WHERE cu.fecha_vencimiento::date < (${hoyGT} - ${DIAS_GRACIA})
         AND c."statusCredit" = 'ACTIVO'
         ${filtroSifco}
     ),
@@ -113,7 +125,9 @@ export async function getComportamientoPago(
         credito_id,
         numero_credito_sifco,
         numero_cuota,
-        (fecha_pago_cubriente IS NOT NULL AND fecha_pago_cubriente <= venc)
+        -- Al día = pago cubriente dentro de la gracia (venc + DIAS_GRACIA).
+        (fecha_pago_cubriente IS NOT NULL
+          AND fecha_pago_cubriente <= venc + ${DIAS_GRACIA})
           AS al_dia
       FROM vencidas
     ),

--- a/apps/cartera-back/src/controllers/comportamientoPago.ts
+++ b/apps/cartera-back/src/controllers/comportamientoPago.ts
@@ -32,7 +32,7 @@ const DIAS_GRACIA = 2;
 
 // Pago que realmente cubre una cuota (espejo de pagoCubriente en
 // cuotasProximas.ts / latefee.ts — mantener alineados). Dos formas del MISMO
-// predicado: la fecha (MIN, escalar) para clasificar al día vs tarde, y el
+// predicado: la fecha de COMPLETADO (para clasificar al día vs tarde) y el
 // EXISTS (SELECT 1) para el NOT EXISTS de "cuota aún sin pagar".
 const filtroPagoCubriente = (cuotaIdCol: ReturnType<typeof sql.raw>) => sql`
     pc.cuota_id = ${cuotaIdCol}
@@ -41,8 +41,14 @@ const filtroPagoCubriente = (cuotaIdCol: ReturnType<typeof sql.raw>) => sql`
     AND pc.validation_status IN ('validated', 'no_required')
     AND COALESCE(pc.monto_aplicado, 0) > 0`;
 
+// Fecha en que la cuota quedó COMPLETADA = el ÚLTIMO pago cubriente (MAX), no el
+// primero (review Codex P2). Cuando una cuota se paga en abonos, al completarse
+// el flujo marca TODAS sus filas de pago como pagado=true; un MIN tomaría el
+// primer abono parcial (quizá anterior al vencimiento) y clasificaría "al día"
+// una cuota que en realidad se terminó de pagar TARDE. El MAX es la fecha real
+// de completado y es la dirección conservadora para la elegibilidad.
 const pagoCubrienteFecha = (cuotaIdCol: ReturnType<typeof sql.raw>) => sql`
-  SELECT MIN(pc.fecha_pago::date)
+  SELECT MAX(pc.fecha_pago::date)
   FROM ${SQL_CARTERA_SCHEMA}.pagos_credito pc
   WHERE ${filtroPagoCubriente(cuotaIdCol)}`;
 
@@ -105,7 +111,7 @@ export async function getComportamientoPago(
   const res = await db.execute<any>(sql`
     WITH vencidas AS (
       -- Cuotas ya pasadas de su GRACIA (venc + DIAS_GRACIA < hoy GT) de créditos
-      -- ACTIVOS, con la fecha del pago cubriente más temprano. Una cuota dentro
+      -- ACTIVOS, con la fecha de COMPLETADO (último pago cubriente). Una cuota dentro
       -- de su gracia (o que vence hoy/futura) aún no se evalúa: no cuenta ni
       -- rompe la racha.
       SELECT

--- a/apps/cartera-back/src/routers/cuotas.ts
+++ b/apps/cartera-back/src/routers/cuotas.ts
@@ -1,6 +1,7 @@
 // routes/cuotas.ts — COBROS-02 · Premora (CC2-11): cuotas próximas a vencer.
 import { Elysia, t } from "elysia";
 import { authMiddleware } from "./midleware";
+import { getComportamientoPago } from "../controllers/comportamientoPago";
 import { getCuotasProximasVencer } from "../controllers/cuotasProximas";
 
 export const cuotasRouter = new Elysia()
@@ -127,6 +128,74 @@ export const cuotasRouter = new Elysia()
         solo_al_dia: t.Optional(t.String()),
         buckets: t.Optional(t.String()),
         asesor_id: t.Optional(t.String()),
+        page: t.Optional(t.String()),
+        per_page: t.Optional(t.String()),
+      }),
+    },
+  )
+
+  // CB-010 · Comportamiento de pago — racha de cuotas pagadas AL DÍA por
+  // crédito. Lo consume el job diario de elegibilidad del CRM (reducción de
+  // recordatorios premora). Sin gate de rol (solo autenticación), igual que
+  // /cuotas/proximas-vencer: la cuenta de servicio del CRM debe poder llamarlo.
+  .get(
+    "/cuotas/comportamiento-pago",
+    async ({ query, set, user }: any) => {
+      if (!user) {
+        set.status = 401;
+        return { success: false, message: "[ERROR] No autenticado" };
+      }
+      try {
+        // sifcos: CSV opcional para recálculo puntual. Vacío = toda la cartera
+        // activa (el job refresca todo). Cada token es un número de crédito.
+        let sifcos: string[] | undefined;
+        if (query.sifcos != null && String(query.sifcos).trim() !== "") {
+          sifcos = String(query.sifcos)
+            .split(",")
+            .map((s: string) => s.trim())
+            .filter(Boolean);
+          if (sifcos.length === 0) sifcos = undefined;
+        }
+        // page / per_page: paginación OPCIONAL (el job del CRM recorre toda la
+        // cartera de a lotes). per_page se topa a 1000. Sin ellos → todas las
+        // filas de un jalón (compatibilidad con un consumidor no paginado).
+        let perPage: number | undefined;
+        if (query.per_page != null && String(query.per_page).trim() !== "") {
+          const s = String(query.per_page).trim();
+          if (!/^\d{1,4}$/.test(s) || Number(s) < 1 || Number(s) > 1000) {
+            set.status = 400;
+            return {
+              success: false,
+              message: "[ERROR] per_page inválido (entero 1-1000)",
+            };
+          }
+          perPage = Number(s);
+        }
+        let page: number | undefined;
+        if (query.page != null && String(query.page).trim() !== "") {
+          const s = String(query.page).trim();
+          if (!/^\d{1,6}$/.test(s) || Number(s) < 1) {
+            set.status = 400;
+            return {
+              success: false,
+              message: "[ERROR] page inválido (entero positivo)",
+            };
+          }
+          page = Number(s);
+        }
+        return await getComportamientoPago({ sifcos, page, perPage });
+      } catch (err) {
+        set.status = 500;
+        return {
+          success: false,
+          message: "[ERROR] No se pudo obtener el comportamiento de pago",
+          error: String(err),
+        };
+      }
+    },
+    {
+      query: t.Object({
+        sifcos: t.Optional(t.String()),
         page: t.Optional(t.String()),
         per_page: t.Optional(t.String()),
       }),

--- a/apps/crm/apps/server/src/db/migrations/0030_cb010_premora_reduccion.sql
+++ b/apps/crm/apps/server/src/db/migrations/0030_cb010_premora_reduccion.sql
@@ -1,0 +1,54 @@
+-- 0030: CB-010 — Reducción de recordatorios premora a clientes que pagan bien.
+-- Espejo exacto del schema drizzle `src/db/schema/premora-reduccion.ts`.
+-- Idempotente: seguro de re-correr. La corre el usuario (dev y luego prod).
+
+-- 1. Foto del comportamiento de pago por crédito (refrescada por job diario).
+CREATE TABLE IF NOT EXISTS public.premora_pago_tracking (
+  id uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+  numero_credito_sifco text NOT NULL,
+  credito_id integer,
+  cliente text,
+  cuota_mensual text,
+  proxima_fecha_pago text,
+  cuotas_al_dia_consecutivas integer NOT NULL DEFAULT 0,
+  ultima_cuota_evaluada integer,
+  total_vencidas integer,
+  elegible boolean NOT NULL DEFAULT false,
+  calculado_at timestamp NOT NULL DEFAULT now(),
+  created_at timestamp NOT NULL DEFAULT now(),
+  updated_at timestamp NOT NULL DEFAULT now()
+);
+
+-- Columnas cacheadas del crédito (nombre de cartera, cuota mensual, próximo
+-- pago). Como ALTER ADD COLUMN IF NOT EXISTS para que esta migración también
+-- actualice una tabla ya creada por una versión previa de este mismo archivo.
+ALTER TABLE public.premora_pago_tracking ADD COLUMN IF NOT EXISTS cliente text;
+ALTER TABLE public.premora_pago_tracking ADD COLUMN IF NOT EXISTS cuota_mensual text;
+ALTER TABLE public.premora_pago_tracking ADD COLUMN IF NOT EXISTS proxima_fecha_pago text;
+
+-- Un crédito = una fila (el job hace upsert por SIFCO).
+CREATE UNIQUE INDEX IF NOT EXISTS uq_premora_pago_tracking_sifco
+  ON public.premora_pago_tracking (numero_credito_sifco);
+CREATE INDEX IF NOT EXISTS idx_premora_pago_tracking_elegible
+  ON public.premora_pago_tracking (elegible);
+
+-- 2. Reducción que el Gerente aplicó a un crédito (pasos del embudo quitados).
+CREATE TABLE IF NOT EXISTS public.premora_reduccion_config (
+  id uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+  numero_credito_sifco text NOT NULL,
+  pasos_removidos integer[] NOT NULL,
+  activo boolean NOT NULL DEFAULT true,
+  configurado_por text NOT NULL REFERENCES public."user"(id),
+  configurado_at timestamp NOT NULL DEFAULT now(),
+  origen text NOT NULL DEFAULT 'manual',
+  revocado_at timestamp,
+  revocado_motivo text,
+  created_at timestamp NOT NULL DEFAULT now(),
+  updated_at timestamp NOT NULL DEFAULT now()
+);
+
+-- Un crédito = una config (upsert; al revocar se apaga `activo`, no se borra).
+CREATE UNIQUE INDEX IF NOT EXISTS uq_premora_reduccion_config_sifco
+  ON public.premora_reduccion_config (numero_credito_sifco);
+CREATE INDEX IF NOT EXISTS idx_premora_reduccion_config_activo
+  ON public.premora_reduccion_config (activo);

--- a/apps/crm/apps/server/src/db/schema/index.ts
+++ b/apps/crm/apps/server/src/db/schema/index.ts
@@ -19,6 +19,7 @@ export * from "./miniagent-credentials";
 export * from "./notes";
 export * from "./notifications";
 export * from "./otp";
+export * from "./premora-reduccion";
 export * from "./quotations";
 export * from "./recordatorios-premora";
 export * from "./renap";

--- a/apps/crm/apps/server/src/db/schema/premora-reduccion.ts
+++ b/apps/crm/apps/server/src/db/schema/premora-reduccion.ts
@@ -1,0 +1,141 @@
+/**
+ * CB-010 — Reducción de recordatorios premora a clientes que pagan bien.
+ *
+ * Dos tablas que viven en el CRM (aquí se orquesta el funnel premora y el
+ * Gerente de Cobros es un rol del CRM):
+ *
+ *  1. `premora_pago_tracking`: la FOTO del comportamiento de pago de cada
+ *     crédito, refrescada por un job diario contra cartera-back. Responde
+ *     "¿este crédito paga bien?" = racha de cuotas consecutivas pagadas AL DÍA
+ *     (fecha_pago <= fecha_vencimiento). Elegible = racha >= 4 (≈4 meses).
+ *
+ *  2. `premora_reduccion_config`: lo que el Gerente APLICA manualmente sobre un
+ *     crédito elegible — qué pasos del embudo (D-5/D-3/D-1) se le quitan. D-0
+ *     NUNCA se quita (monitoreo preventivo). El job de recordatorios lee esta
+ *     tabla y salta los pasos configurados. El sistema propone (tracking); el
+ *     humano decide (config).
+ *
+ * El puente entre ambas y cartera es `numero_credito_sifco` (mismo criterio que
+ * el resto de cobros; sin FK dura porque los datos de pago viven en otra DB).
+ */
+
+import { relations } from "drizzle-orm";
+import {
+	boolean,
+	index,
+	integer,
+	pgTable,
+	text,
+	timestamp,
+	uniqueIndex,
+	uuid,
+} from "drizzle-orm/pg-core";
+import { user } from "./auth";
+
+/**
+ * Comportamiento de pago por crédito (una fila por crédito, upsert del job
+ * diario). `cuotas_al_dia_consecutivas` es la racha de cuotas ya vencidas
+ * pagadas al día contando desde la más reciente hacia atrás; `elegible` es
+ * simplemente `racha >= 4`, materializado para no recalcular en cada consulta
+ * del módulo del gerente.
+ */
+export const premoraPagoTracking = pgTable(
+	"premora_pago_tracking",
+	{
+		id: uuid("id").primaryKey().defaultRandom(),
+
+		numeroCreditoSifco: text("numero_credito_sifco").notNull(),
+		// credito_id de cartera-back (sin FK dura, otra DB) — para trazar.
+		creditoId: integer("credito_id"),
+
+		// Datos del crédito cacheados desde cartera (para el módulo del gerente
+		// sin llamar a cartera en cada consulta). El NOMBRE viene de cartera
+		// (usuarios), completo para todo crédito. Se refrescan con el job diario.
+		cliente: text("cliente"),
+		cuotaMensual: text("cuota_mensual"),
+		proximaFechaPago: text("proxima_fecha_pago"), // YYYY-MM-DD
+
+		// Racha de cuotas ya vencidas pagadas AL DÍA (fecha_pago <= vencimiento),
+		// contadas desde la más reciente hacia atrás hasta el primer atraso.
+		cuotasAlDiaConsecutivas: integer("cuotas_al_dia_consecutivas")
+			.notNull()
+			.default(0),
+		// numero_cuota más alto ya vencido que se evaluó (para depurar la foto).
+		ultimaCuotaEvaluada: integer("ultima_cuota_evaluada"),
+		// Total de cuotas ya vencidas consideradas en el cálculo.
+		totalVencidas: integer("total_vencidas"),
+
+		// racha >= 4. Materializado: el módulo del gerente filtra por esta columna.
+		elegible: boolean("elegible").notNull().default(false),
+
+		// Cuándo corrió el job que dejó esta foto.
+		calculadoAt: timestamp("calculado_at").notNull().defaultNow(),
+
+		createdAt: timestamp("created_at").notNull().defaultNow(),
+		updatedAt: timestamp("updated_at").notNull().defaultNow(),
+	},
+	(t) => [
+		uniqueIndex("uq_premora_pago_tracking_sifco").on(t.numeroCreditoSifco),
+		index("idx_premora_pago_tracking_elegible").on(t.elegible),
+	],
+);
+
+/**
+ * Reducción de recordatorios que el Gerente aplicó a un crédito. Una fila por
+ * crédito (upsert): al reconfigurar se actualiza, al revocar se apaga
+ * `activo=false` conservando la fila como historial.
+ *
+ * `pasos_removidos` guarda los DÍAS exactos quitados (subconjunto de {5,3,1}),
+ * NO un conteo, para que el job de recordatorios sepa cuáles saltar. D-0 jamás
+ * entra aquí (se valida en el endpoint).
+ */
+export const premoraReduccionConfig = pgTable(
+	"premora_reduccion_config",
+	{
+		id: uuid("id").primaryKey().defaultRandom(),
+
+		numeroCreditoSifco: text("numero_credito_sifco").notNull(),
+
+		// Días del embudo que NO se envían (subconjunto de {5,3,1}; máx 2).
+		pasosRemovidos: integer("pasos_removidos").array().notNull(),
+
+		activo: boolean("activo").notNull().default(true),
+
+		// Quién y cuándo configuró (el gerente). Para auto-revoke el origen es
+		// 'auto' y configuradoPor queda con el usuario sistema del job.
+		configuradoPor: text("configurado_por")
+			.notNull()
+			.references(() => user.id),
+		configuradoAt: timestamp("configurado_at").notNull().defaultNow(),
+		// 'manual' (gerente) | 'auto' (nunca se crea auto, solo se revoca auto).
+		origen: text("origen").notNull().default("manual"),
+
+		// Auto-revoke: cuándo y por qué se apagó (motivo 'auto' = dejó de pagar
+		// bien; 'manual' = el gerente lo quitó).
+		revocadoAt: timestamp("revocado_at"),
+		revocadoMotivo: text("revocado_motivo"),
+
+		createdAt: timestamp("created_at").notNull().defaultNow(),
+		updatedAt: timestamp("updated_at").notNull().defaultNow(),
+	},
+	(t) => [
+		uniqueIndex("uq_premora_reduccion_config_sifco").on(t.numeroCreditoSifco),
+		index("idx_premora_reduccion_config_activo").on(t.activo),
+	],
+);
+
+export const premoraReduccionConfigRelations = relations(
+	premoraReduccionConfig,
+	({ one }) => ({
+		configurador: one(user, {
+			fields: [premoraReduccionConfig.configuradoPor],
+			references: [user.id],
+		}),
+	}),
+);
+
+export type PremoraPagoTracking = typeof premoraPagoTracking.$inferSelect;
+export type NewPremoraPagoTracking = typeof premoraPagoTracking.$inferInsert;
+export type PremoraReduccionConfig = typeof premoraReduccionConfig.$inferSelect;
+export type NewPremoraReduccionConfig =
+	typeof premoraReduccionConfig.$inferInsert;

--- a/apps/crm/apps/server/src/index.ts
+++ b/apps/crm/apps/server/src/index.ts
@@ -1315,9 +1315,6 @@ function scheduleAtPremoraGT() {
 	}, next.getTime() - now.getTime());
 }
 scheduleAtPremoraGT();
-setTimeout(() => {
-	sendPremoraReminders().catch(console.error);
-}, 15_000);
 
 // CB-010: elegibilidad de la reducción de recordatorios, diario a las 7:00 GT
 // (= 13:00 UTC) — UNA HORA ANTES del funnel premora, para que la foto de "paga
@@ -1335,9 +1332,18 @@ function scheduleAtElegibilidadGT() {
 	}, next.getTime() - now.getTime());
 }
 scheduleAtElegibilidadGT();
-setTimeout(() => {
-	refreshPremoraElegibilidad().catch(console.error);
-}, 10_000);
+
+// Recuperación al boot (deploy tardío): la elegibilidad se refresca ANTES del
+// envío premora y este ESPERA a que termine (review Codex P2). En el path
+// diario no se solapan (07:00 vs 08:00), pero en el boot ambos se disparan
+// juntos; si premora corriera primero leería reducciones stale y saltaría
+// D-5/D-3/D-1 de un crédito que ya debía auto-revocarse (el WhatsApp perdido no
+// se recupera después). Premora es idempotente (claims), así que re-correr al
+// boot no duplica mensajes.
+setTimeout(async () => {
+	await refreshPremoraElegibilidad().catch(console.error);
+	await sendPremoraReminders().catch(console.error);
+}, 15_000);
 
 // COBROS-02: alertas de cobros con propósito (cliente_subido + sin_contacto_3d),
 // diario a las 8:00 GT — DESPUÉS de que la subida de bucket de medianoche ya

--- a/apps/crm/apps/server/src/index.ts
+++ b/apps/crm/apps/server/src/index.ts
@@ -52,6 +52,7 @@ import { investmentsRouter } from "./routers/investments";
 import externalContractsRouter from "./routes/external-contracts";
 import { checkCobrosAlertas } from "./services/check-cobros-alertas";
 import { checkPromesasPago } from "./services/check-promesas-pago";
+import { refreshPremoraElegibilidad } from "./services/refresh-premora-elegibilidad";
 import { sendPremoraReminders } from "./services/send-premora-reminders";
 
 const app = new Hono();
@@ -1260,6 +1261,26 @@ app.post("/api/premora/run", async (c) => {
 	});
 });
 
+// CB-010: corrida MANUAL del job de elegibilidad de la reducción de
+// recordatorios (refresca la foto de "paga bien" desde cartera y hace el
+// auto-revoke). Mismo gate que premora (admin/cobros_supervisor, POST con
+// Origin validado). Útil para repoblar el tracking sin reiniciar el server.
+app.post("/api/premora/elegibilidad/run", async (c) => {
+	if (!esOrigenConfiable(c.req.header("origin"))) {
+		return c.json({ error: "Origen no permitido" }, 403);
+	}
+	const context = await createContext({ context: c });
+	if (!context.session?.user?.id) {
+		return c.json({ error: "No autorizado" }, 401);
+	}
+	const userRole = context.session.user.role;
+	if (!userRole || !PERMISSIONS.canAssignCobros(userRole)) {
+		return c.json({ error: "No tienes permiso para correr este job" }, 403);
+	}
+	const resumen = await refreshPremoraElegibilidad();
+	return c.json({ success: true, resumen });
+});
+
 // Job periódico de notificaciones de cobros (cada hora)
 setInterval(
 	async () => {
@@ -1297,6 +1318,26 @@ scheduleAtPremoraGT();
 setTimeout(() => {
 	sendPremoraReminders().catch(console.error);
 }, 15_000);
+
+// CB-010: elegibilidad de la reducción de recordatorios, diario a las 7:00 GT
+// (= 13:00 UTC) — UNA HORA ANTES del funnel premora, para que la foto de "paga
+// bien" y el auto-revoke queden frescos antes de que se decidan los envíos del
+// día. Idempotente (upsert de la foto + revoca solo configs ya inactivas por
+// segunda vez no reactiva nada), así que el run de boot recupera sin efectos.
+function scheduleAtElegibilidadGT() {
+	const now = new Date();
+	const next = new Date();
+	next.setUTCHours(13, 0, 0, 0); // 07:00 GT
+	if (next <= now) next.setUTCDate(next.getUTCDate() + 1);
+	setTimeout(async () => {
+		await refreshPremoraElegibilidad().catch(console.error);
+		scheduleAtElegibilidadGT();
+	}, next.getTime() - now.getTime());
+}
+scheduleAtElegibilidadGT();
+setTimeout(() => {
+	refreshPremoraElegibilidad().catch(console.error);
+}, 10_000);
 
 // COBROS-02: alertas de cobros con propósito (cliente_subido + sin_contacto_3d),
 // diario a las 8:00 GT — DESPUÉS de que la subida de bucket de medianoche ya

--- a/apps/crm/apps/server/src/routers/index.ts
+++ b/apps/crm/apps/server/src/routers/index.ts
@@ -20,6 +20,7 @@ import { messagingRouter } from "./messaging";
 import { miniagentRouter } from "./miniagent";
 import { notesRouter } from "./notes";
 import { notificationsRouter } from "./notifications";
+import { premoraReduccionRouter } from "./premora-reduccion";
 import { quotationsRouter } from "./quotations";
 import { reportesCarteraRouter } from "./reportes-cartera";
 import * as reportsRouter from "./reports";
@@ -194,6 +195,16 @@ export const cobrosAppRouter = {
 	getDescuentosCRM: cobrosRouter.getDescuentosCRM,
 	getCierreDiarioPorRango: cobrosRouter.getCierreDiarioPorRango,
 	getDetalleCierrePorAsesor: cobrosRouter.getDetalleCierrePorAsesor,
+
+	// CB-010: reducción de recordatorios premora (módulo del Gerente de Cobros)
+	getCreditosElegiblesReduccion:
+		premoraReduccionRouter.getCreditosElegiblesReduccion,
+	getReduccionesConfiguradas: premoraReduccionRouter.getReduccionesConfiguradas,
+	getReduccionesAutoRevocadas:
+		premoraReduccionRouter.getReduccionesAutoRevocadas,
+	configurarReduccion: premoraReduccionRouter.configurarReduccion,
+	revocarReduccion: premoraReduccionRouter.revocarReduccion,
+	recalcularElegibilidad: premoraReduccionRouter.recalcularElegibilidad,
 
 	// Seguimientos programados
 	createSeguimiento: seguimientosRouter.createSeguimiento,

--- a/apps/crm/apps/server/src/routers/premora-reduccion.ts
+++ b/apps/crm/apps/server/src/routers/premora-reduccion.ts
@@ -1,0 +1,269 @@
+/**
+ * CB-010 — Módulo del Gerente de Cobros: reducción de recordatorios premora.
+ *
+ * El sistema PROPONE (tracking `elegible = racha >= 4`); el Gerente APLICA
+ * manualmente qué pasos del embudo (D-5/D-3/D-1) quitarle a cada crédito. D-0
+ * nunca se quita (monitoreo preventivo). El auto-revoke lo maneja el job diario
+ * (refresh-premora-elegibilidad.ts), no estos endpoints.
+ *
+ * Todo gateado a `cobrosSupervisorProcedure` (= admin | cobros_supervisor, el
+ * Gerente de Cobros).
+ */
+
+import { ORPCError } from "@orpc/server";
+import { and, desc, eq, inArray, sql } from "drizzle-orm";
+import { z } from "zod";
+import { db } from "../db";
+import { user } from "../db/schema/auth";
+import {
+	premoraPagoTracking,
+	premoraReduccionConfig,
+} from "../db/schema/premora-reduccion";
+import { cobrosSupervisorProcedure } from "../lib/orpc";
+import { refreshPremoraElegibilidad } from "../services/refresh-premora-elegibilidad";
+
+// Pasos del embudo que el gerente PUEDE quitar. D-0 (0) queda excluido a
+// propósito: es el monitoreo preventivo que nunca se retira.
+const PASOS_QUITABLES = [5, 3, 1] as const;
+const MAX_PASOS_QUITABLES = 2;
+
+const pasosSchema = z
+	.array(z.number().int())
+	.min(1, "Debes quitar al menos un recordatorio")
+	.max(MAX_PASOS_QUITABLES, `Máximo ${MAX_PASOS_QUITABLES} recordatorios`)
+	.transform((arr) => [...new Set(arr)])
+	.refine(
+		(arr) =>
+			arr.every((d) => (PASOS_QUITABLES as readonly number[]).includes(d)),
+		{ message: "Solo se pueden quitar D-5, D-3 o D-1 (D-0 nunca se quita)" },
+	);
+
+// Datos del crédito cacheados en el tracking (nombre de cartera, cuota mensual,
+// próximo pago) — se refrescan con el job diario, no se consulta cartera aquí.
+const datosCredito = {
+	cliente: premoraPagoTracking.cliente,
+	cuotaMensual: premoraPagoTracking.cuotaMensual,
+	proximaFechaPago: premoraPagoTracking.proximaFechaPago,
+};
+
+export const premoraReduccionRouter = {
+	// Elegibles SIN reducción activa: los que el gerente puede configurar.
+	getCreditosElegiblesReduccion: cobrosSupervisorProcedure.handler(async () => {
+		try {
+			const cfgActiva = db
+				.select({ sifco: premoraReduccionConfig.numeroCreditoSifco })
+				.from(premoraReduccionConfig)
+				.where(eq(premoraReduccionConfig.activo, true));
+
+			const creditos = await db
+				.select({
+					numeroCreditoSifco: premoraPagoTracking.numeroCreditoSifco,
+					creditoId: premoraPagoTracking.creditoId,
+					racha: premoraPagoTracking.cuotasAlDiaConsecutivas,
+					ultimaCuotaEvaluada: premoraPagoTracking.ultimaCuotaEvaluada,
+					calculadoAt: premoraPagoTracking.calculadoAt,
+					...datosCredito,
+				})
+				.from(premoraPagoTracking)
+				.where(
+					and(
+						eq(premoraPagoTracking.elegible, true),
+						sql`${premoraPagoTracking.numeroCreditoSifco} NOT IN (${cfgActiva})`,
+					),
+				)
+				.orderBy(desc(premoraPagoTracking.cuotasAlDiaConsecutivas));
+
+			return { success: true, creditos };
+		} catch (error) {
+			console.error("[getCreditosElegiblesReduccion] Error:", error);
+			throw new ORPCError("INTERNAL_SERVER_ERROR", {
+				message: "No se pudieron obtener los créditos elegibles",
+			});
+		}
+	}),
+
+	// Reducciones ACTIVAS (configuradas por el gerente): ver / editar / revocar.
+	getReduccionesConfiguradas: cobrosSupervisorProcedure.handler(async () => {
+		try {
+			const reducciones = await db
+				.select({
+					numeroCreditoSifco: premoraReduccionConfig.numeroCreditoSifco,
+					pasosRemovidos: premoraReduccionConfig.pasosRemovidos,
+					configuradoAt: premoraReduccionConfig.configuradoAt,
+					configuradoPorNombre: user.name,
+					racha: premoraPagoTracking.cuotasAlDiaConsecutivas,
+					elegible: premoraPagoTracking.elegible,
+					...datosCredito,
+				})
+				.from(premoraReduccionConfig)
+				.leftJoin(user, eq(premoraReduccionConfig.configuradoPor, user.id))
+				.leftJoin(
+					premoraPagoTracking,
+					eq(
+						premoraReduccionConfig.numeroCreditoSifco,
+						premoraPagoTracking.numeroCreditoSifco,
+					),
+				)
+				.where(eq(premoraReduccionConfig.activo, true))
+				.orderBy(desc(premoraReduccionConfig.configuradoAt));
+
+			return { success: true, reducciones };
+		} catch (error) {
+			console.error("[getReduccionesConfiguradas] Error:", error);
+			throw new ORPCError("INTERNAL_SERVER_ERROR", {
+				message: "No se pudieron obtener las reducciones configuradas",
+			});
+		}
+	}),
+
+	// Historial de reducciones RETIRADAS por el sistema (dejaron de pagar bien).
+	getReduccionesAutoRevocadas: cobrosSupervisorProcedure.handler(async () => {
+		try {
+			const revocadas = await db
+				.select({
+					numeroCreditoSifco: premoraReduccionConfig.numeroCreditoSifco,
+					pasosRemovidos: premoraReduccionConfig.pasosRemovidos,
+					revocadoAt: premoraReduccionConfig.revocadoAt,
+					racha: premoraPagoTracking.cuotasAlDiaConsecutivas,
+					...datosCredito,
+				})
+				.from(premoraReduccionConfig)
+				.leftJoin(
+					premoraPagoTracking,
+					eq(
+						premoraReduccionConfig.numeroCreditoSifco,
+						premoraPagoTracking.numeroCreditoSifco,
+					),
+				)
+				.where(
+					and(
+						eq(premoraReduccionConfig.activo, false),
+						eq(premoraReduccionConfig.revocadoMotivo, "auto"),
+					),
+				)
+				.orderBy(desc(premoraReduccionConfig.revocadoAt))
+				.limit(100);
+
+			return { success: true, revocadas };
+		} catch (error) {
+			console.error("[getReduccionesAutoRevocadas] Error:", error);
+			throw new ORPCError("INTERNAL_SERVER_ERROR", {
+				message: "No se pudo obtener el historial",
+			});
+		}
+	}),
+
+	// Configura (o edita) la reducción de UNO O VARIOS créditos con la MISMA
+	// config (el gerente selecciona varios elegibles y los configura de un solo).
+	// Upsert por crédito. Solo aplica a los que son elegibles AHORA (paga bien);
+	// los no elegibles se omiten y se reportan. Un crédito ya configurado se
+	// re-configura (edición) con los nuevos pasos.
+	configurarReduccion: cobrosSupervisorProcedure
+		.input(
+			z.object({
+				numerosCreditoSifco: z
+					.array(z.string().min(1).max(100))
+					.min(1, "Selecciona al menos un crédito")
+					.max(500, "Máximo 500 créditos por lote")
+					.transform((arr) => [...new Set(arr)]),
+				pasosRemovidos: pasosSchema,
+			}),
+		)
+		.handler(async ({ input, context }) => {
+			// Solo los elegibles del lote (la config solo aplica a quien paga bien).
+			const elegibles = await db
+				.select({ sifco: premoraPagoTracking.numeroCreditoSifco })
+				.from(premoraPagoTracking)
+				.where(
+					and(
+						inArray(
+							premoraPagoTracking.numeroCreditoSifco,
+							input.numerosCreditoSifco,
+						),
+						eq(premoraPagoTracking.elegible, true),
+					),
+				);
+			const elegibleSet = new Set(elegibles.map((e) => e.sifco));
+			const aAplicar = input.numerosCreditoSifco.filter((s) =>
+				elegibleSet.has(s),
+			);
+
+			if (aAplicar.length === 0) {
+				throw new ORPCError("BAD_REQUEST", {
+					message:
+						"Ninguno de los créditos seleccionados es elegible: solo se puede reducir a clientes que pagan al día (4 cuotas consecutivas).",
+				});
+			}
+
+			await db
+				.insert(premoraReduccionConfig)
+				.values(
+					aAplicar.map((sifco) => ({
+						numeroCreditoSifco: sifco,
+						pasosRemovidos: input.pasosRemovidos,
+						activo: true,
+						origen: "manual",
+						configuradoPor: context.userId,
+					})),
+				)
+				.onConflictDoUpdate({
+					target: premoraReduccionConfig.numeroCreditoSifco,
+					set: {
+						pasosRemovidos: input.pasosRemovidos,
+						activo: true,
+						origen: "manual",
+						configuradoPor: context.userId,
+						configuradoAt: sql`now()`,
+						// Reconfigurar limpia una revocación previa (manual o auto).
+						revocadoAt: null,
+						revocadoMotivo: null,
+						updatedAt: sql`now()`,
+					},
+				});
+
+			return {
+				success: true,
+				aplicados: aAplicar.length,
+				omitidos: input.numerosCreditoSifco.length - aAplicar.length,
+			};
+		}),
+
+	// Revoca MANUALMENTE la reducción de un crédito (vuelve al embudo completo).
+	revocarReduccion: cobrosSupervisorProcedure
+		.input(z.object({ numeroCreditoSifco: z.string().min(1).max(100) }))
+		.handler(async ({ input }) => {
+			const res = await db
+				.update(premoraReduccionConfig)
+				.set({
+					activo: false,
+					revocadoAt: sql`now()`,
+					revocadoMotivo: "manual",
+					updatedAt: sql`now()`,
+				})
+				.where(
+					and(
+						eq(
+							premoraReduccionConfig.numeroCreditoSifco,
+							input.numeroCreditoSifco,
+						),
+						eq(premoraReduccionConfig.activo, true),
+					),
+				)
+				.returning({ id: premoraReduccionConfig.id });
+
+			if (res.length === 0) {
+				throw new ORPCError("NOT_FOUND", {
+					message: "No hay una reducción activa para ese crédito",
+				});
+			}
+			return { success: true };
+		}),
+
+	// Recalcula la elegibilidad AHORA (refresca la foto de pago desde cartera +
+	// auto-revoke). El job corre solo a diario; esto deja al gerente forzar el
+	// refresco cuando quiere ver datos al instante.
+	recalcularElegibilidad: cobrosSupervisorProcedure.handler(async () => {
+		const resumen = await refreshPremoraElegibilidad();
+		return { success: true, resumen };
+	}),
+};

--- a/apps/crm/apps/server/src/services/cartera-back-client.ts
+++ b/apps/crm/apps/server/src/services/cartera-back-client.ts
@@ -18,6 +18,7 @@ import type {
 	CarteraBucketHistorialEvento,
 	CarteraBucketsHistorialResponse,
 	CarteraColaDiaResponse,
+	CarteraComportamientoPagoResponse,
 	CarteraCredito,
 	CarteraCuotasProximasResponse,
 	CarteraInversionista,
@@ -1064,6 +1065,26 @@ export class CarteraBackClient {
 		if (opts.perPage != null) queryParams.set("per_page", String(opts.perPage));
 		return this.request<CarteraCuotasProximasResponse>(
 			`/cuotas/proximas-vencer?${queryParams}`,
+			{ method: "GET" },
+		);
+	}
+
+	// CB-010: comportamiento de pago (racha de cuotas al día por crédito). Lo
+	// consume el job diario de elegibilidad de la reducción de recordatorios.
+	// Sin cache: es una foto que se calcula una vez al día y debe reflejar los
+	// pagos más recientes. `sifcos` opcional para recálculo puntual; page/perPage
+	// para recorrer toda la cartera de a lotes (fetchAllPages).
+	async getComportamientoPago(
+		opts: { sifcos?: string[]; page?: number; perPage?: number } = {},
+	): Promise<CarteraComportamientoPagoResponse> {
+		const qs = new URLSearchParams();
+		if (opts.sifcos && opts.sifcos.length > 0)
+			qs.set("sifcos", opts.sifcos.join(","));
+		if (opts.page != null) qs.set("page", String(opts.page));
+		if (opts.perPage != null) qs.set("per_page", String(opts.perPage));
+		const suffix = qs.toString() ? `?${qs}` : "";
+		return this.request<CarteraComportamientoPagoResponse>(
+			`/cuotas/comportamiento-pago${suffix}`,
 			{ method: "GET" },
 		);
 	}

--- a/apps/crm/apps/server/src/services/refresh-premora-elegibilidad.ts
+++ b/apps/crm/apps/server/src/services/refresh-premora-elegibilidad.ts
@@ -156,7 +156,12 @@ export async function refreshPremoraElegibilidad(): Promise<ElegibilidadResumen>
 		let autoRevocados = 0;
 		if (aRevocar.length > 0) {
 			const ids = aRevocar.map((c) => c.id);
-			await db
+			// Filtrar por activo=true + RETURNING (review Codex P2): si otra corrida
+			// (el job y el recálculo manual solapados) ya revocó estas configs, el
+			// UPDATE no las vuelve a tocar y `revocadas` trae SOLO las que ESTA
+			// corrida apagó de verdad. Así no se duplican notificaciones al gerente
+			// ni se sobre-cuentan las revocaciones.
+			const revocadas = await db
 				.update(premoraReduccionConfig)
 				.set({
 					activo: false,
@@ -164,10 +169,20 @@ export async function refreshPremoraElegibilidad(): Promise<ElegibilidadResumen>
 					revocadoMotivo: "auto",
 					updatedAt: sql`now()`,
 				})
-				.where(inArray(premoraReduccionConfig.id, ids));
-			autoRevocados = aRevocar.length;
+				.where(
+					and(
+						inArray(premoraReduccionConfig.id, ids),
+						eq(premoraReduccionConfig.activo, true),
+					),
+				)
+				.returning({
+					numeroCreditoSifco: premoraReduccionConfig.numeroCreditoSifco,
+				});
+			autoRevocados = revocadas.length;
 
-			await notificarAutoRevoke(aRevocar.map((c) => c.numeroCreditoSifco));
+			if (revocadas.length > 0) {
+				await notificarAutoRevoke(revocadas.map((r) => r.numeroCreditoSifco));
+			}
 		}
 
 		const resumen = resumenVacio({

--- a/apps/crm/apps/server/src/services/refresh-premora-elegibilidad.ts
+++ b/apps/crm/apps/server/src/services/refresh-premora-elegibilidad.ts
@@ -1,0 +1,219 @@
+/**
+ * CB-010 — Job diario de elegibilidad para la reducción de recordatorios.
+ *
+ * Refresca la FOTO del comportamiento de pago (`premora_pago_tracking`) de toda
+ * la cartera activa preguntándole a cartera-back la racha de cuotas pagadas AL
+ * DÍA por crédito. Elegible = racha >= 4 (≈4 meses).
+ *
+ * Y hace el AUTO-REVOKE: si un crédito que tenía una reducción activa dejó de
+ * ser elegible (pagó tarde o entró en mora), apaga su config y avisa al Gerente
+ * de Cobros. El sistema propone y también RETIRA solo — el gerente no tiene que
+ * vigilar quién dejó de pagar bien.
+ *
+ * Nunca lanza al caller: devuelve un resumen y loguea (patrón premora).
+ */
+
+import { eq, inArray, sql } from "drizzle-orm";
+import { db } from "../db";
+import { casosCobros } from "../db/schema/cobros";
+import { notifications } from "../db/schema/notifications";
+import {
+	premoraPagoTracking,
+	premoraReduccionConfig,
+} from "../db/schema/premora-reduccion";
+import { fetchAllPages } from "../lib/fetch-all-pages";
+import { carteraBackClient } from "./cartera-back-client";
+import { isCarteraBackEnabled } from "./cartera-back-integration";
+import {
+	obtenerSupervisoresCobros,
+	resolverUsuarioSistemaCobros,
+} from "./cobros-notif-helpers";
+
+const LOG_PREFIX = "[PremoraElegibilidad]";
+
+/** Racha mínima de cuotas al día para que un crédito sea elegible (≈4 meses). */
+export const RACHA_ELEGIBLE = 4;
+
+export interface ElegibilidadResumen {
+	skipped?: boolean;
+	reason?: string;
+	evaluados: number;
+	elegibles: number;
+	autoRevocados: number;
+}
+
+const resumenVacio = (
+	extra?: Partial<ElegibilidadResumen>,
+): ElegibilidadResumen => ({
+	evaluados: 0,
+	elegibles: 0,
+	autoRevocados: 0,
+	...extra,
+});
+
+export async function refreshPremoraElegibilidad(): Promise<ElegibilidadResumen> {
+	try {
+		if (!isCarteraBackEnabled()) {
+			console.log(`${LOG_PREFIX} Cartera-back deshabilitado; job omitido`);
+			return resumenVacio({ skipped: true, reason: "cartera_back_disabled" });
+		}
+
+		// 1. Comportamiento de pago de TODA la cartera activa, recorriendo todas
+		// las páginas (la cartera puede ser de miles; el endpoint pagina).
+		const PER_PAGE = 500;
+		const filas = await fetchAllPages(
+			(page) =>
+				carteraBackClient
+					.getComportamientoPago({ page, perPage: PER_PAGE })
+					.then((r) => ({ data: r.data ?? [], totalPages: r.totalPages })),
+			{ perPage: PER_PAGE },
+		);
+		console.log(`${LOG_PREFIX} ${filas.length} crédito(s) evaluado(s)`);
+
+		const elegibleSet = new Set<string>();
+
+		// 2. Upsert de la foto por crédito (en lotes; puede ser toda la cartera).
+		if (filas.length > 0) {
+			const CHUNK = 500;
+			for (let i = 0; i < filas.length; i += CHUNK) {
+				const lote = filas.slice(i, i + CHUNK).map((f) => {
+					const elegible = f.racha >= RACHA_ELEGIBLE;
+					if (elegible) elegibleSet.add(f.numero_credito_sifco);
+					return {
+						numeroCreditoSifco: f.numero_credito_sifco,
+						creditoId: f.credito_id,
+						cliente: f.cliente,
+						cuotaMensual: f.cuota_mensual,
+						proximaFechaPago: f.proxima_fecha_pago,
+						cuotasAlDiaConsecutivas: f.racha,
+						ultimaCuotaEvaluada: f.ultima_cuota_evaluada,
+						totalVencidas: f.total_vencidas,
+						elegible,
+					};
+				});
+				await db
+					.insert(premoraPagoTracking)
+					.values(lote)
+					.onConflictDoUpdate({
+						target: premoraPagoTracking.numeroCreditoSifco,
+						set: {
+							creditoId: sql`excluded.credito_id`,
+							cliente: sql`excluded.cliente`,
+							cuotaMensual: sql`excluded.cuota_mensual`,
+							proximaFechaPago: sql`excluded.proxima_fecha_pago`,
+							cuotasAlDiaConsecutivas: sql`excluded.cuotas_al_dia_consecutivas`,
+							ultimaCuotaEvaluada: sql`excluded.ultima_cuota_evaluada`,
+							totalVencidas: sql`excluded.total_vencidas`,
+							elegible: sql`excluded.elegible`,
+							calculadoAt: sql`now()`,
+							updatedAt: sql`now()`,
+						},
+					});
+			}
+		}
+
+		// 3. Auto-revoke: cualquier config ACTIVA cuyo crédito ya NO es elegible
+		//    (bajó la racha o dejó de estar en la cartera activa) se apaga. Se
+		//    compara contra el set fresco — no contra la tabla tracking — para
+		//    cubrir también a los créditos que desaparecieron del resultado.
+		const configsActivas = await db
+			.select({
+				id: premoraReduccionConfig.id,
+				numeroCreditoSifco: premoraReduccionConfig.numeroCreditoSifco,
+			})
+			.from(premoraReduccionConfig)
+			.where(eq(premoraReduccionConfig.activo, true));
+
+		const aRevocar = configsActivas.filter(
+			(c) => !elegibleSet.has(c.numeroCreditoSifco),
+		);
+
+		let autoRevocados = 0;
+		if (aRevocar.length > 0) {
+			const ids = aRevocar.map((c) => c.id);
+			await db
+				.update(premoraReduccionConfig)
+				.set({
+					activo: false,
+					revocadoAt: sql`now()`,
+					revocadoMotivo: "auto",
+					updatedAt: sql`now()`,
+				})
+				.where(inArray(premoraReduccionConfig.id, ids));
+			autoRevocados = aRevocar.length;
+
+			await notificarAutoRevoke(aRevocar.map((c) => c.numeroCreditoSifco));
+		}
+
+		const resumen = resumenVacio({
+			evaluados: filas.length,
+			elegibles: elegibleSet.size,
+			autoRevocados,
+		});
+		console.log(
+			`${LOG_PREFIX} Resumen: ${resumen.evaluados} evaluados · ${resumen.elegibles} elegibles · ${resumen.autoRevocados} auto-revocados`,
+		);
+		return resumen;
+	} catch (error) {
+		const msg = error instanceof Error ? error.message : String(error);
+		console.error(`${LOG_PREFIX} Error no controlado: ${msg}`);
+		return resumenVacio({ skipped: true, reason: msg });
+	}
+}
+
+/**
+ * Avisa al Gerente de Cobros (todos los `cobros_supervisor`) que se retiró la
+ * reducción de un crédito porque dejó de pagar al día. Notificación simple
+ * (sin `cobros_tipo`): es un aviso de gestión, no una de las tres alertas de
+ * asesor. Redirige al detalle de cobros si el crédito tiene caso.
+ */
+async function notificarAutoRevoke(sifcos: string[]): Promise<void> {
+	try {
+		const supervisores = await obtenerSupervisoresCobros();
+		if (supervisores.length === 0) return;
+		const usuarioSistema = await resolverUsuarioSistemaCobros();
+		if (!usuarioSistema) {
+			console.error(
+				`${LOG_PREFIX} Sin usuario sistema; no se notifica el auto-revoke`,
+			);
+			return;
+		}
+
+		// Caso de cobros por SIFCO (para el redirect al detalle 360 si existe).
+		const casos = await db
+			.select({
+				id: casosCobros.id,
+				numeroCreditoSifco: casosCobros.numeroCreditoSifco,
+			})
+			.from(casosCobros)
+			.where(inArray(casosCobros.numeroCreditoSifco, sifcos));
+		const casoPorSifco = new Map(
+			casos.map((c) => [c.numeroCreditoSifco ?? "", c.id]),
+		);
+
+		const filas = sifcos.flatMap((sifco) => {
+			const casoId = casoPorSifco.get(sifco) ?? null;
+			return supervisores.map((supervisorId) => ({
+				titulo: "Reducción de recordatorios retirada",
+				descripcion: `El crédito ${sifco} dejó de pagar al día, así que el sistema restauró sus recordatorios premora completos. Revisa su gestión.`,
+				type: "aviso" as const,
+				status: "pending" as const,
+				createdBy: usuarioSistema,
+				createdByRole: "cobros_supervisor" as const,
+				assignedToRole: "cobros_supervisor" as const,
+				assignedTo: supervisorId,
+				...(casoId
+					? {
+							relatedEntityType: "collection_case" as const,
+							relatedEntityId: casoId,
+							redirectPage: "cobros_detail" as const,
+						}
+					: {}),
+			}));
+		});
+
+		if (filas.length > 0) await db.insert(notifications).values(filas);
+	} catch (err) {
+		console.error(`${LOG_PREFIX} Error notificando auto-revoke:`, err);
+	}
+}

--- a/apps/crm/apps/server/src/services/refresh-premora-elegibilidad.ts
+++ b/apps/crm/apps/server/src/services/refresh-premora-elegibilidad.ts
@@ -116,6 +116,12 @@ export async function refreshPremoraElegibilidad(): Promise<ElegibilidadResumen>
 							calculadoAt: sql`excluded.calculado_at`,
 							updatedAt: sql`now()`,
 						},
+						// "El más nuevo gana" por fila (review Codex P2): solo aplica si
+						// la corrida entrante es MÁS RECIENTE que lo guardado. Si el job
+						// programado y un recálculo manual se solapan, una corrida vieja
+						// y lenta no puede re-escribir elegible=true sobre lo que una
+						// corrida más nueva ya dejó (incluido el 2b que sella runInicio).
+						setWhere: sql`${premoraPagoTracking.calculadoAt} < excluded.calculado_at`,
 					});
 			}
 		}
@@ -127,9 +133,12 @@ export async function refreshPremoraElegibilidad(): Promise<ElegibilidadResumen>
 		//     módulo del gerente (que confía en elegible=true). El fetch fue
 		//     exitoso (si cartera falla, fetchAllPages lanza y no llegamos acá),
 		//     así que un resultado vacío es un "nadie califica hoy" legítimo.
+		//     Se SELLA calculadoAt = runInicio (review Codex P2): así una corrida
+		//     vieja y lenta que aún tenía el crédito no puede re-escribir
+		//     elegible=true encima (el setWhere del upsert la rechaza por antigua).
 		await db
 			.update(premoraPagoTracking)
-			.set({ elegible: false, updatedAt: sql`now()` })
+			.set({ elegible: false, calculadoAt: runInicio, updatedAt: sql`now()` })
 			.where(
 				and(
 					lt(premoraPagoTracking.calculadoAt, runInicio),

--- a/apps/crm/apps/server/src/services/refresh-premora-elegibilidad.ts
+++ b/apps/crm/apps/server/src/services/refresh-premora-elegibilidad.ts
@@ -13,7 +13,7 @@
  * Nunca lanza al caller: devuelve un resumen y loguea (patrón premora).
  */
 
-import { eq, inArray, sql } from "drizzle-orm";
+import { and, eq, inArray, lt, sql } from "drizzle-orm";
 import { db } from "../db";
 import { casosCobros } from "../db/schema/cobros";
 import { notifications } from "../db/schema/notifications";
@@ -58,6 +58,13 @@ export async function refreshPremoraElegibilidad(): Promise<ElegibilidadResumen>
 			return resumenVacio({ skipped: true, reason: "cartera_back_disabled" });
 		}
 
+		// Marca de esta corrida: las filas que se refrescan quedan con
+		// `calculadoAt = runInicio`; las que NO aparezcan hoy (crédito cancelado,
+		// ya no ACTIVO o sin cuotas evaluables) quedan con un calculadoAt más
+		// viejo y se limpian abajo. Se usa un único instante (no now() por fila)
+		// para que la comparación de "no tocado" sea exacta.
+		const runInicio = new Date();
+
 		// 1. Comportamiento de pago de TODA la cartera activa, recorriendo todas
 		// las páginas (la cartera puede ser de miles; el endpoint pagina).
 		const PER_PAGE = 500;
@@ -89,6 +96,7 @@ export async function refreshPremoraElegibilidad(): Promise<ElegibilidadResumen>
 						ultimaCuotaEvaluada: f.ultima_cuota_evaluada,
 						totalVencidas: f.total_vencidas,
 						elegible,
+						calculadoAt: runInicio,
 					};
 				});
 				await db
@@ -105,12 +113,29 @@ export async function refreshPremoraElegibilidad(): Promise<ElegibilidadResumen>
 							ultimaCuotaEvaluada: sql`excluded.ultima_cuota_evaluada`,
 							totalVencidas: sql`excluded.total_vencidas`,
 							elegible: sql`excluded.elegible`,
-							calculadoAt: sql`now()`,
+							calculadoAt: sql`excluded.calculado_at`,
 							updatedAt: sql`now()`,
 						},
 					});
 			}
 		}
+
+		// 2b. Limpiar elegibilidad STALE: cualquier fila que NO se refrescó en
+		//     esta corrida (calculadoAt < runInicio) ya no está en la cartera
+		//     evaluable → deja de ser elegible. Sin esto, un crédito cancelado o
+		//     que dejó de ser ACTIVO seguiría apareciendo como configurable en el
+		//     módulo del gerente (que confía en elegible=true). El fetch fue
+		//     exitoso (si cartera falla, fetchAllPages lanza y no llegamos acá),
+		//     así que un resultado vacío es un "nadie califica hoy" legítimo.
+		await db
+			.update(premoraPagoTracking)
+			.set({ elegible: false, updatedAt: sql`now()` })
+			.where(
+				and(
+					lt(premoraPagoTracking.calculadoAt, runInicio),
+					eq(premoraPagoTracking.elegible, true),
+				),
+			);
 
 		// 3. Auto-revoke: cualquier config ACTIVA cuyo crédito ya NO es elegible
 		//    (bajó la racha o dejó de estar en la cartera activa) se apaga. Se

--- a/apps/crm/apps/server/src/services/refresh-premora-elegibilidad.ts
+++ b/apps/crm/apps/server/src/services/refresh-premora-elegibilidad.ts
@@ -146,52 +146,41 @@ export async function refreshPremoraElegibilidad(): Promise<ElegibilidadResumen>
 				),
 			);
 
-		// 3. Auto-revoke: cualquier config ACTIVA cuyo crédito ya NO es elegible
-		//    (bajó la racha o dejó de estar en la cartera activa) se apaga. Se
-		//    compara contra el set fresco — no contra la tabla tracking — para
-		//    cubrir también a los créditos que desaparecieron del resultado.
-		const configsActivas = await db
-			.select({
-				id: premoraReduccionConfig.id,
-				numeroCreditoSifco: premoraReduccionConfig.numeroCreditoSifco,
+		// 3. Auto-revoke: apagar toda config ACTIVA cuyo crédito ya NO es elegible.
+		//    Se decide contra el TRACKING PERSISTIDO (no el set en memoria de esta
+		//    corrida) porque el tracking ya es "newest-wins" por el setWhere de
+		//    arriba, así que es la fuente autoritativa aunque haya corridas
+		//    solapadas (review Codex P2). Solo se revoca si NO existe un tracking
+		//    del crédito que sea elegible O que lo haya tocado una corrida MÁS
+		//    NUEVA (calculado_at > runInicio) — en ese caso manda la corrida nueva
+		//    y esta (más vieja) se abstiene, evitando revocaciones/avisos falsos.
+		//    RETURNING + activo=true → solo cuenta/notifica lo que ESTA corrida
+		//    apagó de verdad (sin duplicar con una corrida concurrente).
+		const revocadas = await db
+			.update(premoraReduccionConfig)
+			.set({
+				activo: false,
+				revocadoAt: sql`now()`,
+				revocadoMotivo: "auto",
+				updatedAt: sql`now()`,
 			})
-			.from(premoraReduccionConfig)
-			.where(eq(premoraReduccionConfig.activo, true));
+			.where(
+				and(
+					eq(premoraReduccionConfig.activo, true),
+					sql`NOT EXISTS (
+						SELECT 1 FROM premora_pago_tracking t
+						WHERE t.numero_credito_sifco = ${premoraReduccionConfig.numeroCreditoSifco}
+							AND (t.elegible = true OR t.calculado_at > ${runInicio})
+					)`,
+				),
+			)
+			.returning({
+				numeroCreditoSifco: premoraReduccionConfig.numeroCreditoSifco,
+			});
+		const autoRevocados = revocadas.length;
 
-		const aRevocar = configsActivas.filter(
-			(c) => !elegibleSet.has(c.numeroCreditoSifco),
-		);
-
-		let autoRevocados = 0;
-		if (aRevocar.length > 0) {
-			const ids = aRevocar.map((c) => c.id);
-			// Filtrar por activo=true + RETURNING (review Codex P2): si otra corrida
-			// (el job y el recálculo manual solapados) ya revocó estas configs, el
-			// UPDATE no las vuelve a tocar y `revocadas` trae SOLO las que ESTA
-			// corrida apagó de verdad. Así no se duplican notificaciones al gerente
-			// ni se sobre-cuentan las revocaciones.
-			const revocadas = await db
-				.update(premoraReduccionConfig)
-				.set({
-					activo: false,
-					revocadoAt: sql`now()`,
-					revocadoMotivo: "auto",
-					updatedAt: sql`now()`,
-				})
-				.where(
-					and(
-						inArray(premoraReduccionConfig.id, ids),
-						eq(premoraReduccionConfig.activo, true),
-					),
-				)
-				.returning({
-					numeroCreditoSifco: premoraReduccionConfig.numeroCreditoSifco,
-				});
-			autoRevocados = revocadas.length;
-
-			if (revocadas.length > 0) {
-				await notificarAutoRevoke(revocadas.map((r) => r.numeroCreditoSifco));
-			}
+		if (revocadas.length > 0) {
+			await notificarAutoRevoke(revocadas.map((r) => r.numeroCreditoSifco));
 		}
 
 		const resumen = resumenVacio({

--- a/apps/crm/apps/server/src/services/send-premora-reminders.ts
+++ b/apps/crm/apps/server/src/services/send-premora-reminders.ts
@@ -27,6 +27,7 @@ import { user } from "../db/schema/auth";
 import { casosCobros, contactosCobros } from "../db/schema/cobros";
 import { leads, opportunities } from "../db/schema/crm";
 import { notifications } from "../db/schema/notifications";
+import { premoraReduccionConfig } from "../db/schema/premora-reduccion";
 import { recordatoriosPremora } from "../db/schema/recordatorios-premora";
 import {
 	interpolar,
@@ -99,6 +100,8 @@ export interface PremoraResumen {
 	fallidos: number;
 	contactosRegistrados: number;
 	notificacionesD0: number;
+	/** CB-010: recordatorios NO enviados por reducción configurada (paga bien). */
+	omitidosPorReduccion: number;
 }
 
 const resumenVacio = (extra?: Partial<PremoraResumen>): PremoraResumen => ({
@@ -110,6 +113,7 @@ const resumenVacio = (extra?: Partial<PremoraResumen>): PremoraResumen => ({
 	fallidos: 0,
 	contactosRegistrados: 0,
 	notificacionesD0: 0,
+	omitidosPorReduccion: 0,
 	...extra,
 });
 
@@ -209,6 +213,30 @@ export async function sendPremoraReminders(
 			enviadosPrevios.map((e) => `${e.cuotaId}:${e.tipo}`),
 		);
 
+		// CB-010: reducciones ACTIVAS del batch — qué días del embudo (D-5/D-3/
+		// D-1) NO se le mandan a cada crédito que "paga bien". El Gerente las
+		// configura sobre los elegibles; el auto-revoke las apaga cuando el
+		// crédito deja de pagar al día. D-0 nunca se remueve (se valida al
+		// configurar y, por si acaso, el check de abajo solo aplica a dias >= 1).
+		const reducciones = await db
+			.select({
+				numeroCreditoSifco: premoraReduccionConfig.numeroCreditoSifco,
+				pasosRemovidos: premoraReduccionConfig.pasosRemovidos,
+			})
+			.from(premoraReduccionConfig)
+			.where(
+				and(
+					eq(premoraReduccionConfig.activo, true),
+					inArray(premoraReduccionConfig.numeroCreditoSifco, sifcos),
+				),
+			);
+		const pasosRemovidosPorSifco = new Map<string, Set<number>>(
+			reducciones.map((r) => [
+				r.numeroCreditoSifco,
+				new Set(r.pasosRemovidos ?? []),
+			]),
+		);
+
 		// Casos de cobros TAMBIÉN inactivos (review Codex): el sync cierra los
 		// casos curados con activo=false, y premora apunta justo a créditos al
 		// día (los curados). El caso —aunque cerrado— trae el teléfono
@@ -282,6 +310,19 @@ export async function sendPremoraReminders(
 
 			if (enviadoSet.has(`${cuota.cuota_id}:${tipo}`)) {
 				resumen.yaEnviados++;
+				continue;
+			}
+
+			// CB-010: si el crédito "paga bien" y el Gerente le quitó ESTE paso
+			// del embudo, no se envía (ni se reclama: es una omisión deliberada,
+			// no un envío pendiente). D-0 (dias=0) nunca está en pasosRemovidos.
+			if (
+				cuota.dias_para_vencer >= 1 &&
+				pasosRemovidosPorSifco
+					.get(cuota.numero_credito_sifco)
+					?.has(cuota.dias_para_vencer)
+			) {
+				resumen.omitidosPorReduccion++;
 				continue;
 			}
 
@@ -496,7 +537,7 @@ export async function sendPremoraReminders(
 		}
 
 		console.log(
-			`${LOG_PREFIX} Resumen: ${resumen.enviados} enviados · ${resumen.yaEnviados} ya enviados · ${resumen.sinTelefono} sin teléfono · ${resumen.sinTelefonoAsesor} sin tel. asesor · ${resumen.fallidos} fallidos · ${resumen.contactosRegistrados} contactos · ${resumen.notificacionesD0} notif. D-0`,
+			`${LOG_PREFIX} Resumen: ${resumen.enviados} enviados · ${resumen.yaEnviados} ya enviados · ${resumen.omitidosPorReduccion} omitidos por reducción · ${resumen.sinTelefono} sin teléfono · ${resumen.sinTelefonoAsesor} sin tel. asesor · ${resumen.fallidos} fallidos · ${resumen.contactosRegistrados} contactos · ${resumen.notificacionesD0} notif. D-0`,
 		);
 		return resumen;
 	} catch (error) {

--- a/apps/crm/apps/server/src/types/cartera-back.ts
+++ b/apps/crm/apps/server/src/types/cartera-back.ts
@@ -1108,6 +1108,35 @@ export interface CarteraCuotasProximasResponse {
 	data: CarteraCuotaProximaVencer[];
 }
 
+/**
+ * CB-010: comportamiento de pago de un crédito activo — racha de cuotas ya
+ * vencidas pagadas AL DÍA (fecha_pago <= vencimiento) desde la más reciente
+ * hacia atrás hasta el primer atraso. Elegibilidad (racha >= 4) la decide el CRM.
+ */
+export interface CarteraComportamientoPago {
+	credito_id: number;
+	numero_credito_sifco: string;
+	racha: number;
+	ultima_cuota_evaluada: number;
+	total_vencidas: number;
+	/** Nombre del titular (de cartera.usuarios — completo para todo crédito). */
+	cliente: string | null;
+	/** Cuota mensual del crédito (decimal como string). */
+	cuota_mensual: string;
+	/** Próxima cuota sin pagar que vence (YYYY-MM-DD) o null si no hay. */
+	proxima_fecha_pago: string | null;
+}
+
+export interface CarteraComportamientoPagoResponse {
+	success: boolean;
+	total: number;
+	/** Presentes solo cuando se pidió paginación (el job recorre todas las páginas). */
+	page?: number;
+	perPage?: number;
+	totalPages?: number;
+	data: CarteraComportamientoPago[];
+}
+
 // ============================================================================
 // FACTURACIÓN
 // ============================================================================

--- a/apps/crm/apps/web/src/components/header.tsx
+++ b/apps/crm/apps/web/src/components/header.tsx
@@ -4,6 +4,7 @@ import {
 	Banknote,
 	BarChart3,
 	Bell,
+	BellOff,
 	Briefcase,
 	Building2,
 	Calculator,
@@ -297,6 +298,14 @@ export default function Header() {
 											<Link to="/cobros/buckets" className="cursor-pointer">
 												<Layers className="mr-2 h-4 w-4" />
 												Historial de Buckets
+											</Link>
+										</DropdownMenuItem>
+									)}
+									{PERMISSIONS.canAssignCobros(userRole) && (
+										<DropdownMenuItem asChild>
+											<Link to="/cobros/reduccion" className="cursor-pointer">
+												<BellOff className="mr-2 h-4 w-4" />
+												Reducción de recordatorios
 											</Link>
 										</DropdownMenuItem>
 									)}
@@ -691,6 +700,15 @@ function MobileNav({
 											<Link to="/cobros/buckets" className={MOBILE_LINK_CLASS}>
 												<Layers />
 												Historial de Buckets
+											</Link>
+										)}
+										{PERMISSIONS.canAssignCobros(userRole) && (
+											<Link
+												to="/cobros/reduccion"
+												className={MOBILE_LINK_CLASS}
+											>
+												<BellOff />
+												Reducción de recordatorios
 											</Link>
 										)}
 										{PERMISSIONS.canAssignCobros(userRole) && (

--- a/apps/crm/apps/web/src/routeTree.gen.ts
+++ b/apps/crm/apps/web/src/routeTree.gen.ts
@@ -32,6 +32,7 @@ import { Route as CrmLeadsRouteImport } from './routes/crm/leads'
 import { Route as CrmCompaniesRouteImport } from './routes/crm/companies'
 import { Route as CrmClientsRouteImport } from './routes/crm/clients'
 import { Route as CobrosReportesRouteImport } from './routes/cobros/reportes'
+import { Route as CobrosReduccionRouteImport } from './routes/cobros/reduccion'
 import { Route as CobrosReasignacionesRouteImport } from './routes/cobros/reasignaciones'
 import { Route as CobrosMetasRouteImport } from './routes/cobros/metas'
 import { Route as CobrosColaRouteImport } from './routes/cobros/cola'
@@ -172,6 +173,11 @@ const CrmClientsRoute = CrmClientsRouteImport.update({
 const CobrosReportesRoute = CobrosReportesRouteImport.update({
   id: '/cobros/reportes',
   path: '/cobros/reportes',
+  getParentRoute: () => rootRouteImport,
+} as any)
+const CobrosReduccionRoute = CobrosReduccionRouteImport.update({
+  id: '/cobros/reduccion',
+  path: '/cobros/reduccion',
   getParentRoute: () => rootRouteImport,
 } as any)
 const CobrosReasignacionesRoute = CobrosReasignacionesRouteImport.update({
@@ -325,6 +331,7 @@ export interface FileRoutesByFullPath {
   '/cobros/cola': typeof CobrosColaRoute
   '/cobros/metas': typeof CobrosMetasRoute
   '/cobros/reasignaciones': typeof CobrosReasignacionesRoute
+  '/cobros/reduccion': typeof CobrosReduccionRoute
   '/cobros/reportes': typeof CobrosReportesRoute
   '/crm/clients': typeof CrmClientsRoute
   '/crm/companies': typeof CrmCompaniesRoute
@@ -375,6 +382,7 @@ export interface FileRoutesByTo {
   '/cobros/cola': typeof CobrosColaRoute
   '/cobros/metas': typeof CobrosMetasRoute
   '/cobros/reasignaciones': typeof CobrosReasignacionesRoute
+  '/cobros/reduccion': typeof CobrosReduccionRoute
   '/cobros/reportes': typeof CobrosReportesRoute
   '/crm/clients': typeof CrmClientsRoute
   '/crm/companies': typeof CrmCompaniesRoute
@@ -426,6 +434,7 @@ export interface FileRoutesById {
   '/cobros/cola': typeof CobrosColaRoute
   '/cobros/metas': typeof CobrosMetasRoute
   '/cobros/reasignaciones': typeof CobrosReasignacionesRoute
+  '/cobros/reduccion': typeof CobrosReduccionRoute
   '/cobros/reportes': typeof CobrosReportesRoute
   '/crm/clients': typeof CrmClientsRoute
   '/crm/companies': typeof CrmCompaniesRoute
@@ -478,6 +487,7 @@ export interface FileRouteTypes {
     | '/cobros/cola'
     | '/cobros/metas'
     | '/cobros/reasignaciones'
+    | '/cobros/reduccion'
     | '/cobros/reportes'
     | '/crm/clients'
     | '/crm/companies'
@@ -528,6 +538,7 @@ export interface FileRouteTypes {
     | '/cobros/cola'
     | '/cobros/metas'
     | '/cobros/reasignaciones'
+    | '/cobros/reduccion'
     | '/cobros/reportes'
     | '/crm/clients'
     | '/crm/companies'
@@ -578,6 +589,7 @@ export interface FileRouteTypes {
     | '/cobros/cola'
     | '/cobros/metas'
     | '/cobros/reasignaciones'
+    | '/cobros/reduccion'
     | '/cobros/reportes'
     | '/crm/clients'
     | '/crm/companies'
@@ -629,6 +641,7 @@ export interface RootRouteChildren {
   CobrosColaRoute: typeof CobrosColaRoute
   CobrosMetasRoute: typeof CobrosMetasRoute
   CobrosReasignacionesRoute: typeof CobrosReasignacionesRoute
+  CobrosReduccionRoute: typeof CobrosReduccionRoute
   CobrosReportesRoute: typeof CobrosReportesRoute
   CrmClientsRoute: typeof CrmClientsRoute
   CrmCompaniesRoute: typeof CrmCompaniesRoute
@@ -823,6 +836,13 @@ declare module '@tanstack/react-router' {
       path: '/cobros/reportes'
       fullPath: '/cobros/reportes'
       preLoaderRoute: typeof CobrosReportesRouteImport
+      parentRoute: typeof rootRouteImport
+    }
+    '/cobros/reduccion': {
+      id: '/cobros/reduccion'
+      path: '/cobros/reduccion'
+      fullPath: '/cobros/reduccion'
+      preLoaderRoute: typeof CobrosReduccionRouteImport
       parentRoute: typeof rootRouteImport
     }
     '/cobros/reasignaciones': {
@@ -1021,6 +1041,7 @@ const rootRouteChildren: RootRouteChildren = {
   CobrosColaRoute: CobrosColaRoute,
   CobrosMetasRoute: CobrosMetasRoute,
   CobrosReasignacionesRoute: CobrosReasignacionesRoute,
+  CobrosReduccionRoute: CobrosReduccionRoute,
   CobrosReportesRoute: CobrosReportesRoute,
   CrmClientsRoute: CrmClientsRoute,
   CrmCompaniesRoute: CrmCompaniesRoute,

--- a/apps/crm/apps/web/src/routes/cobros/reduccion.tsx
+++ b/apps/crm/apps/web/src/routes/cobros/reduccion.tsx
@@ -1,0 +1,696 @@
+import { useMutation, useQuery } from "@tanstack/react-query";
+import { createFileRoute, Link } from "@tanstack/react-router";
+import {
+	BellOff,
+	Loader2,
+	RefreshCw,
+	ShieldCheck,
+	TrendingDown,
+} from "lucide-react";
+import { useState } from "react";
+import { toast } from "sonner";
+import {
+	AlertDialog,
+	AlertDialogAction,
+	AlertDialogCancel,
+	AlertDialogContent,
+	AlertDialogDescription,
+	AlertDialogFooter,
+	AlertDialogHeader,
+	AlertDialogTitle,
+} from "@/components/ui/alert-dialog";
+import { Badge } from "@/components/ui/badge";
+import { Button } from "@/components/ui/button";
+import {
+	Card,
+	CardContent,
+	CardDescription,
+	CardHeader,
+	CardTitle,
+} from "@/components/ui/card";
+import { Checkbox } from "@/components/ui/checkbox";
+import {
+	Dialog,
+	DialogContent,
+	DialogDescription,
+	DialogFooter,
+	DialogHeader,
+	DialogTitle,
+} from "@/components/ui/dialog";
+import {
+	Table,
+	TableBody,
+	TableCell,
+	TableHead,
+	TableHeader,
+	TableRow,
+} from "@/components/ui/table";
+import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs";
+import { authClient } from "@/lib/auth-client";
+import { PERMISSIONS } from "@/lib/roles";
+import { client, orpc, queryClient } from "@/utils/orpc";
+
+export const Route = createFileRoute("/cobros/reduccion")({
+	component: ReduccionRecordatoriosPage,
+});
+
+// Pasos del embudo que el gerente puede quitar. D-0 nunca se quita (monitoreo
+// preventivo) — se muestra bloqueado en el diálogo.
+const PASOS = [
+	{ dia: 5, label: "Recordatorio D-5", sub: "5 días antes de vencer" },
+	{ dia: 3, label: "Recordatorio D-3", sub: "3 días antes de vencer" },
+	{ dia: 1, label: "Recordatorio D-1", sub: "1 día antes de vencer" },
+] as const;
+const MAX_PASOS = 2;
+
+function pasoLabel(dia: number) {
+	return `D-${dia}`;
+}
+
+function fmtQ(v: string | null | undefined) {
+	if (v == null || v === "") return "—";
+	const n = Number(v);
+	return Number.isFinite(n)
+		? `Q${n.toLocaleString("es-GT", { minimumFractionDigits: 2, maximumFractionDigits: 2 })}`
+		: "—";
+}
+
+function fmtFecha(v: string | null | undefined) {
+	if (!v) return "—";
+	// "YYYY-MM-DD" → "dd/mm/aaaa" sin desfases de zona horaria.
+	const [y, m, d] = v.split("-");
+	return y && m && d ? `${d}/${m}/${y}` : v;
+}
+
+// Enlace al detalle 360 del crédito (misma vista individual de cobros que usan
+// Agenda/Cola): el param es el numero_credito_sifco.
+function CreditoLink({ sifco }: { sifco: string }) {
+	return (
+		<Link
+			to="/cobros/$id"
+			params={{ id: sifco }}
+			search={{ tipo: "caso" }}
+			className="font-mono text-primary text-sm underline-offset-2 hover:underline"
+		>
+			{sifco}
+		</Link>
+	);
+}
+
+function ReduccionRecordatoriosPage() {
+	const { data: session } = authClient.useSession();
+	const userRole = session?.user?.role;
+
+	// Diálogo de configuración: opera sobre UNO o VARIOS créditos (mismo set de
+	// pasos). `dialogTargets` vacío = cerrado. `dialogLabel` es lo que se muestra
+	// (nombre del cliente para uno, "N créditos" para el lote).
+	const [dialogTargets, setDialogTargets] = useState<string[]>([]);
+	const [dialogLabel, setDialogLabel] = useState<string>("");
+	const [dialogSteps, setDialogSteps] = useState<number[]>([]);
+	const [revocarSifco, setRevocarSifco] = useState<string | null>(null);
+	// Selección múltiple de elegibles para configurar en lote.
+	const [seleccionados, setSeleccionados] = useState<Set<string>>(new Set());
+
+	const puedeAcceder = !!userRole && PERMISSIONS.canAssignCobros(userRole);
+
+	const elegiblesQuery = useQuery({
+		...orpc.getCreditosElegiblesReduccion.queryOptions(),
+		enabled: puedeAcceder,
+	});
+	const configuradasQuery = useQuery({
+		...orpc.getReduccionesConfiguradas.queryOptions(),
+		enabled: puedeAcceder,
+	});
+	const revocadasQuery = useQuery({
+		...orpc.getReduccionesAutoRevocadas.queryOptions(),
+		enabled: puedeAcceder,
+	});
+
+	const invalidarTodo = () => {
+		queryClient.invalidateQueries({
+			queryKey: orpc.getCreditosElegiblesReduccion.key(),
+		});
+		queryClient.invalidateQueries({
+			queryKey: orpc.getReduccionesConfiguradas.key(),
+		});
+		queryClient.invalidateQueries({
+			queryKey: orpc.getReduccionesAutoRevocadas.key(),
+		});
+	};
+
+	const configurarMutation = useMutation({
+		mutationFn: (vars: {
+			numerosCreditoSifco: string[];
+			pasosRemovidos: number[];
+		}) => client.configurarReduccion(vars),
+		onSuccess: (res) => {
+			const aplicados = res?.aplicados ?? 0;
+			const omitidos = res?.omitidos ?? 0;
+			toast.success(
+				omitidos > 0
+					? `Reducción aplicada a ${aplicados}; ${omitidos} omitido(s) por no ser elegibles`
+					: `Reducción aplicada a ${aplicados} crédito(s)`,
+			);
+			cerrarDialog();
+			setSeleccionados(new Set());
+			invalidarTodo();
+		},
+		onError: (error: Error) => toast.error(error.message),
+	});
+
+	const revocarMutation = useMutation({
+		mutationFn: (numeroCreditoSifco: string) =>
+			client.revocarReduccion({ numeroCreditoSifco }),
+		onSuccess: () => {
+			toast.success("Reducción retirada; el crédito vuelve al embudo completo");
+			setRevocarSifco(null);
+			invalidarTodo();
+		},
+		onError: (error: Error) => toast.error(error.message),
+	});
+
+	const recalcularMutation = useMutation({
+		mutationFn: () => client.recalcularElegibilidad(),
+		onSuccess: (res) => {
+			const r = res?.resumen;
+			toast.success(
+				r
+					? `Datos actualizados: ${r.evaluados} evaluados · ${r.elegibles} elegibles · ${r.autoRevocados} retirados`
+					: "Datos actualizados",
+			);
+			invalidarTodo();
+		},
+		onError: (error: Error) => toast.error(error.message),
+	});
+
+	// Configurar UN crédito (botón por fila / editar): abre el diálogo con ese
+	// solo target y, si edita, sus pasos actuales.
+	function abrirDialogUno(
+		sifco: string,
+		cliente: string | null,
+		pasosActuales: number[] = [],
+	) {
+		setDialogTargets([sifco]);
+		setDialogLabel(cliente ? `${cliente} · ${sifco}` : sifco);
+		setDialogSteps(pasosActuales);
+	}
+	// Configurar TODOS los seleccionados con la misma config.
+	function abrirDialogSeleccionados() {
+		const targets = [...seleccionados];
+		if (targets.length === 0) return;
+		setDialogTargets(targets);
+		setDialogLabel(`${targets.length} crédito(s) seleccionado(s)`);
+		setDialogSteps([]);
+	}
+	function cerrarDialog() {
+		setDialogTargets([]);
+		setDialogLabel("");
+		setDialogSteps([]);
+	}
+
+	function toggleSeleccion(sifco: string) {
+		setSeleccionados((prev) => {
+			const next = new Set(prev);
+			if (next.has(sifco)) next.delete(sifco);
+			else next.add(sifco);
+			return next;
+		});
+	}
+
+	function toggleStep(dia: number) {
+		setDialogSteps((prev) => {
+			if (prev.includes(dia)) return prev.filter((d) => d !== dia);
+			if (prev.length >= MAX_PASOS) {
+				toast.warning(`Máximo ${MAX_PASOS} recordatorios; quita uno primero`);
+				return prev;
+			}
+			return [...prev, dia];
+		});
+	}
+
+	if (!puedeAcceder) {
+		return (
+			<div className="flex min-h-screen items-center justify-center">
+				<div className="text-center">
+					<h1 className="mb-4 font-bold text-2xl text-gray-800">
+						Acceso Denegado
+					</h1>
+					<p className="text-gray-600">
+						Solo el Gerente de Cobros y administradores pueden gestionar la
+						reducción de recordatorios.
+					</p>
+				</div>
+			</div>
+		);
+	}
+
+	const elegibles = elegiblesQuery.data?.creditos ?? [];
+	const configuradas = configuradasQuery.data?.reducciones ?? [];
+	const revocadas = revocadasQuery.data?.revocadas ?? [];
+
+	const todosSeleccionados =
+		elegibles.length > 0 && seleccionados.size === elegibles.length;
+	function toggleSeleccionTodos() {
+		setSeleccionados(
+			todosSeleccionados
+				? new Set()
+				: new Set(
+						elegibles.map(
+							(c: { numeroCreditoSifco: string }) => c.numeroCreditoSifco,
+						),
+					),
+		);
+	}
+
+	return (
+		<div className="container mx-auto space-y-6 p-6">
+			<div className="flex items-start justify-between gap-4">
+				<div>
+					<h1 className="flex items-center gap-2 font-bold text-3xl">
+						<BellOff className="h-7 w-7" />
+						Reducción de recordatorios
+					</h1>
+					<p className="mt-1 text-muted-foreground">
+						Los clientes que pagan al día 4 cuotas seguidas pueden recibir menos
+						recordatorios premora. El sistema los marca elegibles; tú decides
+						qué pasos quitarles. El recordatorio del día de vencimiento (D-0)
+						siempre se envía.
+					</p>
+				</div>
+				<Button
+					variant="outline"
+					disabled={recalcularMutation.isPending}
+					onClick={() => recalcularMutation.mutate()}
+				>
+					{recalcularMutation.isPending ? (
+						<Loader2 className="mr-2 h-4 w-4 animate-spin" />
+					) : (
+						<RefreshCw className="mr-2 h-4 w-4" />
+					)}
+					Actualizar datos
+				</Button>
+			</div>
+
+			<Tabs defaultValue="elegibles">
+				<TabsList>
+					<TabsTrigger value="elegibles">
+						Elegibles ({elegibles.length})
+					</TabsTrigger>
+					<TabsTrigger value="configuradas">
+						Configurados ({configuradas.length})
+					</TabsTrigger>
+					<TabsTrigger value="revocadas">
+						Retirados automáticamente ({revocadas.length})
+					</TabsTrigger>
+				</TabsList>
+
+				{/* ── Elegibles ─────────────────────────────────────────────── */}
+				<TabsContent value="elegibles">
+					<Card>
+						<CardHeader>
+							<CardTitle className="flex items-center gap-2">
+								<ShieldCheck className="h-5 w-5 text-green-600" />
+								Clientes que pagan al día
+							</CardTitle>
+							<CardDescription>
+								Elegibles sin reducción aplicada. Elige a quién quitarle
+								recordatorios.
+							</CardDescription>
+						</CardHeader>
+						<CardContent>
+							{elegiblesQuery.isLoading ? (
+								<Cargando />
+							) : elegibles.length === 0 ? (
+								<Vacio texto="No hay créditos elegibles por ahora." />
+							) : (
+								<>
+									{/* Toolbar de lote: aparece al seleccionar ≥1 crédito. */}
+									{seleccionados.size > 0 && (
+										<div className="mb-3 flex items-center justify-between rounded-md border bg-muted/40 px-3 py-2">
+											<span className="text-sm">
+												{seleccionados.size} crédito(s) seleccionado(s)
+											</span>
+											<div className="flex gap-2">
+												<Button
+													size="sm"
+													variant="ghost"
+													onClick={() => setSeleccionados(new Set())}
+												>
+													Limpiar
+												</Button>
+												<Button size="sm" onClick={abrirDialogSeleccionados}>
+													Configurar seleccionados
+												</Button>
+											</div>
+										</div>
+									)}
+									<Table>
+										<TableHeader>
+											<TableRow>
+												<TableHead className="w-10">
+													<Checkbox
+														checked={todosSeleccionados}
+														onCheckedChange={toggleSeleccionTodos}
+														aria-label="Seleccionar todos"
+													/>
+												</TableHead>
+												<TableHead>Cliente</TableHead>
+												<TableHead>Crédito</TableHead>
+												<TableHead>Cuota mensual</TableHead>
+												<TableHead>Próximo pago</TableHead>
+												<TableHead>Cuotas al día</TableHead>
+												<TableHead className="text-right">Acción</TableHead>
+											</TableRow>
+										</TableHeader>
+										<TableBody>
+											{elegibles.map((c) => (
+												<TableRow key={c.numeroCreditoSifco}>
+													<TableCell>
+														<Checkbox
+															checked={seleccionados.has(c.numeroCreditoSifco)}
+															onCheckedChange={() =>
+																toggleSeleccion(c.numeroCreditoSifco)
+															}
+															aria-label={`Seleccionar ${c.numeroCreditoSifco}`}
+														/>
+													</TableCell>
+													<TableCell className="font-medium">
+														{c.cliente ?? "—"}
+													</TableCell>
+													<TableCell>
+														<CreditoLink sifco={c.numeroCreditoSifco} />
+													</TableCell>
+													<TableCell>{fmtQ(c.cuotaMensual)}</TableCell>
+													<TableCell>{fmtFecha(c.proximaFechaPago)}</TableCell>
+													<TableCell>
+														<Badge className="bg-green-100 text-green-800">
+															{c.racha} al día
+														</Badge>
+													</TableCell>
+													<TableCell className="text-right">
+														<Button
+															size="sm"
+															onClick={() =>
+																abrirDialogUno(c.numeroCreditoSifco, c.cliente)
+															}
+														>
+															Configurar
+														</Button>
+													</TableCell>
+												</TableRow>
+											))}
+										</TableBody>
+									</Table>
+								</>
+							)}
+						</CardContent>
+					</Card>
+				</TabsContent>
+
+				{/* ── Configurados ──────────────────────────────────────────── */}
+				<TabsContent value="configuradas">
+					<Card>
+						<CardHeader>
+							<CardTitle>Reducciones activas</CardTitle>
+							<CardDescription>
+								Créditos con recordatorios reducidos. Puedes editar los pasos o
+								retirar la reducción.
+							</CardDescription>
+						</CardHeader>
+						<CardContent>
+							{configuradasQuery.isLoading ? (
+								<Cargando />
+							) : configuradas.length === 0 ? (
+								<Vacio texto="Aún no has configurado ninguna reducción." />
+							) : (
+								<Table>
+									<TableHeader>
+										<TableRow>
+											<TableHead>Cliente</TableHead>
+											<TableHead>Crédito</TableHead>
+											<TableHead>Cuota mensual</TableHead>
+											<TableHead>Próximo pago</TableHead>
+											<TableHead>Recordatorios quitados</TableHead>
+											<TableHead>Cuotas al día</TableHead>
+											<TableHead>Configurado por</TableHead>
+											<TableHead className="text-right">Acciones</TableHead>
+										</TableRow>
+									</TableHeader>
+									<TableBody>
+										{configuradas.map((r) => (
+											<TableRow key={r.numeroCreditoSifco}>
+												<TableCell className="font-medium">
+													{r.cliente ?? "—"}
+												</TableCell>
+												<TableCell>
+													<CreditoLink sifco={r.numeroCreditoSifco} />
+												</TableCell>
+												<TableCell>{fmtQ(r.cuotaMensual)}</TableCell>
+												<TableCell>{fmtFecha(r.proximaFechaPago)}</TableCell>
+												<TableCell>
+													<div className="flex flex-wrap gap-1">
+														{[...(r.pasosRemovidos ?? [])]
+															.sort((a, b) => b - a)
+															.map((d) => (
+																<Badge
+																	key={d}
+																	variant="secondary"
+																	className="bg-amber-100 text-amber-800"
+																>
+																	{pasoLabel(d)}
+																</Badge>
+															))}
+													</div>
+												</TableCell>
+												<TableCell>
+													{r.racha != null ? (
+														<Badge className="bg-green-100 text-green-800">
+															{r.racha} al día
+														</Badge>
+													) : (
+														"—"
+													)}
+												</TableCell>
+												<TableCell className="text-muted-foreground text-sm">
+													{r.configuradoPorNombre ?? "—"}
+												</TableCell>
+												<TableCell className="text-right">
+													<div className="flex justify-end gap-2">
+														<Button
+															size="sm"
+															variant="outline"
+															onClick={() =>
+																abrirDialogUno(
+																	r.numeroCreditoSifco,
+																	r.cliente,
+																	[...(r.pasosRemovidos ?? [])],
+																)
+															}
+														>
+															Editar
+														</Button>
+														<Button
+															size="sm"
+															variant="destructive"
+															onClick={() =>
+																setRevocarSifco(r.numeroCreditoSifco)
+															}
+														>
+															Retirar
+														</Button>
+													</div>
+												</TableCell>
+											</TableRow>
+										))}
+									</TableBody>
+								</Table>
+							)}
+						</CardContent>
+					</Card>
+				</TabsContent>
+
+				{/* ── Auto-revocados ────────────────────────────────────────── */}
+				<TabsContent value="revocadas">
+					<Card>
+						<CardHeader>
+							<CardTitle className="flex items-center gap-2">
+								<TrendingDown className="h-5 w-5 text-red-600" />
+								Retirados por el sistema
+							</CardTitle>
+							<CardDescription>
+								Reducciones que el sistema retiró automáticamente porque el
+								cliente dejó de pagar al día.
+							</CardDescription>
+						</CardHeader>
+						<CardContent>
+							{revocadasQuery.isLoading ? (
+								<Cargando />
+							) : revocadas.length === 0 ? (
+								<Vacio texto="No hay reducciones retiradas automáticamente." />
+							) : (
+								<Table>
+									<TableHeader>
+										<TableRow>
+											<TableHead>Cliente</TableHead>
+											<TableHead>Crédito</TableHead>
+											<TableHead>Tenía quitados</TableHead>
+											<TableHead>Cuotas al día ahora</TableHead>
+											<TableHead>Retirado</TableHead>
+										</TableRow>
+									</TableHeader>
+									<TableBody>
+										{revocadas.map((r) => (
+											<TableRow key={r.numeroCreditoSifco}>
+												<TableCell className="font-medium">
+													{r.cliente ?? "—"}
+												</TableCell>
+												<TableCell>
+													<CreditoLink sifco={r.numeroCreditoSifco} />
+												</TableCell>
+												<TableCell>
+													<div className="flex flex-wrap gap-1">
+														{[...(r.pasosRemovidos ?? [])]
+															.sort((a, b) => b - a)
+															.map((d) => (
+																<Badge
+																	key={d}
+																	variant="outline"
+																	className="text-muted-foreground"
+																>
+																	{pasoLabel(d)}
+																</Badge>
+															))}
+													</div>
+												</TableCell>
+												<TableCell>{r.racha ?? "—"}</TableCell>
+												<TableCell className="text-muted-foreground text-sm">
+													{r.revocadoAt
+														? new Date(r.revocadoAt).toLocaleDateString("es-GT")
+														: "—"}
+												</TableCell>
+											</TableRow>
+										))}
+									</TableBody>
+								</Table>
+							)}
+						</CardContent>
+					</Card>
+				</TabsContent>
+			</Tabs>
+
+			{/* ── Diálogo configurar / editar (uno o varios) ────────────────── */}
+			<Dialog
+				open={dialogTargets.length > 0}
+				onOpenChange={(o) => {
+					if (!o) cerrarDialog();
+				}}
+			>
+				<DialogContent>
+					<DialogHeader>
+						<DialogTitle>Reducir recordatorios</DialogTitle>
+						<DialogDescription>
+							{dialogLabel}. Marca los recordatorios que NO quieres enviarle
+							(máximo {MAX_PASOS}).
+						</DialogDescription>
+					</DialogHeader>
+
+					<div className="space-y-3 py-2">
+						{PASOS.map((p) => {
+							const checked = dialogSteps.includes(p.dia);
+							return (
+								<label
+									key={p.dia}
+									htmlFor={`paso-${p.dia}`}
+									className="flex cursor-pointer items-center gap-3 rounded-md border p-3 hover:bg-muted/50"
+								>
+									<Checkbox
+										id={`paso-${p.dia}`}
+										checked={checked}
+										onCheckedChange={() => toggleStep(p.dia)}
+									/>
+									<div>
+										<div className="font-medium">{p.label}</div>
+										<div className="text-muted-foreground text-sm">{p.sub}</div>
+									</div>
+								</label>
+							);
+						})}
+						<div className="flex items-center gap-3 rounded-md border border-dashed p-3 opacity-60">
+							<Checkbox checked disabled />
+							<div>
+								<div className="font-medium">Recordatorio D-0</div>
+								<div className="text-muted-foreground text-sm">
+									El día de vencimiento — siempre se envía
+								</div>
+							</div>
+						</div>
+					</div>
+
+					<DialogFooter>
+						<Button variant="outline" onClick={cerrarDialog}>
+							Cancelar
+						</Button>
+						<Button
+							disabled={
+								dialogSteps.length === 0 || configurarMutation.isPending
+							}
+							onClick={() =>
+								dialogTargets.length > 0 &&
+								configurarMutation.mutate({
+									numerosCreditoSifco: dialogTargets,
+									pasosRemovidos: dialogSteps,
+								})
+							}
+						>
+							{configurarMutation.isPending && (
+								<Loader2 className="mr-2 h-4 w-4 animate-spin" />
+							)}
+							Aplicar
+						</Button>
+					</DialogFooter>
+				</DialogContent>
+			</Dialog>
+
+			{/* ── Confirmar retiro manual ───────────────────────────────────── */}
+			<AlertDialog
+				open={revocarSifco != null}
+				onOpenChange={(o) => {
+					if (!o) setRevocarSifco(null);
+				}}
+			>
+				<AlertDialogContent>
+					<AlertDialogHeader>
+						<AlertDialogTitle>¿Retirar la reducción?</AlertDialogTitle>
+						<AlertDialogDescription>
+							El crédito {revocarSifco} volverá a recibir todos los
+							recordatorios del embudo (D-5, D-3, D-1 y D-0).
+						</AlertDialogDescription>
+					</AlertDialogHeader>
+					<AlertDialogFooter>
+						<AlertDialogCancel>Cancelar</AlertDialogCancel>
+						<AlertDialogAction
+							onClick={() =>
+								revocarSifco && revocarMutation.mutate(revocarSifco)
+							}
+						>
+							Retirar
+						</AlertDialogAction>
+					</AlertDialogFooter>
+				</AlertDialogContent>
+			</AlertDialog>
+		</div>
+	);
+}
+
+function Cargando() {
+	return (
+		<div className="flex items-center justify-center py-10 text-muted-foreground">
+			<Loader2 className="mr-2 h-5 w-5 animate-spin" />
+			Cargando…
+		</div>
+	);
+}
+
+function Vacio({ texto }: { texto: string }) {
+	return <div className="py-10 text-center text-muted-foreground">{texto}</div>;
+}

--- a/apps/crm/apps/web/src/routes/cobros/reduccion.tsx
+++ b/apps/crm/apps/web/src/routes/cobros/reduccion.tsx
@@ -390,6 +390,9 @@ function ReduccionRecordatoriosPage() {
 													<TableCell className="text-right">
 														<Button
 															size="sm"
+															// Con selección múltiple activa se usa el botón de lote
+															// ("Configurar seleccionados"); los individuales se apagan.
+															disabled={seleccionados.size > 0}
 															onClick={() =>
 																abrirDialogUno(c.numeroCreditoSifco, c.cliente)
 															}

--- a/apps/crm/apps/web/src/routes/cobros/reduccion.tsx
+++ b/apps/crm/apps/web/src/routes/cobros/reduccion.tsx
@@ -272,9 +272,10 @@ function ReduccionRecordatoriosPage() {
 					</h1>
 					<p className="mt-1 text-muted-foreground">
 						Los clientes que pagan al día 4 cuotas seguidas pueden recibir menos
-						recordatorios premora. El sistema los marca elegibles; tú decides
-						qué pasos quitarles. El recordatorio del día de vencimiento (D-0)
-						siempre se envía.
+						recordatorios premora (se toleran hasta 2 días de gracia después del
+						vencimiento). El sistema los marca elegibles; tú decides qué pasos
+						quitarles. El recordatorio del día de vencimiento (D-0) siempre se
+						envía.
 					</p>
 				</div>
 				<Button


### PR DESCRIPTION
## Qué hace
Módulo del **Gerente de Cobros** (`cobros_supervisor`) para reducir el embudo premora (D-5/D-3/D-1) a créditos que **pagan al día**. El sistema propone (elegibilidad automática), el gerente decide qué pasos quitar. **D-0 nunca se quita** (monitoreo preventivo). Si el crédito deja de pagar bien, el sistema **retira solo** la reducción y avisa al gerente.

## Cómo funciona
- **Elegibilidad** = racha de **≥ 4 cuotas consecutivas pagadas al día** (`fecha_pago <= vencimiento`). Un pago tarde o una cuota vencida sin pagar rompe la racha.
- **Job diario 07:00 GT** (1h antes del funnel premora): refresca la foto de pago desde cartera y hace el **auto-revoke**.
- El **funnel premora** salta los pasos configurados por crédito.

## Cambios
**cartera-back** (solo lectura)
- `GET /cuotas/comportamiento-pago` — racha de cuotas al día por crédito activo, **paginado**; devuelve nombre (de `usuarios`), cuota mensual y próxima fecha de pago. Espejo del predicado de pago cubriente de premora/motor.

**CRM server**
- 2 tablas nuevas: `premora_pago_tracking` + `premora_reduccion_config` (**migración `0030`, la corre el usuario**).
- Job `refresh-premora-elegibilidad` (07:00 GT + boot) con `fetchAllPages` + auto-revoke con notificación al gerente.
- `send-premora-reminders`: salta los pasos configurados (guard `dias >= 1`, D-0 nunca).
- ORPC (gateado a `cobros_supervisor`): elegibles / configuradas / auto-revocadas + **configurar en lote** (lista de SIFCOs, misma config) + revocar + recalcular.
- Endpoint HTTP admin `POST /api/premora/elegibilidad/run` para re-correr el job.

**CRM web**
- Pantalla `/cobros/reduccion`: 3 tabs (Elegibles / Configurados / Retirados auto), **selección múltiple** para configurar varios de un solo, links a la **vista 360** del crédito, columnas de cuota mensual y próximo pago. Botón "Actualizar datos". Nav (desktop + mobile) gateado a `canAssignCobros`.

## Notas
- La **migración 0030 la corre el usuario** (dev y luego prod). Es idempotente (incluye `ADD COLUMN IF NOT EXISTS`).
- Los errores de tsc en el web (`reduccion.tsx`) son la degradación baseline de ORPC `{}` (igual que el resto de rutas); server y cartera-back compilan limpio.


<img width="1851" height="779" alt="image" src="https://github.com/user-attachments/assets/0cd1c2bd-e063-4b58-94cf-2478cd94fbc9" />


🤖 Generated with [Claude Code](https://claude.com/claude-code)