### PR TITLE
hotfix(cartera): facturas fantasma no emitidas en SAT — detección en el job y sincronización en /anular

### DIFF
--- a/apps/cartera-back/src/cofidi/satClientService.ts
+++ b/apps/cartera-back/src/cofidi/satClientService.ts
@@ -36,7 +36,11 @@ function esDocumentoNoEncontrado(mensaje: string | undefined): boolean {
   const normalizado = normalizarMensajeCofidi(mensaje);
   return (
     /(documento|dte|uuid).*no (se )?(encontro|encontrado|existe)/.test(normalizado) ||
-    /no (se )?(encontro|existe).*(documento|dte|uuid)/.test(normalizado)
+    /no (se )?(encontro|existe).*(documento|dte|uuid)/.test(normalizado) ||
+    // "El documento no ha sido emitido": el certificador devolvió UUID al
+    // certificar pero nunca emitió el DTE a SAT. Es un "no existe" definitivo,
+    // no un error transitorio de consulta.
+    /(documento|dte|uuid).*no ha sido emitid/.test(normalizado)
   );
 }
 

--- a/apps/cartera-back/src/routers/cofidi.ts
+++ b/apps/cartera-back/src/routers/cofidi.ts
@@ -2188,6 +2188,7 @@ if (facturasExistentes.length > 0) {
         factura_fecha_anulacion: facturas_electronicas.fecha_anulacion,
         factura_motivo_anulacion: facturas_electronicas.motivo_anulacion,
         factura_tipo_documento: facturas_electronicas.tipo_documento,
+        factura_emisor_nit: facturas_electronicas.emisor_nit,
         
         // Datos del pago
         pago_id: pagos_credito.pago_id,
@@ -2405,9 +2406,85 @@ if (facturasExistentes.length > 0) {
       }
       
       // 🔥 Error de documento no encontrado
-      else if (descripcionError.includes('no existe') || 
+      else if (descripcionError.includes('no existe') ||
                descripcionError.includes('not found') ||
-               descripcionError.includes('No se encontró')) {
+               descripcionError.includes('No se encontró') ||
+               descripcionError.includes('no ha sido emitido')) {
+        // Puede ser una factura "fantasma": el certificador devolvió UUID al
+        // certificar pero nunca la emitió a SAT, así que no hay nada que anular
+        // allá y dejarla ACTIVA en la BD sería mantener el fantasma. Antes de
+        // sincronizar se CONFIRMA con un GET usando el emisor propio de la
+        // factura (el mensaje de arriba puede venir de un emisor equivocado del
+        // loop). Solo si SAT tampoco la devuelve ahí, se marca ANULADA en BD.
+        // Si el GET falla (red) o la encuentra, sigue el flujo de error normal.
+        try {
+          const emisorConfGet = Object.values(EMISORES_CONFIG).find(
+            (c) => c.config.emisor.nit === facturaCompleta.factura_emisor_nit
+          );
+          if (emisorConfGet) {
+            const satGet = new SATClientService(
+              {
+                requestor: emisorConfGet.satConfig.requestor,
+                user: emisorConfGet.satConfig.user || emisorConfGet.satConfig.requestor,
+                userName: emisorConfGet.satConfig.userName,
+                entity: emisorConfGet.config.emisor.nit,
+              },
+              emisorConfGet.satConfig.endpointUrl
+            );
+            const enSat = await satGet.obtenerPorUUID(uuid);
+            if (!enSat.encontrado) {
+              const [facturaSincronizada] = await db
+                .update(facturas_electronicas)
+                .set({
+                  status: "ANULADA",
+                  fecha_anulacion: new Date(),
+                  motivo_anulacion: `${motivo} (sin anular en SAT: el documento nunca fue emitido — ${descripcionError})`,
+                  anulada_por: userId,
+                })
+                .where(eq(facturas_electronicas.uuid, uuid))
+                .returning();
+
+              // Misma limpieza best-effort del desglose genérico que en la anulación normal.
+              try {
+                await db.execute(
+                  sql`DELETE FROM cartera.facturacion_desglose WHERE factura_id = ${facturaSincronizada.factura_id} AND pago_id IS NULL`
+                );
+              } catch (limpiezaError) {
+                console.error(
+                  '⚠️ No se pudo limpiar el desglose genérico (NO afecta la anulación):',
+                  (limpiezaError as Error).message
+                );
+              }
+
+              console.log('🧹 Factura fantasma sincronizada: ANULADA solo en BD (no existía en SAT)');
+              set.status = 200;
+              return {
+                success: true,
+                anulada_solo_en_sistema: true,
+                mensaje: `Factura ${facturaCompleta.factura_serie}-${facturaCompleta.factura_numero} anulada solo en el sistema: SAT no tiene el documento (el certificador nunca lo emitió)`,
+                data: {
+                  factura: {
+                    factura_id: facturaSincronizada.factura_id,
+                    serie: facturaSincronizada.serie,
+                    numero: facturaSincronizada.numero,
+                    uuid: facturaSincronizada.uuid,
+                    status: facturaSincronizada.status,
+                    monto_total: facturaSincronizada.monto_total,
+                    fecha_anulacion: facturaSincronizada.fecha_anulacion,
+                    motivo_anulacion: facturaSincronizada.motivo_anulacion,
+                    anulada_por: facturaSincronizada.anulada_por,
+                  },
+                  descripcion_cofidi: descripcionError,
+                },
+              };
+            }
+          }
+        } catch (verificacionError) {
+          console.error(
+            '⚠️ No se pudo confirmar con GET si la factura existe en SAT (sigue el error normal):',
+            (verificacionError as Error).message
+          );
+        }
         mensajeUsuario = 'La factura no fue encontrada en el sistema SAT';
         codigoError = 'FACTURA_NO_EXISTE_SAT';
         sugerencia = 'Verifique que la factura haya sido certificada correctamente';
@@ -3171,7 +3248,7 @@ if (facturasExistentes.length > 0) {
     "/facturar-generico",
     async ({ body, set, request }) => {
       try {
-        const { nit, items: itemsInput, created_by: bodyCreatedBy, emisor, credito_nuevo} = body;
+        const { nit, items: itemsInput, created_by: bodyCreatedBy, emisor, credito_nuevo, fecha_vencimiento} = body;
 
         // Si no viene created_by en el body, extraerlo del token
         let created_by = bodyCreatedBy;
@@ -3298,7 +3375,7 @@ if (facturasExistentes.length > 0) {
         console.log(`💰 Total factura: Q${totalFactura.toFixed(2)}`);
 
         // ============================================
-        // 4️⃣ CONSTRUIR COMPLEMENTOS (1 ABONO, FECHA HOY)
+        // 4️⃣ CONSTRUIR COMPLEMENTOS (1 ABONO, FECHA HOY O fecha_vencimiento)
         // ============================================
         const fechaHoy = new Date().toISOString().split("T")[0];
 
@@ -3308,7 +3385,7 @@ if (facturasExistentes.length > 0) {
             abonos: [
               {
                 numeroAbono: 1,
-                fechaVencimiento: fechaHoy,
+                fechaVencimiento: fecha_vencimiento ?? fechaHoy,
                 montoAbono: parseFloat(totalFactura.toFixed(2)),
               },
             ],
@@ -3461,6 +3538,9 @@ if (facturasExistentes.length > 0) {
           t.Literal("AUTOCASH"),
         ]),
         credito_nuevo: t.Optional(t.Boolean({ default: false })),
+        // Opcional: fecha de vencimiento del abono cambiario (yyyy-mm-dd).
+        // Si no viene, se usa la fecha de hoy (comportamiento original).
+        fecha_vencimiento: t.Optional(t.String({ pattern: "^\\d{4}-\\d{2}-\\d{2}$" })),
       }),
     }
   )

--- a/apps/cartera-back/src/routers/cofidi.ts
+++ b/apps/cartera-back/src/routers/cofidi.ts
@@ -2188,7 +2188,6 @@ if (facturasExistentes.length > 0) {
         factura_fecha_anulacion: facturas_electronicas.fecha_anulacion,
         factura_motivo_anulacion: facturas_electronicas.motivo_anulacion,
         factura_tipo_documento: facturas_electronicas.tipo_documento,
-        factura_emisor_nit: facturas_electronicas.emisor_nit,
         
         // Datos del pago
         pago_id: pagos_credito.pago_id,
@@ -2255,85 +2254,6 @@ if (facturasExistentes.length > 0) {
       };
     }
 
-    // 🧹 Sincronización de facturas "fantasma": el certificador devolvió UUID
-    // al certificar pero nunca emitió el DTE a SAT, así que allá no hay nada
-    // que anular (ni nota de crédito que aplicar). Se CONFIRMA con un GET
-    // usando el emisor propio de la factura y, solo si SAT tampoco la
-    // devuelve, se marca ANULADA en BD. Devuelve la respuesta 200 o null si no
-    // aplica (existe en SAT, emisor desconocido o falló la consulta — en esos
-    // casos el caller sigue su flujo de error normal).
-    const sincronizarSiEsFantasma = async (contexto: string) => {
-      try {
-        const emisorConfGet = Object.values(EMISORES_CONFIG).find(
-          (c) => c.config.emisor.nit === facturaCompleta.factura_emisor_nit
-        );
-        if (!emisorConfGet) return null;
-
-        const satGet = new SATClientService(
-          {
-            requestor: emisorConfGet.satConfig.requestor,
-            user: emisorConfGet.satConfig.user || emisorConfGet.satConfig.requestor,
-            userName: emisorConfGet.satConfig.userName,
-            entity: emisorConfGet.config.emisor.nit,
-          },
-          emisorConfGet.satConfig.endpointUrl
-        );
-        const enSat = await satGet.obtenerPorUUID(uuid);
-        if (enSat.encontrado) return null;
-
-        const [facturaSincronizada] = await db
-          .update(facturas_electronicas)
-          .set({
-            status: "ANULADA",
-            fecha_anulacion: new Date(),
-            motivo_anulacion: `${motivo} (sin anular en SAT: el documento nunca fue emitido — ${contexto})`,
-            anulada_por: userId,
-          })
-          .where(eq(facturas_electronicas.uuid, uuid))
-          .returning();
-
-        // Misma limpieza best-effort del desglose genérico que en la anulación normal.
-        try {
-          await db.execute(
-            sql`DELETE FROM cartera.facturacion_desglose WHERE factura_id = ${facturaSincronizada.factura_id} AND pago_id IS NULL`
-          );
-        } catch (limpiezaError) {
-          console.error(
-            '⚠️ No se pudo limpiar el desglose genérico (NO afecta la anulación):',
-            (limpiezaError as Error).message
-          );
-        }
-
-        console.log('🧹 Factura fantasma sincronizada: ANULADA solo en BD (no existía en SAT)');
-        set.status = 200;
-        return {
-          success: true,
-          anulada_solo_en_sistema: true,
-          mensaje: `Factura ${facturaCompleta.factura_serie}-${facturaCompleta.factura_numero} anulada solo en el sistema: SAT no tiene el documento (el certificador nunca lo emitió)`,
-          data: {
-            factura: {
-              factura_id: facturaSincronizada.factura_id,
-              serie: facturaSincronizada.serie,
-              numero: facturaSincronizada.numero,
-              uuid: facturaSincronizada.uuid,
-              status: facturaSincronizada.status,
-              monto_total: facturaSincronizada.monto_total,
-              fecha_anulacion: facturaSincronizada.fecha_anulacion,
-              motivo_anulacion: facturaSincronizada.motivo_anulacion,
-              anulada_por: facturaSincronizada.anulada_por,
-            },
-            descripcion_cofidi: contexto,
-          },
-        };
-      } catch (verificacionError) {
-        console.error(
-          '⚠️ No se pudo confirmar con GET si la factura existe en SAT (sigue el flujo normal):',
-          (verificacionError as Error).message
-        );
-        return null;
-      }
-    };
-
     // 🔥 VALIDACIÓN: Verificar período válido para anular
     const fechaCertificacion = facturaCompleta.factura_fecha_certificacion
       ? new Date(facturaCompleta.factura_fecha_certificacion)
@@ -2350,14 +2270,6 @@ if (facturasExistentes.length > 0) {
     const esMismoPeriodo = (anioFactura === anioActual && mesFactura === mesActual);
 
     if (!esMismoPeriodo) {
-      // Antes de rechazar por período: si la factura es un fantasma nunca
-      // emitido a SAT, la restricción de período no aplica (no hay anulación
-      // ni nota de crédito que hacer allá) y se sincroniza la BD directamente.
-      // Sin esto, un fantasma descubierto en un mes posterior quedaría ACTIVA
-      // para siempre.
-      const sync = await sincronizarSiEsFantasma('detectada al intentar anular fuera de período');
-      if (sync) return sync;
-
       const nombresMeses = ['Enero', 'Febrero', 'Marzo', 'Abril', 'Mayo', 'Junio',
                            'Julio', 'Agosto', 'Septiembre', 'Octubre', 'Noviembre', 'Diciembre'];
 
@@ -2493,16 +2405,13 @@ if (facturasExistentes.length > 0) {
       }
       
       // 🔥 Error de documento no encontrado
+      // "no ha sido emitido" = factura fantasma (el certificador devolvió UUID
+      // pero nunca la emitió a SAT). La corrección del estado en BD es MANUAL
+      // por decisión del equipo: este endpoint solo reporta el error claro.
       else if (descripcionError.includes('no existe') ||
                descripcionError.includes('not found') ||
                descripcionError.includes('No se encontró') ||
                descripcionError.includes('no ha sido emitido')) {
-        // Ojo: este mensaje puede venir de un emisor equivocado del loop de
-        // anulación; el helper re-confirma contra SAT con el emisor propio de
-        // la factura antes de sincronizar.
-        const sync = await sincronizarSiEsFantasma(descripcionError);
-        if (sync) return sync;
-
         mensajeUsuario = 'La factura no fue encontrada en el sistema SAT';
         codigoError = 'FACTURA_NO_EXISTE_SAT';
         sugerencia = 'Verifique que la factura haya sido certificada correctamente';

--- a/apps/cartera-back/src/routers/cofidi.ts
+++ b/apps/cartera-back/src/routers/cofidi.ts
@@ -2255,8 +2255,87 @@ if (facturasExistentes.length > 0) {
       };
     }
 
+    // 🧹 Sincronización de facturas "fantasma": el certificador devolvió UUID
+    // al certificar pero nunca emitió el DTE a SAT, así que allá no hay nada
+    // que anular (ni nota de crédito que aplicar). Se CONFIRMA con un GET
+    // usando el emisor propio de la factura y, solo si SAT tampoco la
+    // devuelve, se marca ANULADA en BD. Devuelve la respuesta 200 o null si no
+    // aplica (existe en SAT, emisor desconocido o falló la consulta — en esos
+    // casos el caller sigue su flujo de error normal).
+    const sincronizarSiEsFantasma = async (contexto: string) => {
+      try {
+        const emisorConfGet = Object.values(EMISORES_CONFIG).find(
+          (c) => c.config.emisor.nit === facturaCompleta.factura_emisor_nit
+        );
+        if (!emisorConfGet) return null;
+
+        const satGet = new SATClientService(
+          {
+            requestor: emisorConfGet.satConfig.requestor,
+            user: emisorConfGet.satConfig.user || emisorConfGet.satConfig.requestor,
+            userName: emisorConfGet.satConfig.userName,
+            entity: emisorConfGet.config.emisor.nit,
+          },
+          emisorConfGet.satConfig.endpointUrl
+        );
+        const enSat = await satGet.obtenerPorUUID(uuid);
+        if (enSat.encontrado) return null;
+
+        const [facturaSincronizada] = await db
+          .update(facturas_electronicas)
+          .set({
+            status: "ANULADA",
+            fecha_anulacion: new Date(),
+            motivo_anulacion: `${motivo} (sin anular en SAT: el documento nunca fue emitido — ${contexto})`,
+            anulada_por: userId,
+          })
+          .where(eq(facturas_electronicas.uuid, uuid))
+          .returning();
+
+        // Misma limpieza best-effort del desglose genérico que en la anulación normal.
+        try {
+          await db.execute(
+            sql`DELETE FROM cartera.facturacion_desglose WHERE factura_id = ${facturaSincronizada.factura_id} AND pago_id IS NULL`
+          );
+        } catch (limpiezaError) {
+          console.error(
+            '⚠️ No se pudo limpiar el desglose genérico (NO afecta la anulación):',
+            (limpiezaError as Error).message
+          );
+        }
+
+        console.log('🧹 Factura fantasma sincronizada: ANULADA solo en BD (no existía en SAT)');
+        set.status = 200;
+        return {
+          success: true,
+          anulada_solo_en_sistema: true,
+          mensaje: `Factura ${facturaCompleta.factura_serie}-${facturaCompleta.factura_numero} anulada solo en el sistema: SAT no tiene el documento (el certificador nunca lo emitió)`,
+          data: {
+            factura: {
+              factura_id: facturaSincronizada.factura_id,
+              serie: facturaSincronizada.serie,
+              numero: facturaSincronizada.numero,
+              uuid: facturaSincronizada.uuid,
+              status: facturaSincronizada.status,
+              monto_total: facturaSincronizada.monto_total,
+              fecha_anulacion: facturaSincronizada.fecha_anulacion,
+              motivo_anulacion: facturaSincronizada.motivo_anulacion,
+              anulada_por: facturaSincronizada.anulada_por,
+            },
+            descripcion_cofidi: contexto,
+          },
+        };
+      } catch (verificacionError) {
+        console.error(
+          '⚠️ No se pudo confirmar con GET si la factura existe en SAT (sigue el flujo normal):',
+          (verificacionError as Error).message
+        );
+        return null;
+      }
+    };
+
     // 🔥 VALIDACIÓN: Verificar período válido para anular
-    const fechaCertificacion = facturaCompleta.factura_fecha_certificacion 
+    const fechaCertificacion = facturaCompleta.factura_fecha_certificacion
       ? new Date(facturaCompleta.factura_fecha_certificacion)
       : new Date(facturaCompleta.factura_fecha_emision);
     
@@ -2271,9 +2350,17 @@ if (facturasExistentes.length > 0) {
     const esMismoPeriodo = (anioFactura === anioActual && mesFactura === mesActual);
 
     if (!esMismoPeriodo) {
-      const nombresMeses = ['Enero', 'Febrero', 'Marzo', 'Abril', 'Mayo', 'Junio', 
+      // Antes de rechazar por período: si la factura es un fantasma nunca
+      // emitido a SAT, la restricción de período no aplica (no hay anulación
+      // ni nota de crédito que hacer allá) y se sincroniza la BD directamente.
+      // Sin esto, un fantasma descubierto en un mes posterior quedaría ACTIVA
+      // para siempre.
+      const sync = await sincronizarSiEsFantasma('detectada al intentar anular fuera de período');
+      if (sync) return sync;
+
+      const nombresMeses = ['Enero', 'Febrero', 'Marzo', 'Abril', 'Mayo', 'Junio',
                            'Julio', 'Agosto', 'Septiembre', 'Octubre', 'Noviembre', 'Diciembre'];
-      
+
       set.status = 422;
       return {
         success: false,
@@ -2410,81 +2497,12 @@ if (facturasExistentes.length > 0) {
                descripcionError.includes('not found') ||
                descripcionError.includes('No se encontró') ||
                descripcionError.includes('no ha sido emitido')) {
-        // Puede ser una factura "fantasma": el certificador devolvió UUID al
-        // certificar pero nunca la emitió a SAT, así que no hay nada que anular
-        // allá y dejarla ACTIVA en la BD sería mantener el fantasma. Antes de
-        // sincronizar se CONFIRMA con un GET usando el emisor propio de la
-        // factura (el mensaje de arriba puede venir de un emisor equivocado del
-        // loop). Solo si SAT tampoco la devuelve ahí, se marca ANULADA en BD.
-        // Si el GET falla (red) o la encuentra, sigue el flujo de error normal.
-        try {
-          const emisorConfGet = Object.values(EMISORES_CONFIG).find(
-            (c) => c.config.emisor.nit === facturaCompleta.factura_emisor_nit
-          );
-          if (emisorConfGet) {
-            const satGet = new SATClientService(
-              {
-                requestor: emisorConfGet.satConfig.requestor,
-                user: emisorConfGet.satConfig.user || emisorConfGet.satConfig.requestor,
-                userName: emisorConfGet.satConfig.userName,
-                entity: emisorConfGet.config.emisor.nit,
-              },
-              emisorConfGet.satConfig.endpointUrl
-            );
-            const enSat = await satGet.obtenerPorUUID(uuid);
-            if (!enSat.encontrado) {
-              const [facturaSincronizada] = await db
-                .update(facturas_electronicas)
-                .set({
-                  status: "ANULADA",
-                  fecha_anulacion: new Date(),
-                  motivo_anulacion: `${motivo} (sin anular en SAT: el documento nunca fue emitido — ${descripcionError})`,
-                  anulada_por: userId,
-                })
-                .where(eq(facturas_electronicas.uuid, uuid))
-                .returning();
+        // Ojo: este mensaje puede venir de un emisor equivocado del loop de
+        // anulación; el helper re-confirma contra SAT con el emisor propio de
+        // la factura antes de sincronizar.
+        const sync = await sincronizarSiEsFantasma(descripcionError);
+        if (sync) return sync;
 
-              // Misma limpieza best-effort del desglose genérico que en la anulación normal.
-              try {
-                await db.execute(
-                  sql`DELETE FROM cartera.facturacion_desglose WHERE factura_id = ${facturaSincronizada.factura_id} AND pago_id IS NULL`
-                );
-              } catch (limpiezaError) {
-                console.error(
-                  '⚠️ No se pudo limpiar el desglose genérico (NO afecta la anulación):',
-                  (limpiezaError as Error).message
-                );
-              }
-
-              console.log('🧹 Factura fantasma sincronizada: ANULADA solo en BD (no existía en SAT)');
-              set.status = 200;
-              return {
-                success: true,
-                anulada_solo_en_sistema: true,
-                mensaje: `Factura ${facturaCompleta.factura_serie}-${facturaCompleta.factura_numero} anulada solo en el sistema: SAT no tiene el documento (el certificador nunca lo emitió)`,
-                data: {
-                  factura: {
-                    factura_id: facturaSincronizada.factura_id,
-                    serie: facturaSincronizada.serie,
-                    numero: facturaSincronizada.numero,
-                    uuid: facturaSincronizada.uuid,
-                    status: facturaSincronizada.status,
-                    monto_total: facturaSincronizada.monto_total,
-                    fecha_anulacion: facturaSincronizada.fecha_anulacion,
-                    motivo_anulacion: facturaSincronizada.motivo_anulacion,
-                    anulada_por: facturaSincronizada.anulada_por,
-                  },
-                  descripcion_cofidi: descripcionError,
-                },
-              };
-            }
-          }
-        } catch (verificacionError) {
-          console.error(
-            '⚠️ No se pudo confirmar con GET si la factura existe en SAT (sigue el error normal):',
-            (verificacionError as Error).message
-          );
-        }
         mensajeUsuario = 'La factura no fue encontrada en el sistema SAT';
         codigoError = 'FACTURA_NO_EXISTE_SAT';
         sugerencia = 'Verifique que la factura haya sido certificada correctamente';


### PR DESCRIPTION
## Qué pasó (incidente 2026-07-29/30)

El 29/07 entre 13:21 y 13:35, COFIDI **certificó 5 facturas de CUBE devolviendo UUID/serie/número, pero nunca las emitió a SAT** (falla intermitente del certificador: en los mismos 4 pagos, las facturas hermanas sí quedaron bien). Al consultar esos UUIDs, COFIDI responde `"El documento no ha sido emitido"`.

El problema en nuestro lado: ese mensaje hacía **throw** en `parsearRespuestaGet`, y el job `verificar_facturas_sat` trata cualquier excepción como *error de consulta no concluyente* (diseño anti-caídas de SAT). Resultado: el cursor quedó **congelado ~21 horas** en la factura 20270, sin registrar nada en `facturas_fallidas_sat`, sin correo de alerta — y conta detectó las 5 faltantes manualmente antes que el sistema.

Las 5 fantasmas ya fueron remediadas a mano (anuladas en BD y re-emitidas como facturas 20413–20417, verificadas en SAT, enlazadas a sus pagos). **Este hotfix es para que no vuelva a pasar en silencio.**

## Cambios

### 1. `satClientService.ts` — "no ha sido emitido" = documento no existe (concluyente)
`esDocumentoNoEncontrado()` ahora reconoce el patrón `"no ha sido emitido"` además de los `"no existe / no encontrado"` que ya manejaba. Con esto `obtenerPorUUID` devuelve `encontrado=false` en vez de lanzar, y el job:
- registra la factura en `facturas_fallidas_sat` (PENDIENTE),
- la reporta en el correo horario de alertas,
- y **el cursor sigue avanzando** en vez de congelarse.

Los errores reales (timeout, red, otros mensajes) siguen lanzando y congelando el cursor, que es el comportamiento correcto para una caída de SAT.

### 2. `/api/dte/anular` — error claro para fantasmas (sin escrituras automáticas)
Cuando COFIDI responde `"no ha sido emitido"`, el endpoint ahora lo clasifica como `FACTURA_NO_EXISTE_SAT` (antes caía en el `COFIDI_ERROR` genérico). **Solo mejora el mensaje: no escribe nada.** Por decisión del equipo, la corrección del estado en BD de una fantasma es un proceso manual (detección automática vía job + correo; remediación revisada a mano).

> Nota: una iteración intermedia de este PR marcaba la fantasma como ANULADA automáticamente tras confirmar contra SAT; se descartó — commits `07bc4b39` (fix al orden con el guard de período, review de Codex) y `2cb8b434` (remoción del auto-sync).

### 3. `/api/dte/facturar-generico` — `fecha_vencimiento` opcional
Nuevo parámetro opcional (`yyyy-mm-dd`, validado con pattern) para el abono del complemento cambiario. Se usó para re-emitir una fantasma conservando su vencimiento original (26/08). Sin el parámetro, se comporta exactamente igual que antes (fecha de hoy).

## Verificación
- Regex probado contra el mensaje real de COFIDI (`"El documento no ha sido emitido"`, mayúsculas, y negativos como timeout/NIT inválido).
- El param `fecha_vencimiento` se ejercitó en producción durante la remediación: el XML certificado de la factura 20417 trae `<cfc:FechaVencimiento>2026-08-26</cfc:FechaVencimiento>`.
- Barrido completo del backlog (136 facturas) contra SAT con la config de CUBE: las únicas no emitidas eran las 5 del incidente; el cursor del job avanzó a 20430 tras la remediación.

🤖 Generated with [Claude Code](https://claude.com/claude-code)