### PR TITLE
hotfix(investment): PDF muestra tasa efectiva del inversionista (tasa × %)

### DIFF
--- a/apps/investment-calculator/src/App.tsx
+++ b/apps/investment-calculator/src/App.tsx
@@ -527,8 +527,9 @@ export default function InvestmentCalculator() {
     summary.appendChild(
       createSummaryRow(
         "Tasa de Interés Mensual:",
-        // Tasa real del crédito (no multiplicada por el % del inversionista).
-        `${parseFloat(interestRate.toFixed(4))}%`
+        // En el PDF va la tasa efectiva del inversionista (tasa × % de
+        // participación), pedido de inversiones; en pantalla queda la real.
+        `${parseFloat((interestRate * (investorPercentage / 100)).toFixed(4))}%`
       )
     );
 


### PR DESCRIPTION
## Contexto

Inversiones reporta que el resumen del **PDF descargado** de la calculadora volvió a mostrar la tasa real del crédito (1.5%) en "Tasa de Interés Mensual", cuando antes mostraba la tasa efectiva del inversionista (1.5 × 80% = **1.2%**).

Ese cambio venía de dda58738 (pedido del PM de mostrar la tasa real en pantalla y PDF). Inversiones manda en el PDF, así que se revierte **solo ahí**.

## Cambio

- **PDF descargado**: `Tasa de Interés Mensual` vuelve a ser `tasa × % inversionista` (ej. 1.5% × 80% = 1.2%).
- **Resumen en pantalla**: sin cambios — sigue mostrando la tasa real del crédito (1.5%), como pidió el PM en dda58738.
- Los montos calculados (intereses, impuestos, total a recibir) no se tocan; solo la etiqueta de la tasa en el PDF.

## Verificación

- `bun test:run`: 34/34 en verde.
- `bun run build`: OK.

🤖 Generated with [Claude Code](https://claude.com/claude-code)