### PR TITLE
feat(buckets): endpoint bucket actual por número SIFCO

### DIFF
--- a/apps/cartera-back/src/controllers/buckets/bucketActualCredito.ts
+++ b/apps/cartera-back/src/controllers/buckets/bucketActualCredito.ts
@@ -1,0 +1,114 @@
+import { sql } from "drizzle-orm";
+import { db } from "../../database";
+import { SQL_CARTERA_SCHEMA } from "../../database/db/schema";
+import {
+  bucketActualSql,
+  STATUS_BUCKET_FUERA,
+} from "../../lib/buckets-classification";
+
+export type BucketActualCredito = {
+  credito_id: number;
+  numero_credito_sifco: string;
+  bucket: number | null;
+  prefijo: string | null;
+  nombre: string | null;
+  color: string | null;
+  estado_mora: string | null;
+  /** true = statusCredit en STATUS_BUCKET_FUERA (EN_CONVENIO, CANCELADO...): sin bucket POR DISEÑO. */
+  fuera_funnel: boolean;
+  /**
+   * CB-026: fecha en que el crédito ENTRÓ al bucket actual (ISO), tomada de la
+   * última fila de buckets_historial. null cuando el bucket NO vino de esa fila
+   * sino de un branch de fallback de bucketActualSql (estado que fuerza bucket
+   * o rango de cuotas, típico de ambientes sin backfill de COBROS-02) — en ese
+   * caso no existe fecha de entrada confiable y no se inventa una.
+   */
+  fecha_entrada_bucket: string | null;
+};
+
+/**
+ * Bucket ACTUAL de un crédito por número SIFCO + su fila del catálogo.
+ * Misma fuente que el listado /buckets/creditos y la reasignación manual
+ * (bucketActualSql): COALESCE(último buckets_historial → estado que fuerza
+ * bucket → rango de cuotas de la mora activa). `bucket = null` con
+ * `fuera_funnel = true` es una respuesta CORRECTA (el crédito salió del
+ * funnel), no un error.
+ */
+export async function getBucketActualPorSifco(
+  numero_credito_sifco: string,
+): Promise<BucketActualCredito | null> {
+  const fueraSql = sql.join(
+    STATUS_BUCKET_FUERA.map((s) => sql`${s}`),
+    sql`, `,
+  );
+  const res = await db.execute<{
+    credito_id: number;
+    numero_credito_sifco: string;
+    fuera: boolean;
+    bucket: number | null;
+    prefijo: string | null;
+    nombre: string | null;
+    color: string | null;
+    estado_mora: string | null;
+    fecha_entrada_bucket: string | null;
+  }>(sql`
+    WITH actual AS (
+      SELECT
+        c.credito_id,
+        c.numero_credito_sifco,
+        (c."statusCredit" IN (${fueraSql})) AS fuera,
+        ${bucketActualSql("c", "m")} AS bucket
+      FROM ${SQL_CARTERA_SCHEMA}.creditos c
+      LEFT JOIN ${SQL_CARTERA_SCHEMA}.moras_credito m
+        ON m.credito_id = c.credito_id AND m.activa = true
+      WHERE c.numero_credito_sifco = ${numero_credito_sifco}
+      LIMIT 1
+    ),
+    -- Última fila de historial del crédito. El WHERE por credito_id acota el
+    -- DISTINCT ON a UN crédito (sin él escanearía el historial completo) y cae
+    -- justo sobre buckets_historial_credito_fecha_idx
+    -- (credito_id, fecha DESC, historial_id DESC).
+    ultima_entrada AS (
+      SELECT DISTINCT ON (h.credito_id)
+        h.credito_id, h.bucket_nuevo, h.fecha
+      FROM ${SQL_CARTERA_SCHEMA}.buckets_historial h
+      WHERE h.credito_id = (SELECT a.credito_id FROM actual a)
+      ORDER BY h.credito_id, h.fecha DESC, h.historial_id DESC
+    )
+    SELECT
+      a.credito_id,
+      a.numero_credito_sifco,
+      a.fuera,
+      CASE WHEN a.fuera THEN NULL ELSE a.bucket END AS bucket,
+      -- Solo hay fecha de entrada confiable si el bucket resuelto VIENE de la
+      -- última fila de historial. Si ganó un branch de fallback de
+      -- bucketActualSql (estado que fuerza bucket / rango de cuotas), no existe
+      -- tal fecha: null, no se inventa (mismo criterio "degradar sin inventar
+      -- dato" que colaDia.ts, que directamente excluye esos créditos).
+      CASE
+        WHEN a.fuera THEN NULL
+        WHEN ue.bucket_nuevo IS NOT NULL AND ue.bucket_nuevo = a.bucket
+          THEN ue.fecha::text
+        ELSE NULL
+      END AS fecha_entrada_bucket,
+      b.prefijo, b.nombre, b.color, b.estado_mora
+    FROM actual a
+    LEFT JOIN ultima_entrada ue ON ue.credito_id = a.credito_id
+    LEFT JOIN ${SQL_CARTERA_SCHEMA}.buckets b
+      ON b.numero = a.bucket AND b.activo = true AND a.fuera = false
+  `);
+
+  const row = res.rows?.[0];
+  if (!row) return null;
+  return {
+    credito_id: Number(row.credito_id),
+    numero_credito_sifco: row.numero_credito_sifco,
+    bucket: row.fuera || row.bucket == null ? null : Number(row.bucket),
+    prefijo: row.prefijo ?? null,
+    nombre: row.nombre ?? null,
+    color: row.color ?? null,
+    estado_mora: row.estado_mora ?? null,
+    fuera_funnel: Boolean(row.fuera),
+    fecha_entrada_bucket: row.fecha_entrada_bucket ?? null,
+  };
+}

--- a/apps/cartera-back/src/routers/buckets.ts
+++ b/apps/cartera-back/src/routers/buckets.ts
@@ -5,6 +5,7 @@ import {
   getBucketsHistorial,
   getBucketsHistorialCredito,
 } from "../controllers/buckets/bucketsHistorial";
+import { getBucketActualPorSifco } from "../controllers/buckets/bucketActualCredito";
 import { getAsesorHistorial } from "../controllers/buckets/asesorHistorial";
 import { getCreditosWithUserByMesAnio } from "../controllers/credits";
 import {
@@ -404,6 +405,41 @@ export const bucketsRouter = new Elysia()
         return {
           success: false,
           message: "[ERROR] No se pudo obtener el histórico del crédito",
+          error: String(err),
+        };
+      }
+    },
+  )
+
+  // Bucket ACTUAL de UN crédito por número SIFCO (badge del detalle de cobros
+  // en el CRM). Keyed por numero_credito_sifco —no credito_id— porque es lo
+  // que el handler del CRM ya tiene resuelto. Sin cache del lado del cliente:
+  // el badge debe reflejar el motor al instante (mismo criterio que
+  // /buckets/historial).
+  .get(
+    "/buckets/credito/:numero_credito_sifco",
+    async ({ params, set, user }: any) => {
+      if (!requireBucketsRole(user, set)) return NO_AUTORIZADO;
+      try {
+        const numero = String(params.numero_credito_sifco ?? "").trim();
+        if (!numero || numero.length > 100) {
+          set.status = 400;
+          return {
+            success: false,
+            message: "[ERROR] numero_credito_sifco inválido",
+          };
+        }
+        const data = await getBucketActualPorSifco(numero);
+        if (!data) {
+          set.status = 404;
+          return { success: false, message: "[ERROR] Crédito no encontrado" };
+        }
+        return { success: true, data };
+      } catch (err) {
+        set.status = 500;
+        return {
+          success: false,
+          message: "[ERROR] No se pudo obtener el bucket actual del crédito",
           error: String(err),
         };
       }


### PR DESCRIPTION
## Summary
- Nuevo `GET /buckets/credito/:numero_credito_sifco` que devuelve el bucket ACTUAL de un crédito (motor COBROS-02) más su fecha de entrada al bucket, reusando `bucketActualSql` como fuente única (misma lógica que `/buckets/reasignar` y `/buckets/carga`).
- Sirve como base para el badge B0-B5 y la regla de "gestión temprana B1" que se está construyendo en el CRM (PRs separados hacia `crm/apps/server` y `crm/apps/web`).

## Test plan
- [x] `bunx tsc --noEmit` en `apps/cartera-back` — limpio
- [ ] Probar `GET /buckets/credito/:numero_credito_sifco` con un SIFCO real (bucket con y sin historial) contra dev

🤖 Generated with [Claude Code](https://claude.com/claude-code)