### PR TITLE
feat(cartera): orden cronológico de pagos por cuota + chip de último aplicado

### DIFF
--- a/apps/cartera-back/src/controllers/payments.ts
+++ b/apps/cartera-back/src/controllers/payments.ts
@@ -134,7 +134,14 @@ export async function getAllPagosWithCreditAndInversionistas(
         eq(pagos_credito.cuota_id, cuotas_credito.cuota_id)
       )
       .where(eq(creditos.numero_credito_sifco, credito_sifco))
-      .orderBy(cuotas_credito.numero_cuota);
+      // Dentro de cada cuota: primero el recibo placeholder (sin fecha_aplicado ni
+      // fecha_pago), luego los pagos en orden cronológico — los registrados sin
+      // aplicar entran por su fecha de pago para no flotar arriba del historial.
+      .orderBy(
+        cuotas_credito.numero_cuota,
+        sql`COALESCE(${pagos_credito.fecha_aplicado}, ${pagos_credito.fecha_pago}) ASC NULLS FIRST`,
+        pagos_credito.pago_id
+      );
 
     const pagoIds = pagos.map((p) => p.pago_id);
 

--- a/apps/carteraFront/src/private/cartera/components/PaymentsCredits.tsx
+++ b/apps/carteraFront/src/private/cartera/components/PaymentsCredits.tsx
@@ -516,6 +516,34 @@ const handleDownloadExcel = async () => {
       return mesOk && anioOk;
     })
     : [];
+
+  // Último pago aplicado de cada cuota abierta: sus "restantes" son el estado real de la cuota
+  const ultimosAplicados = React.useMemo(() => {
+    const porCuota = new Map<number, { pago_id: number; fecha: number }>();
+    for (const item of pagosFiltrados as any[]) {
+      const p = item?.pago;
+      if (!p || p.cuota_pagada === true || p.paymentFalse === true) continue;
+      if (!p.fecha_aplicado || Number(p.monto_aplicado ?? 0) <= 0) continue;
+      // Los abonos a capital no cargan los restantes de la cuota
+      if (p.validationStatus === "capital" || p.validationStatus === "capital_validated") continue;
+      // Si la fila ya no tiene restantes (cuota cubierta esperando validación de
+      // un cierre pendiente), no hay "restantes actuales" que señalar
+      const restantesCuota =
+        Number(p.capital_restante ?? 0) +
+        Number(p.interes_restante ?? 0) +
+        Number(p.iva_12_restante ?? 0) +
+        Number(p.seguro_restante ?? 0) +
+        Number(p.gps_restante ?? 0);
+      if (restantesCuota <= 0) continue;
+      const fecha = new Date(p.fecha_aplicado).getTime();
+      const actual = porCuota.get(p.numero_cuota);
+      if (!actual || fecha > actual.fecha || (fecha === actual.fecha && p.pago_id > actual.pago_id)) {
+        porCuota.set(p.numero_cuota, { pago_id: p.pago_id, fecha });
+      }
+    }
+    return new Set([...porCuota.values()].map((v) => v.pago_id));
+  }, [pagosFiltrados]);
+
   return (
     <div className="fixed inset-x-0 top-16 xl:top-20 bottom-0 flex flex-col items-center justify-start bg-gradient-to-br from-blue-50 to-white px-2 overflow-auto pt-8 pb-8">
       <div className="w-full max-w-[1600px] mx-auto">
@@ -744,6 +772,11 @@ const handleDownloadExcel = async () => {
                       </TableCell>
                       <TableCell className="text-center text-green-700 font-bold">
                         {formatCurrency(item.pago.monto_aplicado)}
+                        {ultimosAplicados.has(item.pago.pago_id) && (
+                          <span className="block mx-auto mt-1 w-fit px-2 py-0.5 rounded-full bg-emerald-100 text-emerald-700 text-xs font-bold whitespace-nowrap">
+                            Último aplicado · restantes actuales
+                          </span>
+                        )}
                       </TableCell>
                       <TableCell className="text-center font-semibold">
                         {formatDate(item.pago.fecha_pago)}


### PR DESCRIPTION
## Qué hace

La pantalla **Historial de Pagos del Crédito** mostraba los pagos de cada cuota en orden arbitrario (solo se ordenaba por `numero_cuota`): la fila del recibo pre-sembrado (Q0.00, sin fechas) flotaba en medio de los pagos parciales y los restantes se leían "al revés", lo que confundía a contabilidad al revisar cuotas con parciales (caso real: crédito de Yeiner López Carías tras su abono a capital).

### Back — `/paymentByCredit` (`getAllPagosWithCreditAndInversionistas`)
Orden dentro de cada cuota: `COALESCE(fecha_aplicado, fecha_pago) ASC NULLS FIRST, pago_id`:
- El **recibo placeholder** (sin ninguna fecha) queda siempre de primero.
- Los pagos corren en **orden cronológico** hacia abajo — la última fila es el estado más reciente.
- Los pagos **registrados sin validar** (sin `fecha_aplicado`) entran por su fecha de pago, en su lugar cronológico real, en vez de flotar arriba del historial.
- El **Excel exportado** usa la misma función, así que sale ordenado igual.

### Front — `PaymentsCredits.tsx`
Chip verde **"Último aplicado · restantes actuales"** en el último pago aplicado de cada cuota abierta: es la fila cuyos `restantes` reflejan el estado real de la cuota (lo que falta para cerrarla). Se excluyen:
- Abonos a capital (`capital` / `capital_validated`) — sus restantes no son el estado de la cuota.
- Pagos anulados (`paymentFalse`).
- Filas con restantes componentes en 0 (cuota ya cubierta esperando la validación de un cierre pendiente — ahí no hay "restantes actuales" que señalar).

## Verificación
- Simulación del ORDER BY contra datos reales de prod (créditos con parciales, con abonos y con cierre pendiente de validar): el placeholder queda primero, el historial corre cronológico y el pendiente de validar cae al final.
- Probado visualmente en la pantalla con los tres escenarios: cuota con parciales + abono, cuota con cierre pendiente de validación y cuotas futuras sin movimientos (sin ruido).
- `tsc --noEmit` sin errores nuevos en ambos archivos.

🤖 Generated with [Claude Code](https://claude.com/claude-code)