### PR TITLE
feat(cobros): frontend CB-026 — gestión temprana B1 (3 canales)

### DIFF
--- a/apps/crm/apps/server/src/lib/moraBuckets.test.ts
+++ b/apps/crm/apps/server/src/lib/moraBuckets.test.ts
@@ -214,6 +214,7 @@ describe("getBucketsParaUI", () => {
 
 		expect(ui).toEqual([
 			{
+				numero: 0,
 				estadoMora: "al_dia",
 				label: "Cartera Sana",
 				prefijo: "B0",
@@ -222,6 +223,7 @@ describe("getBucketsParaUI", () => {
 				diasSla: null,
 			},
 			{
+				numero: 1,
 				estadoMora: "mora_30",
 				label: "Alerta Temprana",
 				prefijo: "B1",
@@ -230,6 +232,7 @@ describe("getBucketsParaUI", () => {
 				diasSla: 3,
 			},
 			{
+				numero: 2,
 				estadoMora: "mora_60",
 				label: "Gestión Activa",
 				prefijo: "B2",
@@ -238,6 +241,7 @@ describe("getBucketsParaUI", () => {
 				diasSla: 3,
 			},
 			{
+				numero: 3,
 				estadoMora: "mora_90",
 				label: "Rescate",
 				prefijo: "B3",
@@ -246,6 +250,7 @@ describe("getBucketsParaUI", () => {
 				diasSla: 2,
 			},
 			{
+				numero: 4,
 				estadoMora: "mora_120",
 				label: "Última Instancia / Pre Jurídico",
 				prefijo: "B4",
@@ -254,6 +259,7 @@ describe("getBucketsParaUI", () => {
 				diasSla: 2,
 			},
 			{
+				numero: 5,
 				estadoMora: "mora_120_plus",
 				label: "Jurídico",
 				prefijo: "B5",
@@ -279,6 +285,7 @@ describe("getBucketsParaUI", () => {
 
 		expect(ui.map((b) => b.orden)).toEqual([0, 1, 2, 3, 4, 5]);
 		expect(ui[0]).toEqual({
+			numero: 0,
 			estadoMora: "al_dia",
 			label: "Cartera Sana",
 			prefijo: "B0",
@@ -287,6 +294,7 @@ describe("getBucketsParaUI", () => {
 			diasSla: null,
 		});
 		expect(ui[5]).toEqual({
+			numero: 5,
 			estadoMora: "mora_120_plus",
 			label: "Jurídico",
 			prefijo: "B5",
@@ -339,6 +347,7 @@ describe("getBucketsParaUIAsync", () => {
 		const ui = await getBucketsParaUIAsync();
 
 		expect(ui[0]).toEqual({
+			numero: 0,
 			estadoMora: "al_dia",
 			label: "Cartera Sana",
 			prefijo: "B0",
@@ -364,6 +373,7 @@ describe("getBucketsParaUIAsync", () => {
 		const ui = await getBucketsParaUIAsync();
 
 		expect(ui[0]).toEqual({
+			numero: 0,
 			estadoMora: "al_dia",
 			label: "Cartera Sana",
 			prefijo: "B0",

--- a/apps/crm/apps/server/src/lib/moraBuckets.ts
+++ b/apps/crm/apps/server/src/lib/moraBuckets.ts
@@ -284,6 +284,14 @@ export function estadoMoraPorCuotas(cuotas: number): string {
 }
 
 export type BucketParaUI = {
+	/**
+	 * Número real de bucket (0-5) del catálogo dinámico — `key` es su forma
+	 * string. CB-026: el web lo usa para comparar divergencia motor/estadoMora
+	 * por NÚMERO en vez de reindexar `estadoMora` contra el array hardcodeado
+	 * ESTADO_MORA_POR_NUMERO, que puede desalinearse si un admin reasigna qué
+	 * estado_mora corresponde a qué numero en cartera.buckets (Codex, PR #1205).
+	 */
+	numero: number;
 	estadoMora: string;
 	label: string;
 	prefijo: string | null;
@@ -295,6 +303,7 @@ export type BucketParaUI = {
 function mapearBucketsParaUI(): BucketParaUI[] {
 	return activeBuckets()
 		.map((b) => ({
+			numero: Number(b.key),
 			estadoMora: b.estadoMora,
 			label: b.label,
 			prefijo: b.prefijo,

--- a/apps/crm/apps/web/src/components/contacto-modal.tsx
+++ b/apps/crm/apps/web/src/components/contacto-modal.tsx
@@ -107,7 +107,9 @@ interface ContactoModalProps {
 	telefonoPrincipal: string;
 	telefonoAlternativo?: string;
 	emailCliente?: string;
-	metodoInicial: "llamada" | "whatsapp" | "email";
+	// CB-026: "sms" es un canal registrable desde que se agregó al enum
+	// metodo_contacto — es uno de los 3 que la gestión temprana B1 exige agotar.
+	metodoInicial: "llamada" | "whatsapp" | "sms" | "email";
 	children?: React.ReactNode;
 	// Modo controlado opcional (cuando el padre maneja el estado open)
 	open?: boolean;
@@ -352,6 +354,8 @@ export function ContactoModal({
 				return <Phone className="h-4 w-4" />;
 			case "whatsapp":
 				return <MessageCircle className="h-4 w-4" />;
+			case "sms":
+				return <MessageSquare className="h-4 w-4" />;
 			case "email":
 				return <Mail className="h-4 w-4" />;
 			default:
@@ -591,6 +595,7 @@ export function ContactoModal({
 												<SelectContent>
 													<SelectItem value="llamada">📞 Llamada</SelectItem>
 													<SelectItem value="whatsapp">💬 WhatsApp</SelectItem>
+													<SelectItem value="sms">📱 SMS</SelectItem>
 													<SelectItem value="email">📧 Email</SelectItem>
 													<SelectItem value="visita_domicilio">
 														🏠 Visita Domicilio

--- a/apps/crm/apps/web/src/lib/cobros/buckets-catalogo.ts
+++ b/apps/crm/apps/web/src/lib/cobros/buckets-catalogo.ts
@@ -126,6 +126,8 @@ const BUCKET_DESCONOCIDO: BucketUI = {
 const DEFAULT_POR_KEY = new Map(DEFAULT_BUCKETS.map((b) => [b.key, b]));
 
 export type BucketsCatalogoQueryData = {
+	/** Número real de bucket (0-5) del catálogo dinámico — identidad estable, no `orden`. */
+	numero: number;
 	estadoMora: string;
 	label: string;
 	prefijo: string | null;
@@ -168,12 +170,15 @@ export function bucketDeNumero(
  * `estadoMora`, o null si no matchea ninguno (pseudo-buckets de status como
  * "en_convenio"/"pagado" no tienen número — no son filas de aging).
  *
- * Preferir el catálogo dinámico (`catalogo`) sobre `ESTADO_MORA_POR_NUMERO`
- * cuando esté cargado: es la fuente de verdad real del puente número↔estado
- * (`cartera.buckets.estado_mora`), evita comparar dos catálogos de string
- * mantenidos por separado que podrían divergir en nombre para el mismo
- * concepto (ver detalle de caso, badge de bucket: comparar por NÚMERO, no
- * por string, es justamente lo que evita ese falso positivo).
+ * Usa el `numero` que el catálogo dinámico ya trae por fila (fuente real,
+ * `cartera.buckets.numero`) en vez de reindexar `estadoMora` contra
+ * `ESTADO_MORA_POR_NUMERO`. Reindexar por string se desalinea si un admin
+ * reasigna qué `estado_mora` corresponde a qué `numero` en el catálogo — el
+ * string seguiría matcheando una posición vieja del array hardcodeado, no el
+ * bucket real (Codex, PR #1205: hacía exactamente eso y podía marcar
+ * divergencia motor/CRM aunque ambos usaran la misma fila del catálogo).
+ * `ESTADO_MORA_POR_NUMERO` queda solo de fallback cuando el catálogo dinámico
+ * aún no cargó.
  */
 export function numeroDeEstadoMora(
 	estadoMora: string | null | undefined,
@@ -182,12 +187,7 @@ export function numeroDeEstadoMora(
 	if (!estadoMora) return null;
 	if (catalogo) {
 		const fila = catalogo.find((b) => b.estadoMora === estadoMora);
-		if (fila) {
-			const numero = ESTADO_MORA_POR_NUMERO.indexOf(
-				fila.estadoMora as (typeof ESTADO_MORA_POR_NUMERO)[number],
-			);
-			if (numero !== -1) return numero;
-		}
+		if (fila) return fila.numero;
 	}
 	const numero = ESTADO_MORA_POR_NUMERO.indexOf(
 		estadoMora as (typeof ESTADO_MORA_POR_NUMERO)[number],

--- a/apps/crm/apps/web/src/lib/cobros/buckets-catalogo.ts
+++ b/apps/crm/apps/web/src/lib/cobros/buckets-catalogo.ts
@@ -157,11 +157,25 @@ const ESTADO_MORA_POR_NUMERO = [
 	"mora_120_plus",
 ] as const;
 
-/** Bucket combinado a partir del número (0-5) que devuelve getAperturaDia/getBucketsCarga. */
+/**
+ * Bucket combinado a partir del número (0-5) que devuelve getAperturaDia/getBucketsCarga.
+ *
+ * Resuelve la fila por `numero` directo (`catalogoDeNumero`) en vez de pasar
+ * por `ESTADO_MORA_POR_NUMERO[numero]` → buscar por estado: si un admin
+ * reasigna qué `estado_mora` corresponde a qué `numero` en el catálogo, esa
+ * ruta seguía devolviendo la fila VIEJA que ocupaba esa posición en el array
+ * hardcodeado, no la fila real del bucket pedido (Codex, PR #1205 — mismo
+ * defecto que ya se corrigió en `numeroDeEstadoMora`, acá en la dirección
+ * inversa número→fila). Sin catálogo (aún no cargó), cae al default vía
+ * `bucketDeEstado` con el estado hardcodeado — ahí no hay catálogo real que
+ * pueda haberse reasignado.
+ */
 export function bucketDeNumero(
 	numero: number,
 	catalogo: BucketsCatalogoQueryData | undefined,
 ): BucketUI {
+	const fila = catalogoDeNumero(numero, catalogo);
+	if (fila) return bucketDeEstado(fila.estadoMora, catalogo);
 	return bucketDeEstado(ESTADO_MORA_POR_NUMERO[numero], catalogo);
 }
 
@@ -195,13 +209,20 @@ export function numeroDeEstadoMora(
 	return numero === -1 ? null : numero;
 }
 
-/** Fila cruda del catálogo dinámico para el bucket numérico (0-5), o undefined si no cargó / no está. */
+/**
+ * Fila cruda del catálogo dinámico para el bucket numérico (0-5), o undefined
+ * si no cargó / no está.
+ *
+ * Busca por `b.numero === numero` directo — la fila ya trae su `numero` real
+ * (CB-026). Antes buscaba por `b.estadoMora === ESTADO_MORA_POR_NUMERO[numero]`,
+ * que devolvía la fila equivocada si un admin reasignaba qué `estado_mora`
+ * corresponde a qué `numero` en `cartera.buckets` (Codex, PR #1205).
+ */
 export function catalogoDeNumero(
 	numero: number,
 	catalogo: BucketsCatalogoQueryData | undefined,
 ) {
-	const estadoMora = ESTADO_MORA_POR_NUMERO[numero];
-	return catalogo?.find((b) => b.estadoMora === estadoMora);
+	return catalogo?.find((b) => b.numero === numero);
 }
 
 /**

--- a/apps/crm/apps/web/src/lib/cobros/buckets-catalogo.ts
+++ b/apps/crm/apps/web/src/lib/cobros/buckets-catalogo.ts
@@ -163,6 +163,38 @@ export function bucketDeNumero(
 	return bucketDeEstado(ESTADO_MORA_POR_NUMERO[numero], catalogo);
 }
 
+/**
+ * Inverso de `bucketDeNumero`: número de bucket (0-5) a partir de un
+ * `estadoMora`, o null si no matchea ninguno (pseudo-buckets de status como
+ * "en_convenio"/"pagado" no tienen número — no son filas de aging).
+ *
+ * Preferir el catálogo dinámico (`catalogo`) sobre `ESTADO_MORA_POR_NUMERO`
+ * cuando esté cargado: es la fuente de verdad real del puente número↔estado
+ * (`cartera.buckets.estado_mora`), evita comparar dos catálogos de string
+ * mantenidos por separado que podrían divergir en nombre para el mismo
+ * concepto (ver detalle de caso, badge de bucket: comparar por NÚMERO, no
+ * por string, es justamente lo que evita ese falso positivo).
+ */
+export function numeroDeEstadoMora(
+	estadoMora: string | null | undefined,
+	catalogo: BucketsCatalogoQueryData | undefined,
+): number | null {
+	if (!estadoMora) return null;
+	if (catalogo) {
+		const fila = catalogo.find((b) => b.estadoMora === estadoMora);
+		if (fila) {
+			const numero = ESTADO_MORA_POR_NUMERO.indexOf(
+				fila.estadoMora as (typeof ESTADO_MORA_POR_NUMERO)[number],
+			);
+			if (numero !== -1) return numero;
+		}
+	}
+	const numero = ESTADO_MORA_POR_NUMERO.indexOf(
+		estadoMora as (typeof ESTADO_MORA_POR_NUMERO)[number],
+	);
+	return numero === -1 ? null : numero;
+}
+
 /** Fila cruda del catálogo dinámico para el bucket numérico (0-5), o undefined si no cargó / no está. */
 export function catalogoDeNumero(
 	numero: number,

--- a/apps/crm/apps/web/src/routes/cobros/$id.tsx
+++ b/apps/crm/apps/web/src/routes/cobros/$id.tsx
@@ -16,6 +16,7 @@ import {
 	Mail,
 	MapPin,
 	MessageCircle,
+	MessageSquare,
 	Pencil,
 	Phone,
 	Play,
@@ -26,6 +27,11 @@ import {
 	X,
 } from "lucide-react";
 import { useMemo, useState } from "react";
+import {
+	etiquetaMetodoContacto,
+	evaluarGestionTempranaB1,
+	type ResultadoGestionB1,
+} from "server/src/lib/gestion-temprana-b1";
 import { toast } from "sonner";
 import { ReferenciasView } from "@/components/cobros/ReferenciasView";
 import { SeguimientoRecurrenteModal } from "@/components/cobros/seguimiento-recurrente-modal";
@@ -66,7 +72,10 @@ import { Separator } from "@/components/ui/separator";
 import { authClient } from "@/lib/auth-client";
 import {
 	bucketDeEstado,
+	bucketDeNumero,
+	catalogoDeNumero,
 	estiloBucket,
+	numeroDeEstadoMora,
 	useBucketsCatalogo,
 } from "@/lib/cobros/buckets-catalogo";
 import { formatFechaLocal } from "@/lib/date-utils";
@@ -178,10 +187,158 @@ const ETIQUETA_COLORS: Record<string, string> = {
 	reclamo: "bg-pink-100 text-pink-800",
 };
 
+// Ícono por canal de contacto. A nivel de módulo (no dentro de RouteComponent)
+// porque lo usan tanto el Historial de Contactos como la tarjeta de gestión
+// temprana, y no depende de ningún estado del componente.
+function getMetodoIcon(metodo: string) {
+	switch (metodo) {
+		case "llamada":
+			return <Phone className="h-3 w-3" />;
+		case "whatsapp":
+			return <MessageCircle className="h-3 w-3" />;
+		case "sms":
+			return <MessageSquare className="h-3 w-3" />;
+		case "email":
+			return <Mail className="h-3 w-3" />;
+		default:
+			return <Phone className="h-3 w-3" />;
+	}
+}
+
 // Helper para detectar si es un UUID o un ID numérico
 function isUUID(id: string): boolean {
 	return /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i.test(
 		id,
+	);
+}
+
+/**
+ * CB-026: resumen de la gestión temprana de una cuenta B1 — un badge por cada
+ * uno de los 3 canales que hay que agotar (WhatsApp / llamada / SMS) más el
+ * estado global. La regla vive en `server/src/lib/gestion-temprana-b1` (módulo
+ * puro, testeado); acá solo se pinta lo que esa función ya decidió.
+ *
+ * Solo se monta cuando `gestion.aplica` — el caller filtra bucket ≠ B1 y falta
+ * de fecha de entrada, así que este componente nunca se pregunta si debe existir.
+ */
+function GestionTempranaCard({
+	gestion,
+	fechaEntradaBucket,
+}: {
+	gestion: Extract<ResultadoGestionB1, { aplica: true }>;
+	fechaEntradaBucket: string | null;
+}) {
+	const intentados = gestion.canales.filter((c) => c.intentos > 0).length;
+	const entrada = fechaEntradaBucket ? new Date(fechaEntradaBucket) : null;
+
+	// El estilo del contenedor comunica el estado de un vistazo: ámbar solo
+	// cuando falta gestión (lo único accionable), neutro cuando ya se agotó
+	// (éxito de proceso, no error → no va en rojo) y verde cuando el cliente
+	// respondió y ya no hay que insistir.
+	const estiloTarjeta =
+		gestion.estado === "incompleta"
+			? "border-amber-300 dark:border-amber-800"
+			: gestion.estado === "respondio"
+				? "border-emerald-300 dark:border-emerald-800"
+				: undefined;
+
+	return (
+		<Card className={estiloTarjeta}>
+			<CardHeader>
+				<CardTitle className="flex items-center gap-2">
+					<Users className="h-5 w-5" />
+					Gestión Temprana (B1)
+				</CardTitle>
+				<CardDescription>
+					3 intentos en 3 canales distintos
+					{entrada
+						? ` — desde que la cuenta entró a B1 el ${formatFechaGT(entrada)}`
+						: null}
+				</CardDescription>
+			</CardHeader>
+			<CardContent className="space-y-3">
+				<div className="flex flex-wrap items-center gap-2">
+					<span className="font-medium text-sm">
+						{intentados} / {gestion.canales.length} canales
+					</span>
+					<span className="inline-flex flex-wrap items-center gap-1">
+						{gestion.canales.map((canal) => {
+							const etiqueta = etiquetaMetodoContacto(canal.canal);
+							const clase = canal.contesto
+								? "border-transparent bg-emerald-100 text-emerald-800 dark:bg-emerald-900/40 dark:text-emerald-300"
+								: canal.datoInvalido
+									? "border-transparent bg-amber-100 text-amber-800 dark:bg-amber-900/40 dark:text-amber-300"
+									: canal.intentos > 0
+										? "border-transparent bg-slate-200 text-slate-800 dark:bg-slate-800 dark:text-slate-300"
+										: "text-muted-foreground";
+							const detalle = canal.contesto
+								? "contestó"
+								: canal.datoInvalido
+									? "número equivocado"
+									: canal.intentos > 0
+										? `${canal.intentos} ${canal.intentos === 1 ? "intento" : "intentos"}`
+										: "sin intentar";
+							return (
+								<Badge
+									key={canal.canal}
+									variant="outline"
+									className={`gap-1 text-[10px] ${clase}`}
+									title={
+										canal.ultimoIntento
+											? `Último intento: ${formatFechaGT(canal.ultimoIntento)}`
+											: undefined
+									}
+								>
+									{getMetodoIcon(canal.canal)}
+									{etiqueta}: {detalle}
+								</Badge>
+							);
+						})}
+					</span>
+				</div>
+
+				{gestion.estado === "incompleta" && (
+					<div className="flex items-start gap-2 rounded-md border border-yellow-200 bg-yellow-50 p-3 text-sm text-yellow-800 dark:border-yellow-900 dark:bg-yellow-950/30 dark:text-yellow-300">
+						<AlertTriangle className="mt-0.5 h-4 w-4 shrink-0" />
+						<span>
+							Falta intentar por{" "}
+							<span className="font-medium">
+								{gestion.canalesFaltantes
+									.map((c) => etiquetaMetodoContacto(c))
+									.join(", ")}
+							</span>
+							. La gestión temprana no está agotada.
+						</span>
+					</div>
+				)}
+
+				{gestion.estado === "agotada" && (
+					<p className="text-muted-foreground text-sm">
+						Gestión temprana agotada: se intentó por los 3 canales sin respuesta
+						del cliente.
+					</p>
+				)}
+
+				{gestion.estado === "respondio" && (
+					<p className="text-emerald-700 text-sm dark:text-emerald-400">
+						{gestion.canalQueContesto
+							? `El cliente respondió por ${etiquetaMetodoContacto(gestion.canalQueContesto)}. No es necesario intentar los canales restantes.`
+							: "No es necesario intentar los canales restantes."}
+						{gestion.tienePromesa
+							? " Se registró un compromiso de pago."
+							: null}
+					</p>
+				)}
+
+				{gestion.otrosCanales > 0 && (
+					<p className="text-muted-foreground text-xs">
+						+{gestion.otrosCanales}{" "}
+						{gestion.otrosCanales === 1 ? "intento" : "intentos"} por otros
+						medios (no cuentan para los 3 canales).
+					</p>
+				)}
+			</CardContent>
+		</Card>
 	);
 }
 
@@ -223,6 +380,13 @@ function RouteComponent() {
 	const queryClient = useQueryClient();
 
 	const bucketsCatalogo = useBucketsCatalogo();
+
+	// Bucket REAL del motor (cartera-back), no derivado de estadoMora.
+	// Degrada a null en cualquier error → el badge cae al estadoMora.
+	const bucketActual = useQuery({
+		...orpc.getBucketActualCredito.queryOptions({ input: { creditoId: id } }),
+		enabled: !!session && !!id,
+	});
 
 	// Obtener detalles del contrato/caso
 	// Si es ID numérico, usar endpoint de Cartera-Back, si es UUID usar el del CRM
@@ -266,6 +430,22 @@ function RouteComponent() {
 			),
 		[historialContactos.data],
 	);
+
+	// CB-026: gestión temprana B1 — 3 intentos en 3 canales distintos.
+	// Lee historialContactos.data en CRUDO, no `contactos`: esa lista excluye
+	// promesa_pago a propósito (van en su propia tarjeta), pero una promesa ES
+	// el resultado más fuerte de un intento y satisface el early exit del
+	// ticket. La regla vive en el server (módulo puro compartido), no acá.
+	const gestionB1 = useMemo(
+		() =>
+			evaluarGestionTempranaB1({
+				bucket: bucketActual.data?.bucket ?? null,
+				fechaEntradaBucket: bucketActual.data?.fecha_entrada_bucket ?? null,
+				contactos: historialContactos.data ?? [],
+			}),
+		[bucketActual.data, historialContactos.data],
+	);
+
 	const estadoPromesasPago = useQuery({
 		...orpc.getEstadoPromesasPago.queryOptions({
 			input: {
@@ -567,18 +747,49 @@ function RouteComponent() {
 	const getEstadoLabel = (estado: string | null | undefined) =>
 		bucketDeEstado(estado, bucketsCatalogo.data).label;
 
-	const getMetodoIcon = (metodo: string) => {
-		switch (metodo) {
-			case "llamada":
-				return <Phone className="h-3 w-3" />;
-			case "whatsapp":
-				return <MessageCircle className="h-3 w-3" />;
-			case "email":
-				return <Mail className="h-3 w-3" />;
-			default:
-				return <Phone className="h-3 w-3" />;
-		}
-	};
+	// Badge de bucket del header: si el motor devolvió un bucket (0-5), se
+	// muestra "B1 · Alerta Temprana" con el color del catálogo dinámico. Si el
+	// crédito salió del funnel (en convenio, cancelado), si el motor aún no
+	// respondió, o si falló, se cae al badge de estadoMora de siempre — nunca
+	// se muestra un bucket inventado (mismo criterio que BUCKET_DESCONOCIDO).
+	const motorBucket = bucketActual.data;
+	const bucketNumero = motorBucket?.bucket ?? null;
+	const bucketCatalogo =
+		bucketNumero !== null
+			? catalogoDeNumero(bucketNumero, bucketsCatalogo.data)
+			: undefined;
+	const bucketUI =
+		bucketNumero !== null
+			? bucketDeNumero(bucketNumero, bucketsCatalogo.data)
+			: null;
+	const bucketPrefijo =
+		motorBucket?.prefijo ||
+		bucketCatalogo?.prefijo ||
+		(bucketNumero !== null ? `B${bucketNumero}` : null);
+	// Divergencia motor vs. estadoMora calculado en vivo: solo en el tooltip,
+	// el badge siempre muestra el MOTOR (es la fuente operativa: pool de
+	// asesores y SLA se derivan de ahí).
+	// Se compara por NÚMERO de bucket, no por el string estado_mora: son dos
+	// catálogos de texto mantenidos por separado (cartera.buckets.estado_mora
+	// en cartera-back vs. estadoMoraEnum en el CRM) que podrían divergir en
+	// nombre para el mismo concepto — comparar por número evita ese falso
+	// positivo. Si `caso.estadoMora` no mapea a ningún número (pseudo-estado
+	// de status como "pagado"), no hay nada que comparar y no se marca divergencia.
+	const numeroPorEstadoMoraCaso = numeroDeEstadoMora(
+		caso.estadoMora,
+		bucketsCatalogo.data,
+	);
+	const estadoMoraDivergente =
+		bucketUI !== null &&
+		bucketNumero !== null &&
+		numeroPorEstadoMoraCaso !== null &&
+		numeroPorEstadoMoraCaso !== bucketNumero;
+	const bucketTitle =
+		bucketUI === null
+			? undefined
+			: estadoMoraDivergente
+				? `${bucketPrefijo} · ${bucketUI.label} (mora calculada: ${getEstadoLabel(caso.estadoMora)})`
+				: `${bucketPrefijo} · ${bucketUI.label}`;
 
 	const getEstadoContacto = (estado: string) => {
 		const estados: Record<string, { label: string; color: string }> = {
@@ -628,9 +839,23 @@ function RouteComponent() {
 						</p>
 					</div>
 				</div>
-				<Badge variant="outline" style={getEstadoBadge(caso.estadoMora || "")}>
-					{getEstadoLabel(caso.estadoMora || "")}
-				</Badge>
+				{bucketUI ? (
+					<Badge
+						variant="outline"
+						className="whitespace-nowrap font-semibold"
+						style={estiloBucket(bucketUI.colorHex)}
+						title={bucketTitle}
+					>
+						{bucketPrefijo} · {bucketUI.label}
+					</Badge>
+				) : (
+					<Badge
+						variant="outline"
+						style={getEstadoBadge(caso.estadoMora || "")}
+					>
+						{getEstadoLabel(caso.estadoMora || "")}
+					</Badge>
+				)}
 			</div>
 
 			<div className="grid gap-6 lg:grid-cols-3">
@@ -666,16 +891,9 @@ function RouteComponent() {
 										<span className="font-medium">Días de Mora:</span>
 									</div>
 									<p>
-										{caso.estadoMora === "mora_30"
-											? "30"
-											: caso.estadoMora === "mora_60"
-												? "60"
-												: caso.estadoMora === "mora_90"
-													? "90"
-													: caso.estadoMora === "mora_120"
-														? "120+"
-														: "0"}{" "}
-										días
+										{caso.diasMoraMaximo && caso.diasMoraMaximo > 0
+											? `${caso.diasMoraMaximo} ${caso.diasMoraMaximo === 1 ? "día" : "días"}`
+											: "Sin mora"}
 									</p>
 								</div>
 								<div className="space-y-2">
@@ -1561,6 +1779,22 @@ function RouteComponent() {
 						</CardContent>
 					</Card>
 
+					{/* CB-026: Gestión temprana B1 — 3 intentos en 3 canales distintos.
+					    No se renderiza si el crédito no es B1, si no hay fecha de
+					    entrada al bucket, ni mientras cargan las queries que la
+					    alimentan (con contactos vacíos la regla diría "faltan 3
+					    canales" y parpadearía esa alerta antes de tener los datos). */}
+					{!bucketActual.isPending &&
+						!historialContactos.isPending &&
+						gestionB1.aplica && (
+							<GestionTempranaCard
+								gestion={gestionB1}
+								fechaEntradaBucket={
+									bucketActual.data?.fecha_entrada_bucket ?? null
+								}
+							/>
+						)}
+
 					{/* Historial de Contactos */}
 					<Card>
 						<CardHeader>
@@ -1598,10 +1832,9 @@ function RouteComponent() {
 															<div className="flex items-center gap-2">
 																{getMetodoIcon(contacto.metodoContacto)}
 																<span className="font-medium">
-																	{contacto.metodoContacto
-																		?.charAt(0)
-																		.toUpperCase() +
-																		contacto.metodoContacto?.slice(1)}
+																	{etiquetaMetodoContacto(
+																		contacto.metodoContacto,
+																	)}
 																</span>
 																<Badge className={estadoInfo.color}>
 																	{estadoInfo.label}

--- a/apps/crm/apps/web/src/routes/cobros/$id.tsx
+++ b/apps/crm/apps/web/src/routes/cobros/$id.tsx
@@ -1781,11 +1781,18 @@ function RouteComponent() {
 
 					{/* CB-026: Gestión temprana B1 — 3 intentos en 3 canales distintos.
 					    No se renderiza si el crédito no es B1, si no hay fecha de
-					    entrada al bucket, ni mientras cargan las queries que la
+					    entrada al bucket, mientras cargan las queries que la
 					    alimentan (con contactos vacíos la regla diría "faltan 3
-					    canales" y parpadearía esa alerta antes de tener los datos). */}
+					    canales" y parpadearía esa alerta antes de tener los datos),
+					    ni si historialContactos falló: con TanStack Query un error
+					    deja isPending=false y data=undefined — indistinguible de
+					    "0 contactos" para el memo de gestionB1 (usa `?? []`). Sin
+					    este guard, un error transitorio de red mostraría "faltan
+					    3 canales" con datos reales ocultos, y el asesor podría
+					    re-hacer intentos ya registrados (Codex, PR #1205). */}
 					{!bucketActual.isPending &&
 						!historialContactos.isPending &&
+						!historialContactos.isError &&
 						gestionB1.aplica && (
 							<GestionTempranaCard
 								gestion={gestionB1}


### PR DESCRIPTION
## Summary
- Modal de contacto: opción SMS en el select de método (`contacto-modal.tsx`), ícono `MessageSquare`, `metodoInicial` ampliado a incluir `"sms"`.
- Detalle del caso (`$id.tsx`): tarjeta "Gestión Temprana (B1)" arriba del Historial de Contactos — badge por canal (WhatsApp/llamada/SMS: contestó / intentos / sin intentar / número equivocado), alerta ámbar si faltan canales, estado neutro si se agotaron los 3 sin respuesta, verde si el cliente respondió o dejó un compromiso de pago. Solo se renderiza para bucket B1 con fecha de entrada conocida (degrada a nada, nunca inventa datos).
- `buckets-catalogo.ts`: nuevo helper `numeroDeEstadoMora` para comparar divergencia motor/estadoMora por número de bucket en vez de por string (fix de un P2 de Codex en #1204).
- Depende de #1204 (enum `sms` + módulo `gestion-temprana-b1.ts`, ya mergeado) y de #1203 (endpoint `/buckets/credito/:numero_credito_sifco`, ya mergeado).

## Test plan
- [x] `bun run check-types` en `apps/crm/apps/web` — limpio
- [x] `bunx tsc --build` en `apps/crm/apps/server` — limpio (composite project)
- [ ] Probar en `/cobros/$id?tipo=caso` con un crédito B1 real: registrar WhatsApp + Llamada (no_contesta) → alerta pidiendo SMS; agregar SMS → pasa a "agotada"
- [ ] Confirmar que un B2/B3 no muestra la tarjeta

🤖 Generated with [Claude Code](https://claude.com/claude-code)