### PR TITLE
feat(cobros): backend CB-026 — gestión temprana B1 (3 canales)

### DIFF
--- a/apps/cartera-back/src/controllers/buckets/bucketActualCredito.ts
+++ b/apps/cartera-back/src/controllers/buckets/bucketActualCredito.ts
@@ -85,10 +85,20 @@ export async function getBucketActualPorSifco(
       -- bucketActualSql (estado que fuerza bucket / rango de cuotas), no existe
       -- tal fecha: null, no se inventa (mismo criterio "degradar sin inventar
       -- dato" que colaDia.ts, que directamente excluye esos créditos).
+      -- ue.fecha es un timestamp SIN zona (columna timestamp, no timestamptz;
+      -- servidor en GMT/UTC, verificado con SHOW timezone). Un ::text directo
+      -- da "2026-07-08 15:30:00" sin ningún indicio de zona — new Date() del
+      -- lado del CRM lo reinterpreta como hora LOCAL del proceso Node/Bun, no
+      -- UTC, corriendo la ventana de gestión B1 hasta 6h si ese proceso no
+      -- corre en UTC (findings de Codex en PR #1204). AT TIME ZONE 'UTC'
+      -- convierte a timestamptz ETIQUETANDO el valor como UTC (no lo
+      -- desplaza, el servidor ya guarda en UTC) y to_json sobre eso sí emite
+      -- el offset +00:00 explícito — TZ-independiente en new Date(), igual
+      -- que fechaContacto (que llega vía Date real de drizzle, siempre UTC).
       CASE
         WHEN a.fuera THEN NULL
         WHEN ue.bucket_nuevo IS NOT NULL AND ue.bucket_nuevo = a.bucket
-          THEN ue.fecha::text
+          THEN to_json(ue.fecha AT TIME ZONE 'UTC')#>>'{}'
         ELSE NULL
       END AS fecha_entrada_bucket,
       b.prefijo, b.nombre, b.color, b.estado_mora

--- a/apps/crm/apps/server/src/db/migrations/0030_cb026_metodo_contacto_sms.sql
+++ b/apps/crm/apps/server/src/db/migrations/0030_cb026_metodo_contacto_sms.sql
@@ -1,0 +1,38 @@
+-- 0030: CB-026 — Canal SMS en `metodo_contacto`.
+-- Espejo exacto del schema drizzle `src/db/schema/cobros.ts`
+-- (metodoContactoEnum). Idempotente: seguro de re-correr. Aplicar A MANO (no
+-- drizzle-kit push/migrate corrido desde este trabajo — mismo criterio que
+-- 0026_cb020_promesa_pago_cuotas.sql / 0028 / 0029; el journal de drizzle-kit
+-- está congelado en 0018 y este linaje de migraciones de cobros no pasa por el
+-- runner. NO regenerar snapshots con `db:generate`).
+--
+-- CB-026 pide 3 intentos en 3 canales distintos (WhatsApp, llamada, SMS) para
+-- agotar la gestión temprana de una cuenta B1. Los intentos se cuentan desde
+-- `contactos_cobros`, registrados A MANO por el asesor — el botón "SMS" del
+-- modal (enviarSmsCobros) solo envía y hace toast, no crea fila. Sin este
+-- valor no había forma de REGISTRAR un intento por SMS y el canal quedaba
+-- permanentemente en cero, haciendo imposible el "3 de 3" del ticket.
+--
+-- El tipo `public.metodo_contacto` es la columna de CUATRO lugares:
+--   contactos_cobros.metodo_contacto
+--   notificaciones_cobros.canal
+--   seguimientos_programados.metodo_contacto
+--   casos_cobros.metodo_contacto_proximo
+-- Agregar un valor es ADITIVO para las cuatro: no reescribe tablas, no toma
+-- lock exclusivo, no invalida filas existentes, y ninguna tiene CHECK ni
+-- índice parcial que enumere los valores. Ningún consumidor hace un switch
+-- exhaustivo sin default sobre este enum (getMetodoIcon en web cae a Phone).
+--
+-- IRREVERSIBLE en la práctica: Postgres no permite quitar un valor de un enum
+-- nativo. Revertir exigiría crear un tipo nuevo, migrar las 4 columnas con
+-- ALTER TABLE ... TYPE ... USING y reasignar defaults.
+--
+-- ORDEN DE DESPLIEGUE: aplicar este SQL ANTES de desplegar el web que ofrece
+-- la opción SMS en el modal, o el insert revienta con
+-- "invalid input value for enum metodo_contacto".
+
+DO $$ BEGIN
+  ALTER TYPE "public"."metodo_contacto" ADD VALUE IF NOT EXISTS 'sms';
+EXCEPTION
+  WHEN duplicate_object THEN null;
+END $$;

--- a/apps/crm/apps/server/src/db/schema/cobros.ts
+++ b/apps/crm/apps/server/src/db/schema/cobros.ts
@@ -30,9 +30,24 @@ export const estadoMoraEnum = pgEnum("estado_mora", [
 	"incobrable", // Declarado incobrable
 ]);
 
+// CB-026: los 3 canales de la gestión temprana B1 son llamada / whatsapp /
+// sms. `sms` se agregó a ESTE enum (no a uno aparte) porque el mismo tipo es
+// la columna de 4 lugares — contactos_cobros.metodo_contacto,
+// notificaciones_cobros.canal, seguimientos_programados.metodo_contacto y
+// casos_cobros.metodo_contacto_proximo — y partirlo obligaría a mantener dos
+// catálogos de canal en paralelo.
+// AGREGAR un valor es aditivo y seguro: `ALTER TYPE ... ADD VALUE` no reescribe
+// tabla ni toma lock exclusivo, y ninguna de las 4 columnas tiene CHECK ni
+// índice parcial que enumere valores. QUITARLO después NO se puede en caliente
+// (ver la nota de estado_contacto abajo) — el valor es irreversible en la
+// práctica.
+// Nota: el orden de este array es cosmético. `ADD VALUE` sin BEFORE/AFTER
+// agrega la etiqueta al FINAL del orden de sort de Postgres; nadie hace
+// ORDER BY sobre esta columna, así que la divergencia es inocua.
 export const metodoContactoEnum = pgEnum("metodo_contacto", [
 	"llamada",
 	"whatsapp",
+	"sms",
 	"email",
 	"visita_domicilio",
 	"carta_notarial",

--- a/apps/crm/apps/server/src/jobs/cierre-diario-asesores.ts
+++ b/apps/crm/apps/server/src/jobs/cierre-diario-asesores.ts
@@ -38,6 +38,10 @@ import { inArray } from "drizzle-orm";
 import { db } from "../db";
 import { user } from "../db/schema/auth";
 import { casosCobros } from "../db/schema/cobros";
+import {
+	PREFIJO_PREMORA_AUTO,
+	PREFIJO_WSP_MASIVO,
+} from "../lib/gestion-temprana-b1";
 import { toDateStrGT } from "../lib/guatemala-month-window";
 import { carteraBackClient } from "../services/cartera-back-client";
 
@@ -45,13 +49,20 @@ import { carteraBackClient } from "../services/cartera-back-client";
  * Prefijos con los que el sistema marca los contactos que genera solo
  * (`contactos_cobros` no tiene columna de origen). Los escriben
  * send-premora-reminders.ts y cobros.ts::enviarWhatsappMasivoCobros; acá se
- * leen para excluirlos de la gestión del asesor. Se exportan porque el reporte
- * (routers/cobros.ts) aplica el mismo criterio al contar promesas y al
+ * leen para excluirlos de la gestión del asesor. Se re-exportan porque el
+ * reporte (routers/cobros.ts) aplica el mismo criterio al contar promesas y al
  * etiquetar el origen en el detalle — así el filtro de escritura y el de
  * lectura no pueden divergir.
+ *
+ * CB-026: la definición vive ahora en lib/gestion-temprana-b1.ts, que es un
+ * módulo PURO y por eso lo puede importar también el web (este archivo arrastra
+ * `db` y `carteraBackClient`, que no pueden entrar al bundle del browser). Una
+ * sola definición, dos consumidores.
  */
-export const PREFIJO_PREMORA_AUTO = "Recordatorio automático";
-export const PREFIJO_WSP_MASIVO = "Envío masivo de WhatsApp";
+export {
+	PREFIJO_PREMORA_AUTO,
+	PREFIJO_WSP_MASIVO,
+} from "../lib/gestion-temprana-b1";
 
 // Two-component advisory lock key: namespace=1 (cobros jobs), key=2 (cierre diario asesor)
 const CIERRE_DIARIO_LOCK = [1, 2] as const;

--- a/apps/crm/apps/server/src/lib/gestion-temprana-b1.test.ts
+++ b/apps/crm/apps/server/src/lib/gestion-temprana-b1.test.ts
@@ -1,0 +1,442 @@
+import { describe, expect, spyOn, test } from "bun:test";
+import {
+	type ContactoParaGestionB1,
+	esContactoAutomatico,
+	etiquetaMetodoContacto,
+	evaluarGestionTempranaB1,
+	PREFIJO_PREMORA_AUTO,
+	PREFIJO_WSP_MASIVO,
+} from "./gestion-temprana-b1";
+
+// El crédito entró a B1 el 2026-07-20. Todo lo anterior queda fuera de la
+// ventana; todo lo posterior cuenta.
+const ENTRADA_B1 = new Date("2026-07-20T12:00:00.000Z");
+const ANTES = new Date("2026-07-19T12:00:00.000Z");
+const DESPUES = new Date("2026-07-21T12:00:00.000Z");
+const MAS_TARDE = new Date("2026-07-22T12:00:00.000Z");
+
+function contacto(
+	overrides: Partial<ContactoParaGestionB1> = {},
+): ContactoParaGestionB1 {
+	return {
+		metodoContacto: "whatsapp",
+		estadoContacto: "no_contesta",
+		fechaContacto: DESPUES,
+		comentarios: "Se intentó contactar al cliente",
+		...overrides,
+	};
+}
+
+function evaluar(
+	contactos: ContactoParaGestionB1[],
+	overrides: {
+		bucket?: number | null;
+		fechaEntradaBucket?: Date | string | null;
+	} = {},
+) {
+	return evaluarGestionTempranaB1({
+		bucket: overrides.bucket !== undefined ? overrides.bucket : 1,
+		fechaEntradaBucket:
+			overrides.fechaEntradaBucket !== undefined
+				? overrides.fechaEntradaBucket
+				: ENTRADA_B1,
+		contactos,
+	});
+}
+
+/** Estrecha el resultado a la variante aplicable (falla el test si no aplica). */
+function aplicable(resultado: ReturnType<typeof evaluar>) {
+	if (!resultado.aplica) {
+		throw new Error(
+			`Se esperaba aplica:true, llegó motivo=${resultado.motivo}`,
+		);
+	}
+	return resultado;
+}
+
+describe("evaluarGestionTempranaB1 — aplicabilidad", () => {
+	test("bucket 0 (Cartera Sana) → no aplica", () => {
+		const r = evaluar([], { bucket: 0 });
+		expect(r).toEqual({ aplica: false, motivo: "no_es_b1" });
+	});
+
+	test("bucket 2 (Gestión Activa) → no aplica: la regla es solo de gestión temprana", () => {
+		const r = evaluar([], { bucket: 2 });
+		expect(r).toEqual({ aplica: false, motivo: "no_es_b1" });
+	});
+
+	test("bucket null (fuera del funnel, p.ej. en convenio) → no aplica", () => {
+		const r = evaluar([], { bucket: null });
+		expect(r).toEqual({ aplica: false, motivo: "no_es_b1" });
+	});
+
+	test("B1 sin fecha de entrada → no aplica: no se inventa la ventana", () => {
+		const r = evaluar([], { fechaEntradaBucket: null });
+		expect(r).toEqual({ aplica: false, motivo: "sin_fecha_entrada" });
+	});
+
+	test("B1 con fecha de entrada malformada (no parseable) → no aplica, no revienta", () => {
+		const r = evaluar([], { fechaEntradaBucket: "no-es-una-fecha" });
+		expect(r).toEqual({ aplica: false, motivo: "sin_fecha_entrada" });
+	});
+
+	test("B1 con fecha de entrada → aplica", () => {
+		expect(evaluar([]).aplica).toBe(true);
+	});
+});
+
+describe("evaluarGestionTempranaB1 — ventana temporal", () => {
+	test("contacto ANTERIOR a la entrada al bucket no cuenta", () => {
+		const r = aplicable(evaluar([contacto({ fechaContacto: ANTES })]));
+		expect(r.canalesFaltantes).toEqual(["whatsapp", "llamada", "sms"]);
+	});
+
+	test("contacto EXACTAMENTE en la fecha de entrada sí cuenta (bound inclusivo)", () => {
+		const r = aplicable(evaluar([contacto({ fechaContacto: ENTRADA_B1 })]));
+		expect(r.canalesFaltantes).toEqual(["llamada", "sms"]);
+	});
+
+	test("contacto posterior a la entrada cuenta", () => {
+		const r = aplicable(evaluar([contacto({ fechaContacto: DESPUES })]));
+		expect(r.canalesFaltantes).toEqual(["llamada", "sms"]);
+	});
+
+	test("ciclo B1→B2→B1: la gestión del ciclo viejo NO suprime la alerta del nuevo", () => {
+		// Los 3 canales se agotaron ANTES de reentrar a B1. Si la ventana no
+		// filtrara, esto diría "agotada" y el asesor no volvería a gestionar.
+		const r = aplicable(
+			evaluar([
+				contacto({ metodoContacto: "whatsapp", fechaContacto: ANTES }),
+				contacto({ metodoContacto: "llamada", fechaContacto: ANTES }),
+				contacto({ metodoContacto: "sms", fechaContacto: ANTES }),
+			]),
+		);
+		expect(r.estado).toBe("incompleta");
+		expect(r.canalesFaltantes).toEqual(["whatsapp", "llamada", "sms"]);
+	});
+
+	test("contacto sin fecha se descarta en vez de asumirlo dentro de la ventana", () => {
+		const r = aplicable(evaluar([contacto({ fechaContacto: null })]));
+		expect(r.canalesFaltantes).toEqual(["whatsapp", "llamada", "sms"]);
+	});
+
+	test("contacto con fecha corrupta (string no parseable) se descarta sin reventar", () => {
+		const warnSpy = spyOn(console, "warn").mockImplementation(() => {});
+		try {
+			const r = aplicable(
+				evaluar([contacto({ fechaContacto: "no-es-una-fecha" as any })]),
+			);
+			expect(r.canalesFaltantes).toEqual(["whatsapp", "llamada", "sms"]);
+			expect(warnSpy).toHaveBeenCalledTimes(1);
+		} finally {
+			warnSpy.mockRestore();
+		}
+	});
+});
+
+describe("evaluarGestionTempranaB1 — cobertura de canales", () => {
+	test("sin contactos → faltan los 3, incompleta", () => {
+		const r = aplicable(evaluar([]));
+		expect(r.canalesFaltantes).toEqual(["whatsapp", "llamada", "sms"]);
+		expect(r.estado).toBe("incompleta");
+	});
+
+	test("solo WhatsApp sin respuesta → faltan llamada y sms", () => {
+		const r = aplicable(evaluar([contacto({ metodoContacto: "whatsapp" })]));
+		expect(r.canalesFaltantes).toEqual(["llamada", "sms"]);
+		expect(r.estado).toBe("incompleta");
+	});
+
+	test("WhatsApp + llamada sin respuesta → falta SMS (caso del criterio de aceptación)", () => {
+		const r = aplicable(
+			evaluar([
+				contacto({ metodoContacto: "whatsapp" }),
+				contacto({ metodoContacto: "llamada" }),
+			]),
+		);
+		expect(r.canalesFaltantes).toEqual(["sms"]);
+		expect(r.estado).toBe("incompleta");
+	});
+
+	test("los 3 canales intentados sin respuesta → agotada", () => {
+		const r = aplicable(
+			evaluar([
+				contacto({ metodoContacto: "whatsapp" }),
+				contacto({ metodoContacto: "llamada" }),
+				contacto({ metodoContacto: "sms" }),
+			]),
+		);
+		expect(r.canalesFaltantes).toEqual([]);
+		expect(r.estado).toBe("agotada");
+	});
+
+	test("3 intentos TODOS por WhatsApp ≠ 3 canales: sigue incompleta", () => {
+		const r = aplicable(
+			evaluar([
+				contacto({ metodoContacto: "whatsapp" }),
+				contacto({ metodoContacto: "whatsapp" }),
+				contacto({ metodoContacto: "whatsapp" }),
+			]),
+		);
+		expect(r.canales[0].intentos).toBe(3);
+		expect(r.canalesFaltantes).toEqual(["llamada", "sms"]);
+		expect(r.estado).toBe("incompleta");
+	});
+
+	test("ultimoIntento por canal = el más reciente dentro de la ventana", () => {
+		const r = aplicable(
+			evaluar([
+				contacto({ metodoContacto: "whatsapp", fechaContacto: MAS_TARDE }),
+				contacto({ metodoContacto: "whatsapp", fechaContacto: DESPUES }),
+			]),
+		);
+		expect(r.canales[0].ultimoIntento).toEqual(MAS_TARDE);
+	});
+});
+
+describe("evaluarGestionTempranaB1 — early exit (el cliente contestó)", () => {
+	test("contactado → respondio, aunque falten 2 canales", () => {
+		const r = aplicable(
+			evaluar([
+				contacto({ metodoContacto: "whatsapp", estadoContacto: "contactado" }),
+			]),
+		);
+		expect(r.estado).toBe("respondio");
+		expect(r.canalQueContesto).toBe("whatsapp");
+		expect(r.canalesFaltantes).toEqual(["llamada", "sms"]);
+	});
+
+	test("acuerdo_parcial → respondio", () => {
+		const r = aplicable(
+			evaluar([
+				contacto({
+					metodoContacto: "llamada",
+					estadoContacto: "acuerdo_parcial",
+				}),
+			]),
+		);
+		expect(r.estado).toBe("respondio");
+		expect(r.canalQueContesto).toBe("llamada");
+	});
+
+	test("rechaza_pagar → respondio: el cliente atendió, seguir marcando no lo des-niega", () => {
+		const r = aplicable(
+			evaluar([
+				contacto({
+					metodoContacto: "llamada",
+					estadoContacto: "rechaza_pagar",
+				}),
+			]),
+		);
+		expect(r.estado).toBe("respondio");
+	});
+
+	test("promesa_pago → respondio y tienePromesa", () => {
+		const r = aplicable(
+			evaluar([
+				contacto({
+					metodoContacto: "whatsapp",
+					estadoContacto: "promesa_pago",
+				}),
+			]),
+		);
+		expect(r.estado).toBe("respondio");
+		expect(r.tienePromesa).toBe(true);
+	});
+
+	test("no_contesta NO dispara el early exit", () => {
+		const r = aplicable(
+			evaluar([
+				contacto({ metodoContacto: "whatsapp", estadoContacto: "no_contesta" }),
+			]),
+		);
+		expect(r.estado).toBe("incompleta");
+		expect(r.canalQueContesto).toBeNull();
+	});
+
+	test("numero_equivocado NO es respuesta, pero marca el canal como dato inválido", () => {
+		const r = aplicable(
+			evaluar([
+				contacto({
+					metodoContacto: "whatsapp",
+					estadoContacto: "numero_equivocado",
+				}),
+			]),
+		);
+		expect(r.estado).toBe("incompleta");
+		expect(r.canalQueContesto).toBeNull();
+		expect(r.canales[0].datoInvalido).toBe(true);
+		// Sigue contando como intento: el canal se intentó, no está pendiente.
+		expect(r.canales[0].intentos).toBe(1);
+	});
+
+	test("respondió Y se intentó por los 3 → respondio gana sobre agotada", () => {
+		const r = aplicable(
+			evaluar([
+				contacto({ metodoContacto: "whatsapp", estadoContacto: "contactado" }),
+				contacto({ metodoContacto: "llamada" }),
+				contacto({ metodoContacto: "sms" }),
+			]),
+		);
+		expect(r.estado).toBe("respondio");
+		expect(r.canalesFaltantes).toEqual([]);
+	});
+
+	test("dos canales contestaron → canalQueContesto es el cronológicamente primero", () => {
+		const r = aplicable(
+			evaluar([
+				// Llega primero en el array (el historial viene descendente) pero es
+				// el más NUEVO: no debe ganar.
+				contacto({
+					metodoContacto: "llamada",
+					estadoContacto: "contactado",
+					fechaContacto: MAS_TARDE,
+				}),
+				contacto({
+					metodoContacto: "whatsapp",
+					estadoContacto: "contactado",
+					fechaContacto: DESPUES,
+				}),
+			]),
+		);
+		expect(r.canalQueContesto).toBe("whatsapp");
+	});
+});
+
+describe("evaluarGestionTempranaB1 — contactos automáticos", () => {
+	test("recordatorio automático de premora no cuenta como intento del asesor", () => {
+		const r = aplicable(
+			evaluar([
+				contacto({
+					metodoContacto: "whatsapp",
+					comentarios: `${PREFIJO_PREMORA_AUTO} — cuota vence en 3 días`,
+				}),
+			]),
+		);
+		expect(r.canalesFaltantes).toEqual(["whatsapp", "llamada", "sms"]);
+	});
+
+	test("envío masivo de WhatsApp no cuenta como intento del asesor", () => {
+		const r = aplicable(
+			evaluar([
+				contacto({
+					metodoContacto: "whatsapp",
+					comentarios: `${PREFIJO_WSP_MASIVO} — Plantilla: recordatorio`,
+				}),
+			]),
+		);
+		expect(r.canalesFaltantes).toEqual(["whatsapp", "llamada", "sms"]);
+	});
+
+	test("un automático que SÍ contestó tampoco dispara el early exit", () => {
+		const r = aplicable(
+			evaluar([
+				contacto({
+					metodoContacto: "whatsapp",
+					estadoContacto: "contactado",
+					comentarios: `${PREFIJO_WSP_MASIVO} — Plantilla: x`,
+				}),
+			]),
+		);
+		expect(r.estado).toBe("incompleta");
+		expect(r.canalQueContesto).toBeNull();
+	});
+
+	test("comentarios null cuenta como manual (no revienta)", () => {
+		const r = aplicable(
+			evaluar([contacto({ metodoContacto: "whatsapp", comentarios: null })]),
+		);
+		expect(r.canales[0].intentos).toBe(1);
+	});
+
+	test("el prefijo EN MEDIO del texto sí es manual: solo cuenta al inicio", () => {
+		const r = aplicable(
+			evaluar([
+				contacto({
+					metodoContacto: "whatsapp",
+					comentarios: `El cliente pregunta por el ${PREFIJO_PREMORA_AUTO} que recibió`,
+				}),
+			]),
+		);
+		expect(r.canales[0].intentos).toBe(1);
+	});
+});
+
+describe("evaluarGestionTempranaB1 — canales fuera de los 3", () => {
+	test("email cuenta como otro canal, no cubre ninguno de los 3", () => {
+		const r = aplicable(evaluar([contacto({ metodoContacto: "email" })]));
+		expect(r.otrosCanales).toBe(1);
+		expect(r.canalesFaltantes).toEqual(["whatsapp", "llamada", "sms"]);
+		expect(r.estado).toBe("incompleta");
+	});
+
+	test("visita_domicilio contactado NO dispara el early exit por sí sola", () => {
+		const r = aplicable(
+			evaluar([
+				contacto({
+					metodoContacto: "visita_domicilio",
+					estadoContacto: "contactado",
+				}),
+			]),
+		);
+		expect(r.canalQueContesto).toBeNull();
+		expect(r.estado).toBe("incompleta");
+	});
+
+	test("una promesa por un canal fuera de los 3 sí satisface el early exit", () => {
+		// El compromiso de pago es condición de salida explícita del ticket,
+		// sin importar por dónde se consiguió.
+		const r = aplicable(
+			evaluar([
+				contacto({
+					metodoContacto: "visita_domicilio",
+					estadoContacto: "promesa_pago",
+				}),
+			]),
+		);
+		expect(r.tienePromesa).toBe(true);
+		expect(r.estado).toBe("respondio");
+		expect(r.canalQueContesto).toBeNull();
+	});
+});
+
+describe("esContactoAutomatico", () => {
+	test("null → false", () => {
+		expect(esContactoAutomatico(null)).toBe(false);
+	});
+
+	test("cada prefijo al inicio → true", () => {
+		expect(esContactoAutomatico(`${PREFIJO_PREMORA_AUTO} x`)).toBe(true);
+		expect(esContactoAutomatico(`${PREFIJO_WSP_MASIVO} x`)).toBe(true);
+	});
+
+	test("texto libre del asesor → false", () => {
+		expect(esContactoAutomatico("No contesta, se reintenta mañana")).toBe(
+			false,
+		);
+	});
+});
+
+describe("etiquetaMetodoContacto", () => {
+	test("sms se rinde en mayúsculas, no 'Sms'", () => {
+		expect(etiquetaMetodoContacto("sms")).toBe("SMS");
+	});
+
+	test("visita_domicilio se rinde legible, no 'Visita_domicilio'", () => {
+		expect(etiquetaMetodoContacto("visita_domicilio")).toBe(
+			"Visita a domicilio",
+		);
+	});
+
+	test("whatsapp conserva su capitalización de marca", () => {
+		expect(etiquetaMetodoContacto("whatsapp")).toBe("WhatsApp");
+	});
+
+	test("valor desconocido cae al capitalizado en vez de vaciarse", () => {
+		expect(etiquetaMetodoContacto("telepatia")).toBe("Telepatia");
+	});
+
+	test("string vacío → guion", () => {
+		expect(etiquetaMetodoContacto("")).toBe("—");
+	});
+});

--- a/apps/crm/apps/server/src/lib/gestion-temprana-b1.ts
+++ b/apps/crm/apps/server/src/lib/gestion-temprana-b1.ts
@@ -1,0 +1,277 @@
+/**
+ * CB-026 — Gestión temprana B1 (función pura, sin DB ni red).
+ *
+ * Regla: una cuenta en B1 debe agotar 3 intentos en 3 canales DISTINTOS
+ * (WhatsApp, llamada, SMS) antes de darse por gestionada. Si el cliente
+ * contesta por cualquiera de los 3 — o se registra un compromiso de pago —
+ * no hace falta intentar los restantes (early exit del criterio de aceptación).
+ *
+ * Decisiones de dominio, todas deliberadas:
+ *
+ *  1. LOS 3 CANALES son exactamente los del ticket. email / visita_domicilio /
+ *     carta_notarial NO cuentan ni sustituyen a ninguno — dejar que un email
+ *     tape el hueco del SMS vaciaría de sentido "3 canales distintos". Igual se
+ *     cuentan aparte (`otrosCanales`) para que la UI pueda explicar por qué el
+ *     resumen dice 2/3 mientras el Historial de abajo muestra más filas.
+ *
+ *  2. SOLO INTENTOS MANUALES. Los contactos que genera el sistema (premora
+ *     automática, WhatsApp masivo) se excluyen — `contactos_cobros` no tiene
+ *     columna de origen, así que se detectan por prefijo en `comentarios`,
+ *     mismo criterio que ya usa el cierre diario (CB-024, es_efectivo_manual).
+ *     Si contaran, un B1 mostraría "WhatsApp ✓" sin que el asesor lo tocara:
+ *     exactamente el gaming que la alerta busca evitar.
+ *
+ *  3. "CONTESTÓ" = contactado | acuerdo_parcial | rechaza_pagar | promesa_pago.
+ *     Los primeros tres son el set de es_efectivo_manual de CB-024 — se reusa
+ *     en vez de inventar una segunda definición de "efectivo". `rechaza_pagar`
+ *     cuenta: el cliente atendió, y llamarlo por los otros dos canales no lo va
+ *     a des-negar; lo que sigue es escalar, no seguir marcando. `promesa_pago`
+ *     se suma porque el ticket lo nombra explícito ("desencadenar un compromiso
+ *     de pago"); CB-024 lo excluía solo porque allá las categorías son
+ *     mutuamente excluyentes, restricción que acá no existe.
+ *     `numero_equivocado` NO es respuesta, pero marca el canal como inutilizable
+ *     (`datoInvalido`) — es distinto de "sin intentar" y la UI debe poder
+ *     diferenciarlo.
+ *
+ *  4. VENTANA: solo cuentan los contactos desde que el crédito ENTRÓ al bucket
+ *     (`fechaEntradaBucket`, inclusivo). Sin esto, un crédito que ya ciclò
+ *     B1→B2→B1 arrastraría la gestión del trimestre pasado y suprimiría la
+ *     alerta justo cuando más importa.
+ *
+ *  5. SIN FECHA DE ENTRADA → `aplica: false`. Mismo criterio "degradar sin
+ *     inventar dato" de cola-dia.ts, que EXCLUYE los créditos sin fila en
+ *     buckets_historial en vez de asumirles una fecha. Un falso "gestión
+ *     agotada" es peor que no mostrar nada.
+ *
+ * Módulo PURO a propósito: lo importa tanto el server como el web
+ * (`server/src/lib/...` vía el path alias del tsconfig del web, mismo patrón
+ * que lead-sources.ts) — una sola definición de la regla, no dos que puedan
+ * divergir.
+ */
+
+/** Los 3 canales que la gestión temprana B1 exige agotar. El orden es el de render. */
+export const CANALES_GESTION_B1 = ["whatsapp", "llamada", "sms"] as const;
+
+export type CanalGestionB1 = (typeof CANALES_GESTION_B1)[number];
+
+/** Único bucket al que aplica la regla (B1 = "Alerta Temprana"). */
+export const BUCKET_GESTION_TEMPRANA = 1;
+
+/**
+ * Prefijos con los que el sistema marca los contactos que genera solo
+ * (`contactos_cobros` no tiene columna de origen). Los escriben
+ * send-premora-reminders.ts y cobros.ts::enviarWhatsappMasivoCobros.
+ *
+ * Viven acá —y no en jobs/cierre-diario-asesores.ts, donde nacieron— porque
+ * este módulo es puro y el web lo puede importar; el job arrastra `db` y
+ * `carteraBackClient`, que no pueden entrar al bundle del browser. El job los
+ * re-exporta para que sus consumidores actuales no cambien de import.
+ */
+export const PREFIJO_PREMORA_AUTO = "Recordatorio automático";
+export const PREFIJO_WSP_MASIVO = "Envío masivo de WhatsApp";
+
+/** `estadoContacto` que significan "el cliente CONTESTÓ" (ver decisión 3 arriba). */
+export const ESTADOS_CONTESTO = [
+	"contactado",
+	"acuerdo_parcial",
+	"rechaza_pagar",
+	"promesa_pago",
+] as const;
+
+/** Fila mínima de `contactos_cobros` que la regla necesita. */
+export interface ContactoParaGestionB1 {
+	metodoContacto: string;
+	estadoContacto: string;
+	fechaContacto: Date | string | null;
+	comentarios: string | null;
+}
+
+export interface EstadoCanalB1 {
+	canal: CanalGestionB1;
+	/** Intentos manuales registrados por este canal dentro de la ventana. */
+	intentos: number;
+	/** true si algún intento por este canal tuvo estado de "contestó". */
+	contesto: boolean;
+	/** true si algún intento marcó numero_equivocado (canal inutilizable, ≠ sin intentar). */
+	datoInvalido: boolean;
+	/** Fecha del último intento por este canal dentro de la ventana. */
+	ultimoIntento: Date | null;
+}
+
+/**
+ * - "respondio"  → contestó en algún canal (o hay promesa): NO hace falta
+ *                  intentar los restantes. Es el early exit del ticket.
+ * - "agotada"    → los 3 canales tienen al menos un intento, sin respuesta.
+ * - "incompleta" → faltan canales por intentar. Es el caso que ALERTA.
+ *
+ * Precedencia en ese orden: si el cliente respondió Y además se intentó por los
+ * 3, el estado es "respondio" (más informativo que "agotada").
+ */
+export type EstadoGestionB1 = "respondio" | "agotada" | "incompleta";
+
+export type ResultadoGestionB1 =
+	| { aplica: false; motivo: "no_es_b1" | "sin_fecha_entrada" }
+	| {
+			aplica: true;
+			canales: EstadoCanalB1[];
+			/** Canales de los 3 sin ningún intento manual en la ventana. */
+			canalesFaltantes: CanalGestionB1[];
+			/** Canal donde el cliente contestó primero (cronológicamente), o null. */
+			canalQueContesto: CanalGestionB1 | null;
+			/** true si hay una promesa de pago registrada en la ventana. */
+			tienePromesa: boolean;
+			/** Intentos manuales en la ventana por canales FUERA de los 3 (email, visita...). */
+			otrosCanales: number;
+			estado: EstadoGestionB1;
+	  };
+
+/** true si el contacto lo generó el sistema (premora automática / WhatsApp masivo). */
+export function esContactoAutomatico(comentarios: string | null): boolean {
+	if (!comentarios) return false;
+	return (
+		comentarios.startsWith(PREFIJO_PREMORA_AUTO) ||
+		comentarios.startsWith(PREFIJO_WSP_MASIVO)
+	);
+}
+
+const ETIQUETAS_METODO: Record<string, string> = {
+	llamada: "Llamada",
+	whatsapp: "WhatsApp",
+	sms: "SMS",
+	email: "Email",
+	visita_domicilio: "Visita a domicilio",
+	carta_notarial: "Carta notarial",
+};
+
+/**
+ * Etiqueta en español de un `metodoContacto`. Existe porque capitalizar el
+ * valor crudo produce "Visita_domicilio" y "Sms". Un valor desconocido (enum
+ * ampliado en el futuro) cae al capitalizado en vez de renderizar vacío.
+ */
+export function etiquetaMetodoContacto(metodo: string): string {
+	const conocida = ETIQUETAS_METODO[metodo];
+	if (conocida) return conocida;
+	if (!metodo) return "—";
+	return metodo.charAt(0).toUpperCase() + metodo.slice(1);
+}
+
+function aFecha(valor: Date | string | null): Date | null {
+	if (!valor) return null;
+	const fecha = valor instanceof Date ? valor : new Date(valor);
+	return Number.isNaN(fecha.getTime()) ? null : fecha;
+}
+
+const esCanalGestion = (metodo: string): metodo is CanalGestionB1 =>
+	(CANALES_GESTION_B1 as readonly string[]).includes(metodo);
+
+const contesto = (estadoContacto: string): boolean =>
+	(ESTADOS_CONTESTO as readonly string[]).includes(estadoContacto);
+
+/**
+ * Evalúa la gestión temprana de un crédito. Ver el encabezado del módulo para
+ * las decisiones de dominio. Nunca lanza: entradas inválidas (fecha corrupta,
+ * comentarios null) degradan, no revientan.
+ */
+export function evaluarGestionTempranaB1(params: {
+	bucket: number | null;
+	fechaEntradaBucket: Date | string | null;
+	contactos: readonly ContactoParaGestionB1[];
+}): ResultadoGestionB1 {
+	if (params.bucket !== BUCKET_GESTION_TEMPRANA) {
+		return { aplica: false, motivo: "no_es_b1" };
+	}
+
+	const entrada = aFecha(params.fechaEntradaBucket);
+	if (!entrada) return { aplica: false, motivo: "sin_fecha_entrada" };
+
+	const porCanal = new Map<CanalGestionB1, EstadoCanalB1>(
+		CANALES_GESTION_B1.map((canal) => [
+			canal,
+			{
+				canal,
+				intentos: 0,
+				contesto: false,
+				datoInvalido: false,
+				ultimoIntento: null,
+			},
+		]),
+	);
+
+	let otrosCanales = 0;
+	let tienePromesa = false;
+	// Se resuelve al final: el canal que contestó PRIMERO cronológicamente, no
+	// el primero en el orden de render ni el primero del array de entrada (que
+	// llega en orden descendente desde getHistorialContactos).
+	let respuestaMasTemprana: { canal: CanalGestionB1; fecha: Date } | null =
+		null;
+
+	for (const contacto of params.contactos) {
+		if (esContactoAutomatico(contacto.comentarios)) continue;
+
+		const fecha = aFecha(contacto.fechaContacto);
+		// Sin fecha no se puede ubicar en la ventana: se descarta en vez de
+		// asumir que cae dentro (mismo criterio que la fecha de entrada). A
+		// diferencia de "fuera de ventana" (esperado, no se avisa), esto es un
+		// dato corrupto — un intento real puede desaparecer sin que nadie note
+		// por qué el canal sigue en rojo. Warning, no error: la regla igual
+		// degrada con seguridad y no debe tumbar la carga de la página.
+		if (contacto.fechaContacto && !fecha) {
+			console.warn(
+				`[gestion-temprana-b1] fechaContacto no parseable, se descarta el intento: ${JSON.stringify(contacto.fechaContacto)}`,
+			);
+			continue;
+		}
+		if (!fecha || fecha < entrada) continue;
+
+		if (contacto.estadoContacto === "promesa_pago") tienePromesa = true;
+
+		if (!esCanalGestion(contacto.metodoContacto)) {
+			otrosCanales++;
+			continue;
+		}
+
+		const estado = porCanal.get(contacto.metodoContacto);
+		if (!estado) continue;
+
+		estado.intentos++;
+		if (!estado.ultimoIntento || fecha > estado.ultimoIntento) {
+			estado.ultimoIntento = fecha;
+		}
+		if (contacto.estadoContacto === "numero_equivocado") {
+			estado.datoInvalido = true;
+		}
+		if (contesto(contacto.estadoContacto)) {
+			estado.contesto = true;
+			if (!respuestaMasTemprana || fecha < respuestaMasTemprana.fecha) {
+				respuestaMasTemprana = { canal: contacto.metodoContacto, fecha };
+			}
+		}
+	}
+
+	const canales = CANALES_GESTION_B1.map(
+		(canal) => porCanal.get(canal) as EstadoCanalB1,
+	);
+	const canalesFaltantes = canales
+		.filter((c) => c.intentos === 0)
+		.map((c) => c.canal);
+	const canalQueContesto = respuestaMasTemprana?.canal ?? null;
+
+	// Precedencia: respondió > agotada > incompleta.
+	// `tienePromesa` también satisface el early exit: una promesa registrada
+	// por un canal fuera de los 3 (p.ej. visita) sigue siendo un compromiso
+	// conseguido, y el ticket lo nombra como condición de salida.
+	let estado: EstadoGestionB1;
+	if (canalQueContesto !== null || tienePromesa) estado = "respondio";
+	else if (canalesFaltantes.length === 0) estado = "agotada";
+	else estado = "incompleta";
+
+	return {
+		aplica: true,
+		canales,
+		canalesFaltantes,
+		canalQueContesto,
+		tienePromesa,
+		otrosCanales,
+		estado,
+	};
+}

--- a/apps/crm/apps/server/src/lib/resolver-numero-sifco.ts
+++ b/apps/crm/apps/server/src/lib/resolver-numero-sifco.ts
@@ -1,0 +1,29 @@
+import { eq } from "drizzle-orm";
+import { db } from "../db";
+import { casosCobros } from "../db/schema/cobros";
+
+const UUID_REGEX =
+	/^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i;
+
+/**
+ * Resuelve un `creditoId` de entrada (número SIFCO o UUID de caso, según de
+ * dónde venga el link — notificaciones mandan el UUID, el resto de la app
+ * manda el SIFCO) al número SIFCO real. Si ya es SIFCO, se devuelve tal cual.
+ *
+ * Único lugar de esta resolución: antes vivía duplicada verbatim en
+ * getDetallesCreditoCarteraBack y en getBucketActualCredito — un fix en una
+ * copia podía olvidarse en la otra.
+ */
+export async function resolverNumeroSifco(
+	creditoId: string,
+): Promise<string | null> {
+	if (!UUID_REGEX.test(creditoId)) return creditoId;
+
+	const [caso] = await db
+		.select({ numeroCreditoSifco: casosCobros.numeroCreditoSifco })
+		.from(casosCobros)
+		.where(eq(casosCobros.id, creditoId))
+		.limit(1);
+
+	return caso?.numeroCreditoSifco ?? null;
+}

--- a/apps/crm/apps/server/src/routers/cobros.ts
+++ b/apps/crm/apps/server/src/routers/cobros.ts
@@ -96,6 +96,7 @@ import {
 	type EstadoPromesa,
 	evaluarPromesa,
 } from "../lib/promesa-pago";
+import { resolverNumeroSifco } from "../lib/resolver-numero-sifco";
 import { PERMISSIONS } from "../lib/roles";
 import {
 	sendWhatsappTemplate,
@@ -1745,6 +1746,25 @@ export const cobrosRouter = {
 			}
 		}),
 
+	// Bucket ACTUAL del motor (COBROS-02) para el badge del detalle de cobros.
+	// Acepta el mismo `creditoId` que getDetallesCreditoCarteraBack (número
+	// SIFCO o UUID de caso) para que la página pase el param de la ruta tal
+	// cual. Degrada a null en vez de tirar error: el badge del cliente cae al
+	// estadoMora existente cuando esto falla o el motor no tiene bucket.
+	getBucketActualCredito: cobrosProcedure
+		.input(z.object({ creditoId: z.string().min(1).max(100) }))
+		.handler(async ({ input }) => {
+			if (!isCarteraBackEnabled()) return null;
+			try {
+				const numeroSifco = await resolverNumeroSifco(input.creditoId);
+				if (!numeroSifco) return null;
+				return await carteraBackClient.getBucketActualCredito(numeroSifco);
+			} catch (error) {
+				console.error("[getBucketActualCredito] Error:", error);
+				return null;
+			}
+		}),
+
 	// CC2-11: Agenda del día — cuotas que vencen HOY (D-0) hasta D-5 de créditos
 	// al día, agrupadas por urgencia. El rol cobros SOLO ve su agenda: se fuerza
 	// server-side matcheando su email de login contra los asesores de cartera
@@ -2902,23 +2922,15 @@ export const cobrosRouter = {
 			}
 
 			try {
-				let numeroSifco: string = input.creditoId ?? "";
+				const creditoIdInput = input.creditoId ?? "";
 
 				// 0. Si el creditoId es un UUID (viene de una notificación), resolverlo
 				//    al numeroCreditoSifco del caso de cobros antes de consultar cartera-back.
-				const UUID_REGEX =
-					/^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i;
-				if (UUID_REGEX.test(numeroSifco)) {
-					const [casoPorUUID] = await db
-						.select({ numeroCreditoSifco: casosCobros.numeroCreditoSifco })
-						.from(casosCobros)
-						.where(eq(casosCobros.id, numeroSifco))
-						.limit(1);
-					if (!casoPorUUID?.numeroCreditoSifco) {
-						throw new ORPCError("NOT_FOUND", { message: "Caso no encontrado" });
-					}
-					numeroSifco = casoPorUUID.numeroCreditoSifco;
+				const numeroSifcoResuelto = await resolverNumeroSifco(creditoIdInput);
+				if (numeroSifcoResuelto === null) {
+					throw new ORPCError("NOT_FOUND", { message: "Caso no encontrado" });
 				}
+				let numeroSifco: string = numeroSifcoResuelto;
 
 				// 1. Buscar referencia por sifco número de crédito
 				let reference = await db

--- a/apps/crm/apps/server/src/routers/index.ts
+++ b/apps/crm/apps/server/src/routers/index.ts
@@ -145,6 +145,7 @@ export const cobrosAppRouter = {
 	getBucketsCatalogoCargado: cobrosRouter.getBucketsCatalogoCargado,
 	getBucketsHistorial: cobrosRouter.getBucketsHistorial,
 	getBucketsHistorialCredito: cobrosRouter.getBucketsHistorialCredito,
+	getBucketActualCredito: cobrosRouter.getBucketActualCredito,
 	getAgendaDia: cobrosRouter.getAgendaDia,
 	getColaDia: cobrosRouter.getColaDia,
 	actualizarDiasSlaBuckets: cobrosRouter.actualizarDiasSlaBuckets,

--- a/apps/crm/apps/server/src/services/cartera-back-client.ts
+++ b/apps/crm/apps/server/src/services/cartera-back-client.ts
@@ -14,6 +14,7 @@ import type {
 	CarteraBackConnectionError,
 	CarteraBackError,
 	CarteraBackValidationError,
+	CarteraBucketActualCredito,
 	CarteraBucketCatalogo,
 	CarteraBucketHistorialEvento,
 	CarteraBucketsHistorialResponse,
@@ -1032,6 +1033,23 @@ export class CarteraBackClient {
 			data: CarteraBucketHistorialEvento[];
 		}>(`/buckets/historial/credito/${creditoId}`, { method: "GET" });
 		return response.data ?? [];
+	}
+
+	/**
+	 * Bucket ACTUAL de un crédito (motor COBROS-02) por número SIFCO. Sin
+	 * cache a propósito: getCredito() sí cachea 5 min y este badge debe
+	 * reflejar el motor al instante (mismo criterio que getBucketsHistorial).
+	 */
+	async getBucketActualCredito(
+		numeroSifco: string,
+	): Promise<CarteraBucketActualCredito | null> {
+		const response = await this.request<{
+			success: boolean;
+			data: CarteraBucketActualCredito;
+		}>(`/buckets/credito/${encodeURIComponent(numeroSifco)}`, {
+			method: "GET",
+		});
+		return response?.data ?? null;
 	}
 
 	/**

--- a/apps/crm/apps/server/src/types/cartera-back.ts
+++ b/apps/crm/apps/server/src/types/cartera-back.ts
@@ -948,6 +948,29 @@ export interface CarteraBucketCatalogo {
 	dias_sla: number | null;
 }
 
+/** Bucket ACTUAL de un crédito según el motor (GET /buckets/credito/:numero_credito_sifco). */
+export interface CarteraBucketActualCredito {
+	credito_id: number;
+	numero_credito_sifco: string;
+	/** 0-5, o null si el crédito salió del funnel (ver `fuera_funnel`) o no se pudo derivar. */
+	bucket: number | null;
+	prefijo: string | null;
+	nombre: string | null;
+	color: string | null;
+	estado_mora: string | null;
+	/** true = statusCredit fuera del funnel (EN_CONVENIO/CANCELADO/CAIDO/...): sin bucket por diseño. */
+	fuera_funnel: boolean;
+	/**
+	 * CB-026: fecha en que el crédito ENTRÓ al bucket actual (ISO), de la última
+	 * fila de `buckets_historial`. null = el bucket se derivó por fallback
+	 * (estado que lo fuerza / rango de cuotas) y no hay fecha de entrada
+	 * confiable, o el crédito está fuera del funnel. Los consumidores deben
+	 * degradar, nunca asumir una fecha: la gestión temprana B1 se cuenta desde
+	 * acá y una fecha inventada produciría un falso "gestión agotada".
+	 */
+	fecha_entrada_bucket: string | null;
+}
+
 // ============================================================================
 // HISTORIAL DE BUCKETS (motor COBROS-02, GET /buckets/historial)
 // ============================================================================


### PR DESCRIPTION
## Summary
- Agrega `sms` al enum `metodo_contacto` (migración `0030_cb026_metodo_contacto_sms.sql`, aplicar a mano — ver header del SQL para orden de despliegue).
- Nuevo módulo puro `gestion-temprana-b1.ts`: evalúa si una cuenta B1 agotó los 3 canales requeridos (WhatsApp, llamada, SMS) desde que entró al bucket, con early-exit si el cliente respondió o dejó un compromiso de pago. Excluye contactos automáticos (premora, WhatsApp masivo).
- Extrae `resolverNumeroSifco` (UUID→SIFCO) a helper compartido, eliminando duplicación entre `getDetallesCreditoCarteraBack` y `getBucketActualCredito`.
- Depende del endpoint `/buckets/credito/:numero_credito_sifco` ya mergeado en #1203.

## Test plan
- [x] `bun test src/lib/gestion-temprana-b1.test.ts` — 42/42 pass
- [x] `bunx tsc --build` en `apps/crm/apps/server` — limpio
- [ ] Aplicar migración 0030 en dev antes de mergear el PR de web (crea el valor `sms` que el frontend necesita ofrecer)

🤖 Generated with [Claude Code](https://claude.com/claude-code)