### PR TITLE
🚀 Pase a Producción — Release develop → main

### DIFF
--- a/apps/cartera-back/src/controllers/monto-a-cobrar-participacion.test.ts
+++ b/apps/cartera-back/src/controllers/monto-a-cobrar-participacion.test.ts
@@ -1,0 +1,73 @@
+import { describe, expect, test } from "bun:test";
+import {
+	agregarParticipacionExterna,
+	splitMontoSegunParticipacionActual,
+} from "./monto-a-cobrar-participacion";
+
+describe("splitMontoSegunParticipacionActual", () => {
+	test("asigna 0% externo completamente a CUBE", () => {
+		expect(splitMontoSegunParticipacionActual(100, 12, 0)).toEqual({
+			valido: true,
+			capitalInv: 0,
+			capitalCube: 100,
+			interesIvaInv: 0,
+			interesIvaCube: 12,
+		});
+	});
+
+	test("asigna 100% externo completamente a Inv.", () => {
+		expect(splitMontoSegunParticipacionActual(100, 12, 1)).toEqual({
+			valido: true,
+			capitalInv: 100,
+			capitalCube: 0,
+			interesIvaInv: 12,
+			interesIvaCube: 0,
+		});
+	});
+
+	test("redondea Inv. por crédito y conserva CUBE por diferencia", () => {
+		const split = splitMontoSegunParticipacionActual(100.01, 10.01, 0.3333);
+
+		expect(split).toEqual({
+			valido: true,
+			capitalInv: 33.33,
+			capitalCube: 66.68,
+			interesIvaInv: 3.34,
+			interesIvaCube: 6.67,
+		});
+		if (split.valido) {
+			expect(split.capitalInv + split.capitalCube).toBe(100.01);
+			expect(split.interesIvaInv + split.interesIvaCube).toBe(10.01);
+		}
+	});
+
+	test("calcula CUBE como diferencia exacta sin redondearlo de nuevo", () => {
+		const split = splitMontoSegunParticipacionActual(100.019, 10.019, 0.5);
+
+		expect(split).toMatchObject({ valido: true, capitalInv: 50.01, interesIvaInv: 5.01 });
+		if (split.valido) {
+			expect(split.capitalCube).toBeCloseTo(50.009, 10);
+			expect(split.interesIvaCube).toBeCloseTo(5.009, 10);
+		}
+	});
+
+	test("excluye del split una participación agregada inválida", () => {
+		expect(splitMontoSegunParticipacionActual(100, 12, 1.01)).toEqual({
+			valido: false,
+			capitalInv: 0,
+			capitalCube: 0,
+			interesIvaInv: 0,
+			interesIvaCube: 0,
+		});
+	});
+});
+
+test("agrega múltiples participaciones externas sin duplicar la base", () => {
+	expect(agregarParticipacionExterna([25, 25, 50])).toBe(1);
+	const split = splitMontoSegunParticipacionActual(
+		200,
+		20,
+		agregarParticipacionExterna([25, 25]),
+	);
+	expect(split).toMatchObject({ capitalInv: 100, capitalCube: 100 });
+});

--- a/apps/cartera-back/src/controllers/monto-a-cobrar-participacion.ts
+++ b/apps/cartera-back/src/controllers/monto-a-cobrar-participacion.ts
@@ -1,0 +1,52 @@
+type SplitValido = {
+	valido: true;
+	capitalInv: number;
+	capitalCube: number;
+	interesIvaInv: number;
+	interesIvaCube: number;
+};
+
+type SplitInvalido = {
+	valido: false;
+	capitalInv: 0;
+	capitalCube: 0;
+	interesIvaInv: 0;
+	interesIvaCube: 0;
+};
+
+const redondearMoneda = (monto: number) => Number(monto.toFixed(2));
+
+export function agregarParticipacionExterna(porcentajes: number[]): number {
+	return porcentajes.reduce((total, porcentaje) => total + porcentaje / 100, 0);
+}
+
+export function splitMontoSegunParticipacionActual(
+	capital: number,
+	interesIva: number,
+	participacionExternaActual: number,
+): SplitValido | SplitInvalido {
+	if (
+		participacionExternaActual < 0 ||
+		participacionExternaActual > 1
+	) {
+		return {
+			valido: false,
+			capitalInv: 0,
+			capitalCube: 0,
+			interesIvaInv: 0,
+			interesIvaCube: 0,
+		};
+	}
+
+	const capitalInv = redondearMoneda(capital * participacionExternaActual);
+	const interesIvaInv = redondearMoneda(
+		interesIva * participacionExternaActual,
+	);
+	return {
+		valido: true,
+		capitalInv,
+		capitalCube: capital - capitalInv,
+		interesIvaInv,
+		interesIvaCube: interesIva - interesIvaInv,
+	};
+}

--- a/apps/cartera-back/src/controllers/moraHistorial.ts
+++ b/apps/cartera-back/src/controllers/moraHistorial.ts
@@ -1,6 +1,9 @@
-import { db } from "../database";
 import { sql } from "drizzle-orm";
 import ExcelJS from "exceljs";
+import { db } from "../database";
+import { snapCte } from "./moraSnapshotSql";
+
+export { snapCte } from "./moraSnapshotSql";
 
 // ─────────────────────────────────────────────────────────────────────────────
 // Módulo Mora Histórica: reconstruye la mora a cualquier fecha desde
@@ -15,34 +18,6 @@ const ETAPA_SQL = sql`CASE
   WHEN s.cuotas = 3 THEN 'Mora 90'
   WHEN s.cuotas >= 4 THEN 'Mora 120+'
   ELSE 'Al día' END`;
-
-// CTE: estado de mora por crédito "as-of" `fecha`.
-// monto/tipo = último evento; cuotas = último evento CON cuotas>0 (carry-forward).
-export const snapCte = (fecha: string) => sql`
-  snap_raw AS (
-    SELECT
-      h.credito_id,
-      h.tipo_evento,
-      h.monto_nuevo::numeric AS monto,
-      h.fecha,
-      ROW_NUMBER() OVER (PARTITION BY h.credito_id ORDER BY h.fecha DESC, h.historial_id DESC) AS rn,
-      -- cuotas "vivas": cuotas del evento más reciente con cuotas>0. Los eventos payment-only
-      -- (updateMora sin cuotas, p.ej. reversa de pago en reversePayment.ts) registran
-      -- cuotas_atrasadas_nuevas=0; sin carry-forward un crédito con mora>0 cuyo último evento
-      -- sea payment-only caería a "Al día" y se saldría de los buckets 30/60/90/120 (review Codex).
-      FIRST_VALUE(h.cuotas_atrasadas_nuevas) OVER (
-        PARTITION BY h.credito_id
-        ORDER BY (h.cuotas_atrasadas_nuevas > 0) DESC, h.fecha DESC, h.historial_id DESC
-      ) AS cuotas
-    FROM cartera.moras_historial h
-    -- Corte por DÍA Guatemala: fecha es timestamp UTC (defaultNow, session UTC) y el cron
-    -- corre ~23:59 GT (≈06:00 UTC del día siguiente); comparar en GT evita correr esos
-    -- eventos al día siguiente.
-    WHERE (h.fecha AT TIME ZONE 'UTC' AT TIME ZONE 'America/Guatemala')::date <= ${fecha}::date
-  ),
-  snap AS (
-    SELECT credito_id, tipo_evento, monto, cuotas, fecha FROM snap_raw WHERE rn = 1
-  )`;
 
 type SnapshotArgs = {
   fecha: string; // YYYY-MM-DD (corte "al" día)

--- a/apps/cartera-back/src/controllers/moraRecuperacion.test.ts
+++ b/apps/cartera-back/src/controllers/moraRecuperacion.test.ts
@@ -176,14 +176,32 @@ describe("buildMoraRecoveryReport", () => {
 	});
 
 	it("permite el mes actual provisional antes del día 6 y rechaza ciclos futuros", () => {
-		expect(
-			getMoraRecoveryPeriod({ mes: 6, anio: 2026, hoy: "2026-06-03" }),
-		).toMatchObject({ alcance: "live" });
+		for (const dia of ["01", "02", "03", "04", "05"]) {
+			expect(
+				getMoraRecoveryPeriod({ mes: 6, anio: 2026, hoy: `2026-06-${dia}` }),
+			).toMatchObject({ fechaSnapshot: `2026-06-${dia}`, alcance: "live" });
+		}
 		expect(() =>
 			getMoraRecoveryPeriod({ mes: 7, anio: 2026, hoy: "2026-06-03" }),
 		).toThrow("ciclo futuro");
 		expect(() =>
 			getMoraRecoveryPeriod({ mes: 1, anio: 2027, hoy: "2026-12-20" }),
 		).toThrow("ciclo futuro");
+	});
+
+	it("usa el snapshot histórico de apertura desde el día 6", () => {
+		const period = getMoraRecoveryPeriod({
+			mes: 6,
+			anio: 2026,
+			hoy: "2026-06-06",
+		});
+		const query = new PgDialect().sqlToQuery(buildMoraRecoveryQuery(period));
+
+		expect(period).toMatchObject({
+			fechaSnapshot: "2026-06-06",
+			alcance: "historico",
+		});
+		expect(query.sql).toContain("moras_historial");
+		expect(query.sql).not.toContain("mora_activa");
 	});
 });

--- a/apps/cartera-back/src/controllers/moraRecuperacion.test.ts
+++ b/apps/cartera-back/src/controllers/moraRecuperacion.test.ts
@@ -68,6 +68,37 @@ describe("buildMoraRecoveryReport", () => {
 		]);
 	});
 
+	it("usa un snapshot estrictamente anterior al inicio y cuenta el pago del día 6", () => {
+		const period = getMoraRecoveryPeriod({
+			mes: 6,
+			anio: 2026,
+			hoy: "2026-07-29",
+		});
+		const query = new PgDialect().sqlToQuery(buildMoraRecoveryQuery(period));
+		const report = buildMoraRecoveryReport(
+			[
+				{
+					asesorId: 1,
+					nombre: "Ana",
+					esperado: "100",
+					cobradoEnSnapshot: "40",
+					cobradoFueraSnapshot: "0",
+				},
+			],
+			period,
+		);
+
+		expect(query.sql).toContain(
+			"(h.fecha AT TIME ZONE 'UTC' AT TIME ZONE 'America/Guatemala')::date < $1::date",
+		);
+		expect(report.totales).toMatchObject({
+			esperado: "100.00",
+			cobradoEnSnapshot: "40.00",
+			cobradoFueraSnapshot: "0.00",
+			pendiente: "60.00",
+		});
+	});
+
 	it("separa cobrado del snapshot, fuera, excedente y pendiente sin truncar", () => {
 		const report = buildMoraRecoveryReport(rows, {
 			inicio: "2026-06-06",
@@ -142,5 +173,17 @@ describe("buildMoraRecoveryReport", () => {
 				pendiente: "60.00",
 			}),
 		]);
+	});
+
+	it("permite el mes actual provisional antes del día 6 y rechaza ciclos futuros", () => {
+		expect(
+			getMoraRecoveryPeriod({ mes: 6, anio: 2026, hoy: "2026-06-03" }),
+		).toMatchObject({ alcance: "live" });
+		expect(() =>
+			getMoraRecoveryPeriod({ mes: 7, anio: 2026, hoy: "2026-06-03" }),
+		).toThrow("ciclo futuro");
+		expect(() =>
+			getMoraRecoveryPeriod({ mes: 1, anio: 2027, hoy: "2026-12-20" }),
+		).toThrow("ciclo futuro");
 	});
 });

--- a/apps/cartera-back/src/controllers/moraRecuperacion.test.ts
+++ b/apps/cartera-back/src/controllers/moraRecuperacion.test.ts
@@ -1,0 +1,146 @@
+import { describe, expect, it } from "bun:test";
+import { PgDialect } from "drizzle-orm/pg-core";
+import {
+	type MoraRecoverySourceRow,
+	buildMoraRecoveryQuery,
+	buildMoraRecoveryReport,
+	getMoraRecoveryPeriod,
+} from "./moraRecuperacion";
+
+const rows: MoraRecoverySourceRow[] = [
+	{
+		asesorId: 1,
+		nombre: "Ana",
+		esperado: "100.00",
+		cobradoEnSnapshot: "120.00",
+		cobradoFueraSnapshot: "30.00",
+	},
+	{
+		asesorId: null,
+		nombre: "Sin asignar",
+		esperado: "50.00",
+		cobradoEnSnapshot: "20.00",
+		cobradoFueraSnapshot: "0.00",
+	},
+	{
+		asesorId: 2,
+		nombre: "Beto",
+		esperado: "0.00",
+		cobradoEnSnapshot: "0.00",
+		cobradoFueraSnapshot: "40.00",
+	},
+];
+
+describe("buildMoraRecoveryReport", () => {
+	it("construye el contrato SQL histórico con el ciclo, FULL JOIN y filtros actuales", () => {
+		const period = getMoraRecoveryPeriod({
+			mes: 6,
+			anio: 2026,
+			hoy: "2026-07-29",
+		});
+		const query = new PgDialect().sqlToQuery(
+			buildMoraRecoveryQuery({
+				...period,
+				asesores: [7, 8],
+				emailCobrador: "cashin@example.com",
+			}),
+		);
+
+		expect(period).toEqual({
+			inicio: "2026-06-06",
+			fin: "2026-07-06",
+			fechaSnapshot: "2026-06-06",
+			alcance: "historico",
+		});
+		expect(query.sql).toContain("FULL JOIN pagos_por_credito");
+		expect(query.sql).toContain("moras_historial");
+		expect(query.sql).not.toContain('"statusCredit"');
+		expect(query.sql).toContain("LOWER(a.email_cash_in) = LOWER(TRIM($2))");
+		expect(query.sql).toContain("a.asesor_id IN ($3, $4)");
+		expect(query.sql).toContain("COALESCE(ca.nombre, 'Sin asignar')");
+		expect(query.params).toEqual([
+			"2026-06-06",
+			"cashin@example.com",
+			7,
+			8,
+			"2026-06-06",
+			"2026-07-06",
+		]);
+	});
+
+	it("separa cobrado del snapshot, fuera, excedente y pendiente sin truncar", () => {
+		const report = buildMoraRecoveryReport(rows, {
+			inicio: "2026-06-06",
+			fin: "2026-07-06",
+			alcance: "historico",
+		});
+
+		expect(report.totales).toEqual({
+			esperado: "150.00",
+			cobradoEnSnapshot: "140.00",
+			cobradoFueraSnapshot: "70.00",
+			excedenteEnSnapshot: "20.00",
+			pendiente: "30.00",
+		});
+		expect(
+			report.porAsesor.find((row) => row.asesorId === 1)?.excedenteEnSnapshot,
+		).toBe("20.00");
+		expect(report.porAsesor.find((row) => row.asesorId === 2)?.pendiente).toBe(
+			"0.00",
+		);
+	});
+
+	it("conserva asesores exclusivos y representa Sin asignar de forma tipada", () => {
+		const report = buildMoraRecoveryReport(rows, {
+			inicio: "2026-06-06",
+			fin: "2026-07-06",
+			alcance: "historico",
+		});
+
+		expect(report.porAsesor.map((row) => row.asesorId)).toEqual([1, null, 2]);
+		expect(report.porAsesor.find((row) => row.asesorId === null)).toMatchObject(
+			{
+				nombre: "Sin asignar",
+				esperado: "50.00",
+				pendiente: "30.00",
+			},
+		);
+		expect(report.metadata).toEqual({
+			alcance: "historico",
+			atribucionAsesor: "actual",
+		});
+	});
+
+	it("agrega por asesor sin permitir que excedentes compensen pendientes de otro crédito", () => {
+		const report = buildMoraRecoveryReport(
+			[
+				{
+					asesorId: 7,
+					nombre: "Cora",
+					esperado: "100",
+					cobradoEnSnapshot: "140",
+					cobradoFueraSnapshot: "0",
+				},
+				{
+					asesorId: 7,
+					nombre: "Cora",
+					esperado: "80",
+					cobradoEnSnapshot: "20",
+					cobradoFueraSnapshot: "90",
+				},
+			],
+			{ inicio: "2026-06-06", fin: "2026-07-06", alcance: "live" },
+		);
+
+		expect(report.porAsesor).toEqual([
+			expect.objectContaining({
+				asesorId: 7,
+				esperado: "180.00",
+				cobradoEnSnapshot: "160.00",
+				cobradoFueraSnapshot: "90.00",
+				excedenteEnSnapshot: "40.00",
+				pendiente: "60.00",
+			}),
+		]);
+	});
+});

--- a/apps/cartera-back/src/controllers/moraRecuperacion.ts
+++ b/apps/cartera-back/src/controllers/moraRecuperacion.ts
@@ -39,6 +39,13 @@ export type MoraRecoveryPeriod = {
 	alcance: "live" | "historico";
 };
 
+export class MoraRecoveryFuturePeriodError extends Error {
+	constructor() {
+		super("No se puede consultar un ciclo futuro");
+		this.name = "MoraRecoveryFuturePeriodError";
+	}
+}
+
 export function getMoraRecoveryPeriod({
 	mes,
 	anio,
@@ -48,6 +55,10 @@ export function getMoraRecoveryPeriod({
 	anio: number;
 	hoy: string;
 }): MoraRecoveryPeriod {
+	const [anioActual, mesActual] = hoy.split("-").map(Number);
+	if (anio > anioActual || (anio === anioActual && mes > mesActual)) {
+		throw new MoraRecoveryFuturePeriodError();
+	}
 	const inicio = `${anio}-${String(mes).padStart(2, "0")}-06`;
 	const finMes = mes === 12 ? 1 : mes + 1;
 	const finAnio = mes === 12 ? anio + 1 : anio;
@@ -83,7 +94,7 @@ export function buildMoraRecoveryQuery({
 		: sql``;
 	const snapshotCte =
 		alcance === "historico"
-			? sql`${snapCte(fechaSnapshot)}, snapshot_por_credito AS (
+			? sql`${snapCte(fechaSnapshot, false)}, snapshot_por_credito AS (
       SELECT s.credito_id, s.monto::numeric AS esperado
       FROM snap s
       WHERE s.tipo_evento <> 'DESACTIVACION' AND s.monto > 0 AND s.cuotas > 0

--- a/apps/cartera-back/src/controllers/moraRecuperacion.ts
+++ b/apps/cartera-back/src/controllers/moraRecuperacion.ts
@@ -1,0 +1,199 @@
+import { sql } from "drizzle-orm";
+import { snapCte } from "./moraSnapshotSql";
+
+export type MoraRecoverySourceRow = {
+	asesorId: number | null;
+	nombre: string;
+	esperado: string;
+	cobradoEnSnapshot: string;
+	cobradoFueraSnapshot: string;
+};
+
+export type MoraRecoveryMetric = {
+	esperado: string;
+	cobradoEnSnapshot: string;
+	cobradoFueraSnapshot: string;
+	excedenteEnSnapshot: string;
+	pendiente: string;
+};
+
+export type MoraRecoveryRow = MoraRecoveryMetric & {
+	asesorId: number | null;
+	nombre: string;
+};
+
+type MoraRecoveryReport = {
+	periodo: { inicio: string; fin: string };
+	metadata: {
+		alcance: "live" | "historico";
+		atribucionAsesor: "actual";
+	};
+	totales: MoraRecoveryMetric;
+	porAsesor: MoraRecoveryRow[];
+};
+
+export type MoraRecoveryPeriod = {
+	inicio: string;
+	fin: string;
+	fechaSnapshot: string;
+	alcance: "live" | "historico";
+};
+
+export function getMoraRecoveryPeriod({
+	mes,
+	anio,
+	hoy,
+}: {
+	mes: number;
+	anio: number;
+	hoy: string;
+}): MoraRecoveryPeriod {
+	const inicio = `${anio}-${String(mes).padStart(2, "0")}-06`;
+	const finMes = mes === 12 ? 1 : mes + 1;
+	const finAnio = mes === 12 ? anio + 1 : anio;
+	const fin = `${finAnio}-${String(finMes).padStart(2, "0")}-06`;
+	const fechaSnapshot = inicio > hoy ? hoy : inicio;
+	return {
+		inicio,
+		fin,
+		fechaSnapshot,
+		alcance: fechaSnapshot < hoy ? "historico" : "live",
+	};
+}
+
+export function buildMoraRecoveryQuery({
+	inicio,
+	fin,
+	fechaSnapshot,
+	alcance,
+	asesores,
+	emailCobrador,
+}: MoraRecoveryPeriod & {
+	asesores?: number[];
+	emailCobrador?: string;
+}) {
+	const emailFilter = emailCobrador
+		? sql`AND LOWER(a.email_cash_in) = LOWER(TRIM(${emailCobrador}))`
+		: sql``;
+	const asesoresFilter = asesores?.length
+		? sql`AND a.asesor_id IN (${sql.join(
+				asesores.map((id) => sql`${id}`),
+				sql`, `,
+			)})`
+		: sql``;
+	const snapshotCte =
+		alcance === "historico"
+			? sql`${snapCte(fechaSnapshot)}, snapshot_por_credito AS (
+      SELECT s.credito_id, s.monto::numeric AS esperado
+      FROM snap s
+      WHERE s.tipo_evento <> 'DESACTIVACION' AND s.monto > 0 AND s.cuotas > 0
+    )`
+			: sql`mora_activa AS (
+      SELECT DISTINCT ON (credito_id) credito_id, monto_mora::numeric AS esperado
+      FROM cartera.moras_credito
+      WHERE activa = true AND cuotas_atrasadas > 0
+      ORDER BY credito_id, mora_id DESC
+    ), snapshot_por_credito AS (
+      SELECT m.credito_id, m.esperado
+      FROM mora_activa m
+      JOIN cartera.creditos c ON c.credito_id = m.credito_id
+      WHERE c."statusCredit" IN ('ACTIVO', 'MOROSO', 'EN_CONVENIO')
+    )`;
+
+	return sql`
+    WITH ${snapshotCte},
+    creditos_con_asesor AS (
+      SELECT c.credito_id, c.asesor_id, a.nombre
+      FROM cartera.creditos c
+      LEFT JOIN cartera.asesores a ON a.asesor_id = c.asesor_id
+      WHERE true ${emailFilter} ${asesoresFilter}
+    ),
+    pagos_por_credito AS (
+      SELECT pc.credito_id, COALESCE(SUM(pc.mora::numeric), 0) AS cobrado
+      FROM cartera.pagos_credito pc
+      JOIN creditos_con_asesor ca ON ca.credito_id = pc.credito_id
+      WHERE pc.fecha_pago >= ${inicio}::timestamp
+        AND pc.fecha_pago < ${fin}::timestamp
+        AND COALESCE(pc."paymentFalse", false) = false
+      GROUP BY pc.credito_id
+    )
+    SELECT
+      ca.asesor_id,
+      COALESCE(ca.nombre, 'Sin asignar') AS nombre,
+      COALESCE(s.esperado, 0)::text AS esperado,
+      CASE WHEN s.credito_id IS NOT NULL THEN COALESCE(p.cobrado, 0) ELSE 0 END::text AS cobrado_en_snapshot,
+      CASE WHEN s.credito_id IS NULL THEN COALESCE(p.cobrado, 0) ELSE 0 END::text AS cobrado_fuera_snapshot
+    FROM snapshot_por_credito s
+    FULL JOIN pagos_por_credito p ON p.credito_id = s.credito_id
+    JOIN creditos_con_asesor ca ON ca.credito_id = COALESCE(s.credito_id, p.credito_id)
+  `;
+}
+
+function metricFrom(
+	row: Omit<MoraRecoverySourceRow, "asesorId" | "nombre">,
+): MoraRecoveryMetric {
+	const esperado = Number(row.esperado);
+	const cobradoEnSnapshot = Number(row.cobradoEnSnapshot);
+	const cobradoFueraSnapshot = Number(row.cobradoFueraSnapshot);
+	return {
+		esperado: esperado.toFixed(2),
+		cobradoEnSnapshot: cobradoEnSnapshot.toFixed(2),
+		cobradoFueraSnapshot: cobradoFueraSnapshot.toFixed(2),
+		excedenteEnSnapshot: Math.max(0, cobradoEnSnapshot - esperado).toFixed(2),
+		pendiente: Math.max(0, esperado - cobradoEnSnapshot).toFixed(2),
+	};
+}
+
+export function buildMoraRecoveryReport(
+	rows: MoraRecoverySourceRow[],
+	periodo: { inicio: string; fin: string; alcance: "live" | "historico" },
+): MoraRecoveryReport {
+	const byAsesor = new Map<string, MoraRecoveryRow>();
+	for (const source of rows) {
+		const key = String(source.asesorId);
+		const current = byAsesor.get(key) ?? {
+			asesorId: source.asesorId,
+			nombre: source.nombre,
+			...metricFrom({
+				esperado: "0",
+				cobradoEnSnapshot: "0",
+				cobradoFueraSnapshot: "0",
+			}),
+		};
+		const metric = metricFrom(source);
+		byAsesor.set(key, {
+			asesorId: current.asesorId,
+			nombre: current.nombre,
+			esperado: (Number(current.esperado) + Number(metric.esperado)).toFixed(2),
+			cobradoEnSnapshot: (
+				Number(current.cobradoEnSnapshot) + Number(metric.cobradoEnSnapshot)
+			).toFixed(2),
+			cobradoFueraSnapshot: (
+				Number(current.cobradoFueraSnapshot) +
+				Number(metric.cobradoFueraSnapshot)
+			).toFixed(2),
+			excedenteEnSnapshot: (
+				Number(current.excedenteEnSnapshot) + Number(metric.excedenteEnSnapshot)
+			).toFixed(2),
+			pendiente: (Number(current.pendiente) + Number(metric.pendiente)).toFixed(
+				2,
+			),
+		});
+	}
+	const porAsesor = [...byAsesor.values()];
+	const sum = (field: keyof MoraRecoveryMetric) =>
+		porAsesor.reduce((total, row) => total + Number(row[field]), 0).toFixed(2);
+
+	return {
+		periodo: { inicio: periodo.inicio, fin: periodo.fin },
+		metadata: { alcance: periodo.alcance, atribucionAsesor: "actual" },
+		totales: {
+			esperado: sum("esperado"),
+			cobradoEnSnapshot: sum("cobradoEnSnapshot"),
+			cobradoFueraSnapshot: sum("cobradoFueraSnapshot"),
+			excedenteEnSnapshot: sum("excedenteEnSnapshot"),
+			pendiente: sum("pendiente"),
+		},
+		porAsesor,
+	};
+}

--- a/apps/cartera-back/src/controllers/moraRecuperacion.ts
+++ b/apps/cartera-back/src/controllers/moraRecuperacion.ts
@@ -68,7 +68,7 @@ export function getMoraRecoveryPeriod({
 		inicio,
 		fin,
 		fechaSnapshot,
-		alcance: fechaSnapshot < hoy ? "historico" : "live",
+		alcance: inicio <= hoy ? "historico" : "live",
 	};
 }
 

--- a/apps/cartera-back/src/controllers/moraSnapshotSql.ts
+++ b/apps/cartera-back/src/controllers/moraSnapshotSql.ts
@@ -2,7 +2,9 @@ import { sql } from "drizzle-orm";
 
 // CTE: estado de mora por crédito "as-of" `fecha`.
 // monto/tipo = último evento; cuotas = último evento CON cuotas>0 (carry-forward).
-export const snapCte = (fecha: string) => sql`
+export const snapCte = (fecha: string, incluirFecha = true) => {
+	const comparador = incluirFecha ? sql`<=` : sql`<`;
+	return sql`
   snap_raw AS (
     SELECT
       h.credito_id,
@@ -22,8 +24,9 @@ export const snapCte = (fecha: string) => sql`
     -- Corte por DÍA Guatemala: fecha es timestamp UTC (defaultNow, session UTC) y el cron
     -- corre ~23:59 GT (≈06:00 UTC del día siguiente); comparar en GT evita correr esos
     -- eventos al día siguiente.
-    WHERE (h.fecha AT TIME ZONE 'UTC' AT TIME ZONE 'America/Guatemala')::date <= ${fecha}::date
+    WHERE (h.fecha AT TIME ZONE 'UTC' AT TIME ZONE 'America/Guatemala')::date ${comparador} ${fecha}::date
   ),
   snap AS (
     SELECT credito_id, tipo_evento, monto, cuotas, fecha FROM snap_raw WHERE rn = 1
   )`;
+};

--- a/apps/cartera-back/src/controllers/moraSnapshotSql.ts
+++ b/apps/cartera-back/src/controllers/moraSnapshotSql.ts
@@ -1,0 +1,29 @@
+import { sql } from "drizzle-orm";
+
+// CTE: estado de mora por crédito "as-of" `fecha`.
+// monto/tipo = último evento; cuotas = último evento CON cuotas>0 (carry-forward).
+export const snapCte = (fecha: string) => sql`
+  snap_raw AS (
+    SELECT
+      h.credito_id,
+      h.tipo_evento,
+      h.monto_nuevo::numeric AS monto,
+      h.fecha,
+      ROW_NUMBER() OVER (PARTITION BY h.credito_id ORDER BY h.fecha DESC, h.historial_id DESC) AS rn,
+      -- cuotas "vivas": cuotas del evento más reciente con cuotas>0. Los eventos payment-only
+      -- (updateMora sin cuotas, p.ej. reversa de pago en reversePayment.ts) registran
+      -- cuotas_atrasadas_nuevas=0; sin carry-forward un crédito con mora>0 cuyo último evento
+      -- sea payment-only caería a "Al día" y se saldría de los buckets 30/60/90/120 (review Codex).
+      FIRST_VALUE(h.cuotas_atrasadas_nuevas) OVER (
+        PARTITION BY h.credito_id
+        ORDER BY (h.cuotas_atrasadas_nuevas > 0) DESC, h.fecha DESC, h.historial_id DESC
+      ) AS cuotas
+    FROM cartera.moras_historial h
+    -- Corte por DÍA Guatemala: fecha es timestamp UTC (defaultNow, session UTC) y el cron
+    -- corre ~23:59 GT (≈06:00 UTC del día siguiente); comparar en GT evita correr esos
+    -- eventos al día siguiente.
+    WHERE (h.fecha AT TIME ZONE 'UTC' AT TIME ZONE 'America/Guatemala')::date <= ${fecha}::date
+  ),
+  snap AS (
+    SELECT credito_id, tipo_evento, monto, cuotas, fecha FROM snap_raw WHERE rn = 1
+  )`;

--- a/apps/cartera-back/src/controllers/payments.ts
+++ b/apps/cartera-back/src/controllers/payments.ts
@@ -134,7 +134,14 @@ export async function getAllPagosWithCreditAndInversionistas(
         eq(pagos_credito.cuota_id, cuotas_credito.cuota_id)
       )
       .where(eq(creditos.numero_credito_sifco, credito_sifco))
-      .orderBy(cuotas_credito.numero_cuota);
+      // Dentro de cada cuota: primero el recibo placeholder (sin fecha_aplicado ni
+      // fecha_pago), luego los pagos en orden cronológico — los registrados sin
+      // aplicar entran por su fecha de pago para no flotar arriba del historial.
+      .orderBy(
+        cuotas_credito.numero_cuota,
+        sql`COALESCE(${pagos_credito.fecha_aplicado}, ${pagos_credito.fecha_pago}) ASC NULLS FIRST`,
+        pagos_credito.pago_id
+      );
 
     const pagoIds = pagos.map((p) => p.pago_id);
 

--- a/apps/cartera-back/src/controllers/registerPayment.ts
+++ b/apps/cartera-back/src/controllers/registerPayment.ts
@@ -384,11 +384,34 @@ const obtenerInfoCompletaCredito = async (
     }
 
     console.log(cuotaApagar,"cuota a pagar");
-    const cuotasPendientesUnicas = Array.from(
-      new Map(
-        cuotasPendientes.map((item) => [item.cuotas_credito.cuota_id, item])
-      ).values()
+    // Dedupe por NUMERO_CUOTA, no por cuota_id: hay créditos con cuotas_credito
+    // duplicadas (mismo numero_cuota, cuota_id distinto — artefacto del flujo
+    // viejo de abonos). Si sobreviven ambas copias, la cascada cobra la misma
+    // cuota N veces y corre los tramos una casilla (caso crédito 793, cuota 17:
+    // el tramo de la 18 cerró la 17 fantasma y la 19 nunca recibió el suyo).
+    // Nos quedamos con la copia más reciente (mayor cuota_id): es la que trae
+    // el recibo re-sembrado vigente.
+    const porNumeroCuota = new Map<number, (typeof cuotasPendientes)[number]>();
+    for (const item of cuotasPendientes) {
+      const previo = porNumeroCuota.get(item.cuotas_credito.numero_cuota);
+      if (
+        !previo ||
+        item.cuotas_credito.cuota_id > previo.cuotas_credito.cuota_id
+      ) {
+        porNumeroCuota.set(item.cuotas_credito.numero_cuota, item);
+      }
+    }
+    const cuotasPendientesUnicas = Array.from(porNumeroCuota.values());
+    const cuotaIdsPendientes = new Set(
+      cuotasPendientes.map((item) => item.cuotas_credito.cuota_id)
     );
+    if (cuotaIdsPendientes.size > cuotasPendientesUnicas.length) {
+      console.warn(
+        `⚠️ Crédito ${credito_id}: cuotas_credito DUPLICADAS detectadas en pendientes ` +
+          `(${cuotaIdsPendientes.size} cuota_id para ${cuotasPendientesUnicas.length} números de cuota). ` +
+          `Se usa solo la copia más reciente de cada numero_cuota.`
+      );
+    }
     const numerosCuotas = cuotasPendientesUnicas.map((item) => item.cuotas_credito.numero_cuota);
     console.log("Números de cuotas pendientes:", numerosCuotas);
 

--- a/apps/cartera-back/src/controllers/reinvestmentReport.test.ts
+++ b/apps/cartera-back/src/controllers/reinvestmentReport.test.ts
@@ -7,6 +7,7 @@ import {
   buildInvestorPosition,
   buildNetInterestDetail,
   getPublicReinvestmentDetailError,
+  shouldIncludeInvestorPosition,
 } from "./reinvestmentReport";
 
 test("distribuye el centavo residual sin cambiar el orden de los pagos", () => {
@@ -127,6 +128,24 @@ describe("buildInvestorPosition", () => {
       capital_activo: "900000.00",
     });
   });
+});
+
+test("el reporte conserva y totaliza al inversionista con capital activo y flujo cero", () => {
+  const investor = {
+    reinversion: "0.00",
+    a_recibir: "0.00",
+    monto_aportado: "0.00",
+    capital_activo: "1250.00",
+  };
+  const retained = [investor].filter(shouldIncludeInvestorPosition);
+
+  expect(retained).toEqual([investor]);
+  expect(
+    retained.reduce(
+      (total, investor) => total + Number(investor.capital_activo),
+      0,
+    ),
+  ).toBe(1250);
 });
 
 test("capital activo usa el espejo completo y excluye créditos cerrados", async () => {

--- a/apps/cartera-back/src/controllers/reinvestmentReport.test.ts
+++ b/apps/cartera-back/src/controllers/reinvestmentReport.test.ts
@@ -4,6 +4,7 @@ import {
   allocateRoundedPurchaseAmounts,
   assertModeReconciliation,
   assertReportReconciliation,
+  calculateActiveCapital,
   buildCubeNetInterest,
   canonicalizePurchaseSummaries,
   buildNetInterestDetail,
@@ -154,15 +155,40 @@ test("el reporte conserva y totaliza al inversionista con capital activo y flujo
   ).toBe(1250);
 });
 
-test("capital activo usa el espejo completo y excluye créditos cerrados", async () => {
+test("capital activo conserva la posición aceptada al restar una compra pendiente", () => {
+  expect(calculateActiveCapital(1250, 250)).toBe(1000);
+});
+
+test("capital activo resta múltiples compras pendientes ya agregadas", () => {
+  expect(calculateActiveCapital(1250, 250 + 100)).toBe(900);
+});
+
+test("capital activo no resta compras completadas", () => {
+  expect(calculateActiveCapital(1250, 0)).toBe(1250);
+});
+
+test("capital activo agrega compras pendientes por posición antes de restarlas", async () => {
   const source = await Bun.file(
     new URL("./reportes.ts", import.meta.url),
   ).text();
+  const activeCapitalStart = source.indexOf("const capitalActivoRows");
   const activeCapitalQuery = source.slice(
-    source.indexOf("const capitalActivoRows"),
-    source.indexOf("const montoAportadoRows"),
+    activeCapitalStart,
+    source.indexOf("const porInversionista", activeCapitalStart),
   );
 
+  expect(activeCapitalQuery).toContain("WITH pending_purchase_deltas AS");
+  expect(activeCapitalQuery).toContain("c.tipo_operacion = 'compra_cartera'");
+  expect(activeCapitalQuery).toContain("c.status = 'pendiente_compra_cartera'");
+  expect(activeCapitalQuery).toContain(
+    "GROUP BY c.credito_id, c.inversionista_id",
+  );
+  expect(activeCapitalQuery).toContain(
+    "SUM(ce.monto_aportado::numeric), 0) AS monto_espejo",
+  );
+  expect(activeCapitalQuery).toContain(
+    "SUM(ppd.monto_pendiente), 0) AS monto_compra_pendiente",
+  );
   expect(activeCapitalQuery).toContain(
     "FROM cartera.creditos_inversionistas_espejo ce",
   );
@@ -170,6 +196,9 @@ test("capital activo usa el espejo completo y excluye créditos cerrados", async
     "cr.\"statusCredit\" IN ('ACTIVO', 'MOROSO', 'EN_CONVENIO')",
   );
   expect(activeCapitalQuery).toContain("GROUP BY ce.inversionista_id");
+  expect(activeCapitalQuery).toContain(
+    "calculateActiveCapital(\n        Number(r.monto_espejo ?? 0),\n        Number(r.monto_compra_pendiente ?? 0)",
+  );
 });
 
 test("el resumen de compras canoniza NULL y sin_reinversion en la misma modalidad", async () => {

--- a/apps/cartera-back/src/controllers/reinvestmentReport.test.ts
+++ b/apps/cartera-back/src/controllers/reinvestmentReport.test.ts
@@ -1,11 +1,39 @@
 import { describe, expect, test } from "bun:test";
 import {
+  allocateRoundedAmounts,
   assertModeReconciliation,
   buildInvestorPosition,
   buildNetInterestDetail,
   getPublicReinvestmentDetailError,
   assertReportReconciliation,
 } from "./reinvestmentReport";
+
+test("distribuye el centavo residual sin cambiar el orden de los pagos", () => {
+  const amounts = allocateRoundedAmounts([
+    "33.333333",
+    "33.333333",
+    "33.333333",
+  ]);
+
+  expect(amounts).toEqual(["33.34", "33.33", "33.33"]);
+  expect(
+    assertReportReconciliation({
+      interesNeto: {
+        conFactura: { neto: "0.00" },
+        sinFactura: { neto: "0.00" },
+        cube: { neto: "0.00" },
+      },
+      pagosExtras: { abonos_capital: "100.00", cancelaciones: "0.00" },
+      comprasMes: [],
+      detalleInteresNeto: [],
+      detallePagosExtras: amounts.map((monto) => ({
+        tipo: "abono_capital",
+        monto,
+      })),
+      detalleComprasMes: [],
+    }),
+  ).toMatchObject({ pagosExtras: true });
+});
 
 describe("buildNetInterestDetail", () => {
   test("con factura suma IVA al interés", () => {
@@ -288,6 +316,36 @@ test("cada modalidad concilia destinos y composición fiscal real", () => {
       total_distribuido: "54.65",
     }),
   ).toBe(true);
+});
+
+test("una modalidad admite solo un centavo por redondeo independiente de componentes", () => {
+  expect(
+    assertModeReconciliation({
+      reinversion_capital: "34.27",
+      reinversion_interes: "0.00",
+      reinversion_total: "34.27",
+      total_capital: "33.34",
+      total_interes: "1.01",
+      iva_facturado: "0.00",
+      total_isr: "0.07",
+      total_cuota: "0.00",
+      total_distribuido: "34.27",
+    }),
+  ).toBe(true);
+
+  expect(() =>
+    assertModeReconciliation({
+      reinversion_capital: "34.27",
+      reinversion_interes: "0.00",
+      reinversion_total: "34.27",
+      total_capital: "33.35",
+      total_interes: "1.01",
+      iva_facturado: "0.00",
+      total_isr: "0.07",
+      total_cuota: "0.00",
+      total_distribuido: "34.27",
+    }),
+  ).toThrow("Modalidad no concilia");
 });
 
 test("una modalidad con composición o destinos descuadrados no se publica", () => {

--- a/apps/cartera-back/src/controllers/reinvestmentReport.test.ts
+++ b/apps/cartera-back/src/controllers/reinvestmentReport.test.ts
@@ -5,7 +5,7 @@ import {
   assertModeReconciliation,
   assertReportReconciliation,
   buildCubeNetInterest,
-  buildInvestorPosition,
+  canonicalizePurchaseSummaries,
   buildNetInterestDetail,
   getPublicReinvestmentDetailError,
   shouldIncludeInvestorPosition,
@@ -30,8 +30,7 @@ test("distribuye el centavo residual sin cambiar el orden de los pagos", () => {
   expect(
     assertReportReconciliation({
       interesNeto: {
-        conFactura: { neto: "0.00" },
-        sinFactura: { neto: "0.00" },
+        noVerificado: { interes: "0.00" },
         cube: { neto: "0.00" },
       },
       pagosExtras: { abonos_capital: "100.00", cancelaciones: "0.00" },
@@ -67,8 +66,7 @@ test("distribuye residuos de compras por modalidad sin cambiar cantidad ni orden
   expect(
     assertReportReconciliation({
       interesNeto: {
-        conFactura: { neto: "0.00" },
-        sinFactura: { neto: "0.00" },
+        noVerificado: { interes: "0.00" },
         cube: { neto: "0.00" },
       },
       pagosExtras: { abonos_capital: "0.00", cancelaciones: "0.00" },
@@ -84,7 +82,7 @@ test("distribuye residuos de compras por modalidad sin cambiar cantidad ni orden
 });
 
 describe("buildNetInterestDetail", () => {
-  test("con factura suma IVA al interés", () => {
+  test("sin evidencia fiscal conserva IVA e ISR registrados sin publicar neto", () => {
     expect(
       buildNetInterestDetail({
         inversionista_id: 1,
@@ -95,15 +93,14 @@ describe("buildNetInterestDetail", () => {
         isr: 0,
       }),
     ).toMatchObject({
-      tratamiento_fiscal: "con_factura",
+      tratamiento_fiscal: "no_verificado",
       interes: "100.00",
       iva: "12.00",
       isr: "0.00",
-      neto: "112.00",
     });
   });
 
-  test("sin factura resta ISR y no incorpora el IVA informativo", () => {
+test("ISR registrado no se convierte en neto fiscal", () => {
     expect(
       buildNetInterestDetail({
         inversionista_id: 2,
@@ -114,28 +111,29 @@ describe("buildNetInterestDetail", () => {
         isr: 7,
       }),
     ).toMatchObject({
-      tratamiento_fiscal: "sin_factura",
+      tratamiento_fiscal: "no_verificado",
       interes: "100.00",
-      iva: "0.00",
+      iva: "12.00",
       isr: "7.00",
-      neto: "93.00",
     });
   });
 });
 
-describe("buildInvestorPosition", () => {
-  test("capital activo incluye otro crédito vigente sin alterar el monto del período", () => {
-    expect(buildInvestorPosition(770_924.47, 900_000, 29_075.53, false)).toEqual({
-      monto_aportado: "770924.47",
-      capital_activo: "900000.00",
-    });
-  });
-
-  test("mayo 2026 normaliza el histórico sin duplicar la reinversión", () => {
-    expect(buildInvestorPosition(800_000, 900_000, 29_075.53, true)).toEqual({
-      monto_aportado: "770924.47",
-      capital_activo: "900000.00",
-    });
+test("interés con ISR positivo que redondea a cero no infiere factura ni IVA", () => {
+  expect(
+    buildNetInterestDetail({
+      inversionista_id: 3,
+      inversionista: "Marta",
+      referencia: "LIQ-3",
+      interes: 0.05,
+      iva: 0.01,
+      isr: 0.0035,
+    }),
+  ).toMatchObject({
+    tratamiento_fiscal: "no_verificado",
+    interes: "0.05",
+    iva: "0.01",
+    isr: "0.00",
   });
 });
 
@@ -143,7 +141,6 @@ test("el reporte conserva y totaliza al inversionista con capital activo y flujo
   const investor = {
     reinversion: "0.00",
     a_recibir: "0.00",
-    monto_aportado: "0.00",
     capital_activo: "1250.00",
   };
   const retained = [investor].filter(shouldIncludeInvestorPosition);
@@ -175,11 +172,50 @@ test("capital activo usa el espejo completo y excluye créditos cerrados", async
   expect(activeCapitalQuery).toContain("GROUP BY ce.inversionista_id");
 });
 
+test("el resumen de compras canoniza NULL y sin_reinversion en la misma modalidad", async () => {
+  const source = await Bun.file(
+    new URL("./reportes.ts", import.meta.url),
+  ).text();
+  const purchasesQuery = source.slice(
+    source.indexOf("const comprasRows"),
+    source.indexOf("let detalleInteresNeto"),
+  );
+
+  expect(purchasesQuery).toContain(
+    "GROUP BY COALESCE(c.tipo_reinversion::text, 'sin_reinversion')",
+  );
+});
+
+test("compras legacy NULL y sin_reinversion se agregan bajo una sola llave pública", () => {
+  expect(canonicalizePurchaseSummaries([
+    { tipo: null, cantidad: 1, monto: "10.00" },
+    { tipo: "sin_reinversion", cantidad: 2, monto: "20.00" },
+  ])).toEqual([{ tipo: "sin_reinversion", cantidad: 3, monto: "30.00" }]);
+});
+
+test("el contrato v2 no publica monto_aportado histórico incorrecto", async () => {
+  const source = await Bun.file(
+    new URL("./reportes.ts", import.meta.url),
+  ).text();
+
+  expect(source).not.toContain("const montoAportadoRows");
+  expect(source).not.toContain("monto_aportado: Number");
+});
+
+test("consulta de interés no deja una coma antes de FROM", async () => {
+  const source = await Bun.file(new URL("./reportes.ts", import.meta.url)).text();
+  const query = source.slice(
+    source.indexOf("const facturaRows"),
+    source.indexOf("let interesNoVerificado"),
+  );
+
+  expect(query).not.toContain("AS total_interes,\n    FROM");
+});
+
 test("respuesta completa concilia los tres detalles y no duplica CUBE", () => {
   const response = {
     interesNeto: {
-      conFactura: { neto: "112.00" },
-      sinFactura: { neto: "93.00" },
+      noVerificado: { interes: "205.00" },
       cube: { neto: "22.40" },
     },
     pagosExtras: { abonos_capital: "30.00", cancelaciones: "70.00" },
@@ -188,9 +224,9 @@ test("respuesta completa concilia los tres detalles y no duplica CUBE", () => {
       { tipo: "reinversion_capital", cantidad: 1, monto: "20.00" },
     ],
     detalleInteresNeto: [
-      { tratamiento_fiscal: "con_factura", neto: "112.00" },
-      { tratamiento_fiscal: "sin_factura", neto: "93.00" },
-      { tratamiento_fiscal: "cube", neto: "22.40" },
+      { tratamiento_fiscal: "no_verificado" as const, interes: "112.00", iva: "0.00", isr: "0.00" },
+      { tratamiento_fiscal: "no_verificado" as const, interes: "93.00", iva: "0.00", isr: "0.00" },
+      { tratamiento_fiscal: "cube" as const, interes: "20.00", iva: "2.40", isr: "0.00", neto: "22.40" },
     ],
     detallePagosExtras: [
       { tipo: "abono_capital", monto: "30.00" },
@@ -213,8 +249,7 @@ test("dos compras del mismo inversionista, fecha y modalidad cuentan como dos op
   expect(
     assertReportReconciliation({
       interesNeto: {
-        conFactura: { neto: "0.00" },
-        sinFactura: { neto: "0.00" },
+        noVerificado: { interes: "0.00" },
         cube: { neto: "0.00" },
       },
       pagosExtras: { abonos_capital: "0.00", cancelaciones: "0.00" },
@@ -247,7 +282,7 @@ test("el resumen de compras cuenta filas de operación con la misma granularidad
   ).text();
   const purchasesQuery = source.slice(
     source.indexOf("const comprasRows"),
-    source.indexOf("const comprasMes = ("),
+    source.indexOf("let detalleInteresNeto"),
   );
 
   expect(purchasesQuery).toContain("COUNT(*)::int AS cantidad");
@@ -270,15 +305,14 @@ test("respuesta completa rechaza CUBE duplicado o cualquier detalle descuadrado"
   expect(() =>
     assertReportReconciliation({
       interesNeto: {
-        conFactura: { neto: "0.00" },
-        sinFactura: { neto: "0.00" },
+        noVerificado: { interes: "0.00" },
         cube: { neto: "22.40" },
       },
       pagosExtras: { abonos_capital: "0.00", cancelaciones: "0.00" },
       comprasMes: [],
       detalleInteresNeto: [
-        { tratamiento_fiscal: "cube", neto: "22.40" },
-        { tratamiento_fiscal: "cube", neto: "22.40" },
+        { tratamiento_fiscal: "cube" as const, interes: "20.00", iva: "2.40", isr: "0.00", neto: "22.40" },
+        { tratamiento_fiscal: "cube" as const, interes: "20.00", iva: "2.40", isr: "0.00", neto: "22.40" },
       ],
       detallePagosExtras: [],
       detalleComprasMes: [],
@@ -289,8 +323,7 @@ test("respuesta completa rechaza CUBE duplicado o cualquier detalle descuadrado"
 test("cada clase de descuadre impide publicar una respuesta completa", () => {
   const valid = {
     interesNeto: {
-      conFactura: { neto: "112.00" },
-      sinFactura: { neto: "93.00" },
+      noVerificado: { interes: "205.00" },
       cube: { neto: "22.40" },
     },
     pagosExtras: { abonos_capital: "30.00", cancelaciones: "70.00" },
@@ -298,9 +331,9 @@ test("cada clase de descuadre impide publicar una respuesta completa", () => {
       { tipo: "sin_reinversion", cantidad: 1, monto: "100.00" },
     ],
     detalleInteresNeto: [
-      { tratamiento_fiscal: "con_factura", neto: "112.00" },
-      { tratamiento_fiscal: "sin_factura", neto: "93.00" },
-      { tratamiento_fiscal: "cube", neto: "22.40" },
+      { tratamiento_fiscal: "no_verificado" as const, interes: "112.00", iva: "0.00", isr: "0.00" },
+      { tratamiento_fiscal: "no_verificado" as const, interes: "93.00", iva: "0.00", isr: "0.00" },
+      { tratamiento_fiscal: "cube" as const, interes: "20.00", iva: "2.40", isr: "0.00", neto: "22.40" },
     ],
     detallePagosExtras: [{ tipo: "abono_capital", monto: "30.00" }, { tipo: "cancelacion", monto: "70.00" }],
     detalleComprasMes: [{ modalidad: "sin_reinversion", monto: "100.00" }],
@@ -310,7 +343,7 @@ test("cada clase de descuadre impide publicar una respuesta completa", () => {
     assertReportReconciliation({
       ...valid,
       detalleInteresNeto: valid.detalleInteresNeto.map((row, index) =>
-        index === 0 ? { ...row, neto: "111.99" } : row,
+        index === 0 ? { ...row, interes: "111.99" } : row,
       ),
     }),
   ).toThrow("Detalle de interés neto no concilia");
@@ -336,8 +369,7 @@ test("cada clase de descuadre impide publicar una respuesta completa", () => {
 test("los subresúmenes no permiten descuadres compensados entre categorías", () => {
   const base = {
     interesNeto: {
-      conFactura: { neto: "112.00" },
-      sinFactura: { neto: "93.00" },
+      noVerificado: { interes: "205.00" },
       cube: { neto: "0.00" },
     },
     pagosExtras: { abonos_capital: "30.00", cancelaciones: "70.00" },
@@ -346,8 +378,7 @@ test("los subresúmenes no permiten descuadres compensados entre categorías", (
       { tipo: "reinversion_capital", cantidad: 1, monto: "20.00" },
     ],
     detalleInteresNeto: [
-      { tratamiento_fiscal: "con_factura", neto: "111.00" },
-      { tratamiento_fiscal: "sin_factura", neto: "94.00" },
+      { tratamiento_fiscal: "no_verificado" as const, interes: "204.00", iva: "0.00", isr: "0.00" },
     ],
     detallePagosExtras: [
       { tipo: "abono_capital", monto: "29.00" },
@@ -366,8 +397,7 @@ test("los subresúmenes no permiten descuadres compensados entre categorías", (
     assertReportReconciliation({
       ...base,
       detalleInteresNeto: [
-        { tratamiento_fiscal: "con_factura", neto: "112.00" },
-        { tratamiento_fiscal: "sin_factura", neto: "93.00" },
+        { tratamiento_fiscal: "no_verificado" as const, interes: "205.00", iva: "0.00", isr: "0.00" },
       ],
     }),
   ).toThrow("Detalle de pagos extras no concilia");
@@ -375,8 +405,7 @@ test("los subresúmenes no permiten descuadres compensados entre categorías", (
     assertReportReconciliation({
       ...base,
       detalleInteresNeto: [
-        { tratamiento_fiscal: "con_factura", neto: "112.00" },
-        { tratamiento_fiscal: "sin_factura", neto: "93.00" },
+        { tratamiento_fiscal: "no_verificado" as const, interes: "205.00", iva: "0.00", isr: "0.00" },
       ],
       detallePagosExtras: [
         { tipo: "abono_capital", monto: "30.00" },
@@ -386,7 +415,7 @@ test("los subresúmenes no permiten descuadres compensados entre categorías", (
   ).toThrow("Detalle de compras del mes no concilia");
 });
 
-test("cada modalidad concilia destinos y composición fiscal real", () => {
+test("cada modalidad concilia destinos sin afirmar composición fiscal", () => {
   expect(
     assertModeReconciliation({
       reinversion_capital: "50.00",
@@ -419,20 +448,12 @@ test("una modalidad admite el redondeo acumulado de sus liquidaciones", () => {
     }),
   ).toBe(true);
 
-  expect(() =>
-    assertModeReconciliation({
-      reinversion_capital: "34.27",
-      reinversion_interes: "0.00",
-      reinversion_total: "34.27",
-      total_capital: "33.36",
-      total_interes: "1.01",
-      iva_facturado: "0.00",
-      total_isr: "0.07",
-      total_cuota: "0.00",
-      total_distribuido: "34.27",
-      cantidad_liquidaciones: 2,
-    }),
-  ).toThrow("Modalidad no concilia");
+  expect(assertModeReconciliation({
+    reinversion_capital: "34.27", reinversion_interes: "0.00",
+    reinversion_total: "34.27", total_capital: "33.36", total_interes: "1.01",
+    iva_facturado: "0.00", total_isr: "0.07", total_cuota: "0.00",
+    total_distribuido: "34.27", cantidad_liquidaciones: 2,
+  })).toBe(true);
 });
 
 test("una modalidad con composición o destinos descuadrados no se publica", () => {

--- a/apps/cartera-back/src/controllers/reinvestmentReport.test.ts
+++ b/apps/cartera-back/src/controllers/reinvestmentReport.test.ts
@@ -1,0 +1,322 @@
+import { describe, expect, test } from "bun:test";
+import {
+  assertModeReconciliation,
+  buildInvestorPosition,
+  buildNetInterestDetail,
+  getPublicReinvestmentDetailError,
+  assertReportReconciliation,
+} from "./reinvestmentReport";
+
+describe("buildNetInterestDetail", () => {
+  test("con factura suma IVA al interés", () => {
+    expect(
+      buildNetInterestDetail({
+        inversionista_id: 1,
+        inversionista: "Ana",
+        referencia: "LIQ-1",
+        interes: 100,
+        iva: 12,
+        isr: 0,
+      }),
+    ).toMatchObject({
+      tratamiento_fiscal: "con_factura",
+      interes: "100.00",
+      iva: "12.00",
+      isr: "0.00",
+      neto: "112.00",
+    });
+  });
+
+  test("sin factura resta ISR y no incorpora el IVA informativo", () => {
+    expect(
+      buildNetInterestDetail({
+        inversionista_id: 2,
+        inversionista: "Luis",
+        referencia: "LIQ-2",
+        interes: 100,
+        iva: 12,
+        isr: 7,
+      }),
+    ).toMatchObject({
+      tratamiento_fiscal: "sin_factura",
+      interes: "100.00",
+      iva: "0.00",
+      isr: "7.00",
+      neto: "93.00",
+    });
+  });
+});
+
+describe("buildInvestorPosition", () => {
+  test("capital activo suma monto posterior y reinversión", () => {
+    expect(buildInvestorPosition(770_924.47, 29_075.53, false)).toEqual({
+      monto_aportado: "770924.47",
+      capital_activo: "800000.00",
+    });
+  });
+
+  test("mayo 2026 normaliza el histórico sin duplicar la reinversión", () => {
+    expect(buildInvestorPosition(800_000, 29_075.53, true)).toEqual({
+      monto_aportado: "770924.47",
+      capital_activo: "800000.00",
+    });
+  });
+});
+
+test("respuesta completa concilia los tres detalles y no duplica CUBE", () => {
+  const response = {
+    interesNeto: {
+      conFactura: { neto: "112.00" },
+      sinFactura: { neto: "93.00" },
+      cube: { neto: "22.40" },
+    },
+    pagosExtras: { abonos_capital: "30.00", cancelaciones: "70.00" },
+    comprasMes: [
+      { tipo: "sin_reinversion", cantidad: 1, monto: "80.00" },
+      { tipo: "reinversion_capital", cantidad: 1, monto: "20.00" },
+    ],
+    detalleInteresNeto: [
+      { tratamiento_fiscal: "con_factura", neto: "112.00" },
+      { tratamiento_fiscal: "sin_factura", neto: "93.00" },
+      { tratamiento_fiscal: "cube", neto: "22.40" },
+    ],
+    detallePagosExtras: [
+      { tipo: "abono_capital", monto: "30.00" },
+      { tipo: "cancelacion", monto: "70.00" },
+    ],
+    detalleComprasMes: [
+      { modalidad: "sin_reinversion", monto: "80.00" },
+      { modalidad: "reinversion_capital", monto: "20.00" },
+    ],
+  };
+
+  expect(assertReportReconciliation(response)).toEqual({
+    interesNeto: true,
+    pagosExtras: true,
+    comprasMes: true,
+  });
+});
+
+test("dos compras del mismo inversionista, fecha y modalidad cuentan como dos operaciones", () => {
+  expect(
+    assertReportReconciliation({
+      interesNeto: {
+        conFactura: { neto: "0.00" },
+        sinFactura: { neto: "0.00" },
+        cube: { neto: "0.00" },
+      },
+      pagosExtras: { abonos_capital: "0.00", cancelaciones: "0.00" },
+      comprasMes: [
+        { tipo: "sin_reinversion", cantidad: 2, monto: "80.00" },
+      ],
+      detalleInteresNeto: [],
+      detallePagosExtras: [],
+      detalleComprasMes: [
+        {
+          fecha: "2026-07-03",
+          inversionista: "Ana",
+          modalidad: "sin_reinversion",
+          monto: "40.00",
+        },
+        {
+          fecha: "2026-07-03",
+          inversionista: "Ana",
+          modalidad: "sin_reinversion",
+          monto: "40.00",
+        },
+      ],
+    }),
+  ).toMatchObject({ comprasMes: true });
+});
+
+test("el resumen de compras cuenta filas de operación con la misma granularidad del detalle", async () => {
+  const source = await Bun.file(
+    new URL("./reportes.ts", import.meta.url),
+  ).text();
+  const purchasesQuery = source.slice(
+    source.indexOf("const comprasRows"),
+    source.indexOf("const comprasMes = ("),
+  );
+
+  expect(purchasesQuery).toContain("COUNT(*)::int AS cantidad");
+  expect(purchasesQuery).not.toContain("COUNT(DISTINCT");
+});
+
+test("resumen y detalle de compras reutilizan exactamente el mismo predicado canónico", async () => {
+  const source = await Bun.file(
+    new URL("./reportes.ts", import.meta.url),
+  ).text();
+  const canonicalPredicateUses = source.match(
+    /WHERE \$\{comprasMesPredicate\}/g,
+  );
+
+  expect(source).toContain("const comprasMesPredicate = sql`");
+  expect(canonicalPredicateUses).toHaveLength(2);
+});
+
+test("respuesta completa rechaza CUBE duplicado o cualquier detalle descuadrado", () => {
+  expect(() =>
+    assertReportReconciliation({
+      interesNeto: {
+        conFactura: { neto: "0.00" },
+        sinFactura: { neto: "0.00" },
+        cube: { neto: "22.40" },
+      },
+      pagosExtras: { abonos_capital: "0.00", cancelaciones: "0.00" },
+      comprasMes: [],
+      detalleInteresNeto: [
+        { tratamiento_fiscal: "cube", neto: "22.40" },
+        { tratamiento_fiscal: "cube", neto: "22.40" },
+      ],
+      detallePagosExtras: [],
+      detalleComprasMes: [],
+    }),
+  ).toThrow("Detalle de interés neto no concilia");
+});
+
+test("cada clase de descuadre impide publicar una respuesta completa", () => {
+  const valid = {
+    interesNeto: {
+      conFactura: { neto: "112.00" },
+      sinFactura: { neto: "93.00" },
+      cube: { neto: "22.40" },
+    },
+    pagosExtras: { abonos_capital: "30.00", cancelaciones: "70.00" },
+    comprasMes: [
+      { tipo: "sin_reinversion", cantidad: 1, monto: "100.00" },
+    ],
+    detalleInteresNeto: [
+      { tratamiento_fiscal: "con_factura", neto: "112.00" },
+      { tratamiento_fiscal: "sin_factura", neto: "93.00" },
+      { tratamiento_fiscal: "cube", neto: "22.40" },
+    ],
+    detallePagosExtras: [{ tipo: "abono_capital", monto: "30.00" }, { tipo: "cancelacion", monto: "70.00" }],
+    detalleComprasMes: [{ modalidad: "sin_reinversion", monto: "100.00" }],
+  };
+
+  expect(() =>
+    assertReportReconciliation({
+      ...valid,
+      detalleInteresNeto: valid.detalleInteresNeto.map((row, index) =>
+        index === 0 ? { ...row, neto: "111.99" } : row,
+      ),
+    }),
+  ).toThrow("Detalle de interés neto no concilia");
+  expect(() =>
+    assertReportReconciliation({
+      ...valid,
+      detallePagosExtras: [
+        { tipo: "abono_capital", monto: "29.99" },
+        { tipo: "cancelacion", monto: "70.00" },
+      ],
+    }),
+  ).toThrow("Detalle de pagos extras no concilia");
+  expect(() =>
+    assertReportReconciliation({
+      ...valid,
+      detalleComprasMes: [
+        { modalidad: "sin_reinversion", monto: "99.99" },
+      ],
+    }),
+  ).toThrow("Detalle de compras del mes no concilia");
+});
+
+test("los subresúmenes no permiten descuadres compensados entre categorías", () => {
+  const base = {
+    interesNeto: {
+      conFactura: { neto: "112.00" },
+      sinFactura: { neto: "93.00" },
+      cube: { neto: "0.00" },
+    },
+    pagosExtras: { abonos_capital: "30.00", cancelaciones: "70.00" },
+    comprasMes: [
+      { tipo: "sin_reinversion", cantidad: 1, monto: "80.00" },
+      { tipo: "reinversion_capital", cantidad: 1, monto: "20.00" },
+    ],
+    detalleInteresNeto: [
+      { tratamiento_fiscal: "con_factura", neto: "111.00" },
+      { tratamiento_fiscal: "sin_factura", neto: "94.00" },
+    ],
+    detallePagosExtras: [
+      { tipo: "abono_capital", monto: "29.00" },
+      { tipo: "cancelacion", monto: "71.00" },
+    ],
+    detalleComprasMes: [
+      { modalidad: "sin_reinversion", monto: "79.00" },
+      { modalidad: "reinversion_capital", monto: "21.00" },
+    ],
+  };
+
+  expect(() => assertReportReconciliation(base)).toThrow(
+    "Detalle de interés neto no concilia",
+  );
+  expect(() =>
+    assertReportReconciliation({
+      ...base,
+      detalleInteresNeto: [
+        { tratamiento_fiscal: "con_factura", neto: "112.00" },
+        { tratamiento_fiscal: "sin_factura", neto: "93.00" },
+      ],
+    }),
+  ).toThrow("Detalle de pagos extras no concilia");
+  expect(() =>
+    assertReportReconciliation({
+      ...base,
+      detalleInteresNeto: [
+        { tratamiento_fiscal: "con_factura", neto: "112.00" },
+        { tratamiento_fiscal: "sin_factura", neto: "93.00" },
+      ],
+      detallePagosExtras: [
+        { tipo: "abono_capital", monto: "30.00" },
+        { tipo: "cancelacion", monto: "70.00" },
+      ],
+    }),
+  ).toThrow("Detalle de compras del mes no concilia");
+});
+
+test("cada modalidad concilia destinos y composición fiscal real", () => {
+  expect(
+    assertModeReconciliation({
+      reinversion_capital: "50.00",
+      reinversion_interes: "0.00",
+      reinversion_total: "50.00",
+      total_capital: "50.00",
+      total_interes: "5.00",
+      iva_facturado: "0.00",
+      total_isr: "0.35",
+      total_cuota: "4.65",
+      total_distribuido: "54.65",
+    }),
+  ).toBe(true);
+});
+
+test("una modalidad con composición o destinos descuadrados no se publica", () => {
+  const base = {
+    reinversion_capital: "50.00",
+    reinversion_interes: "0.00",
+    reinversion_total: "50.00",
+    total_capital: "50.00",
+    total_interes: "5.00",
+    iva_facturado: "0.00",
+    total_isr: "0.35",
+    total_cuota: "4.65",
+    total_distribuido: "54.65",
+  };
+  expect(() =>
+    assertModeReconciliation({ ...base, total_distribuido: "54.64" }),
+  ).toThrow("Modalidad no concilia");
+  expect(() =>
+    assertModeReconciliation({ ...base, total_cuota: "4.64" }),
+  ).toThrow("Modalidad no concilia");
+});
+
+test("el contrato parcial no devuelve mensajes técnicos del error", () => {
+  const secret =
+    'relation "cartera.liquidaciones" does not exist at 10.0.0.8:5432';
+  const message = getPublicReinvestmentDetailError(new Error(secret));
+  expect(message).toBe(
+    "Los detalles no están disponibles para este período. Intenta nuevamente más tarde.",
+  );
+  expect(message).not.toContain("cartera.liquidaciones");
+  expect(message).not.toContain("10.0.0.8");
+});

--- a/apps/cartera-back/src/controllers/reinvestmentReport.test.ts
+++ b/apps/cartera-back/src/controllers/reinvestmentReport.test.ts
@@ -4,11 +4,20 @@ import {
   allocateRoundedPurchaseAmounts,
   assertModeReconciliation,
   assertReportReconciliation,
+  buildCubeNetInterest,
   buildInvestorPosition,
   buildNetInterestDetail,
   getPublicReinvestmentDetailError,
   shouldIncludeInvestorPosition,
 } from "./reinvestmentReport";
+
+test("CUBE deriva el neto de los componentes redondeados", () => {
+  expect(buildCubeNetInterest(1.00447)).toEqual({
+    interes: "1.00",
+    iva: "0.12",
+    neto: "1.12",
+  });
+});
 
 test("distribuye el centavo residual sin cambiar el orden de los pagos", () => {
   const amounts = allocateRoundedAmounts([

--- a/apps/cartera-back/src/controllers/reinvestmentReport.test.ts
+++ b/apps/cartera-back/src/controllers/reinvestmentReport.test.ts
@@ -1,11 +1,12 @@
 import { describe, expect, test } from "bun:test";
 import {
   allocateRoundedAmounts,
+  allocateRoundedPurchaseAmounts,
   assertModeReconciliation,
+  assertReportReconciliation,
   buildInvestorPosition,
   buildNetInterestDetail,
   getPublicReinvestmentDetailError,
-  assertReportReconciliation,
 } from "./reinvestmentReport";
 
 test("distribuye el centavo residual sin cambiar el orden de los pagos", () => {
@@ -33,6 +34,43 @@ test("distribuye el centavo residual sin cambiar el orden de los pagos", () => {
       detalleComprasMes: [],
     }),
   ).toMatchObject({ pagosExtras: true });
+});
+
+test("distribuye residuos de compras por modalidad sin cambiar cantidad ni orden", () => {
+  const purchases = allocateRoundedPurchaseAmounts([
+    { modalidad: "sin_reinversion", referencia: "A", monto: "33.333333" },
+    { modalidad: "reinversion_capital", referencia: "B", monto: "10.005" },
+    { modalidad: "sin_reinversion", referencia: "C", monto: "33.333333" },
+    { modalidad: "reinversion_capital", referencia: "D", monto: "10.005" },
+    { modalidad: "sin_reinversion", referencia: "E", monto: "33.333333" },
+  ]);
+
+  expect(purchases.map((row) => row.referencia)).toEqual(["A", "B", "C", "D", "E"]);
+  expect(purchases.map((row) => row.monto)).toEqual([
+    "33.34",
+    "10.00",
+    "33.33",
+    "10.01",
+    "33.33",
+  ]);
+  expect(purchases).toHaveLength(5);
+  expect(
+    assertReportReconciliation({
+      interesNeto: {
+        conFactura: { neto: "0.00" },
+        sinFactura: { neto: "0.00" },
+        cube: { neto: "0.00" },
+      },
+      pagosExtras: { abonos_capital: "0.00", cancelaciones: "0.00" },
+      comprasMes: [
+        { tipo: "sin_reinversion", cantidad: 3, monto: "100.00" },
+        { tipo: "reinversion_capital", cantidad: 2, monto: "20.01" },
+      ],
+      detalleInteresNeto: [],
+      detallePagosExtras: [],
+      detalleComprasMes: purchases,
+    }),
+  ).toMatchObject({ comprasMes: true });
 });
 
 describe("buildNetInterestDetail", () => {
@@ -314,26 +352,13 @@ test("cada modalidad concilia destinos y composición fiscal real", () => {
       total_isr: "0.35",
       total_cuota: "4.65",
       total_distribuido: "54.65",
+      cantidad_liquidaciones: 1,
     }),
   ).toBe(true);
 });
 
-test("una modalidad admite solo un centavo por redondeo independiente de componentes", () => {
+test("una modalidad admite el redondeo acumulado de sus liquidaciones", () => {
   expect(
-    assertModeReconciliation({
-      reinversion_capital: "34.27",
-      reinversion_interes: "0.00",
-      reinversion_total: "34.27",
-      total_capital: "33.34",
-      total_interes: "1.01",
-      iva_facturado: "0.00",
-      total_isr: "0.07",
-      total_cuota: "0.00",
-      total_distribuido: "34.27",
-    }),
-  ).toBe(true);
-
-  expect(() =>
     assertModeReconciliation({
       reinversion_capital: "34.27",
       reinversion_interes: "0.00",
@@ -344,6 +369,22 @@ test("una modalidad admite solo un centavo por redondeo independiente de compone
       total_isr: "0.07",
       total_cuota: "0.00",
       total_distribuido: "34.27",
+      cantidad_liquidaciones: 2,
+    }),
+  ).toBe(true);
+
+  expect(() =>
+    assertModeReconciliation({
+      reinversion_capital: "34.27",
+      reinversion_interes: "0.00",
+      reinversion_total: "34.27",
+      total_capital: "33.36",
+      total_interes: "1.01",
+      iva_facturado: "0.00",
+      total_isr: "0.07",
+      total_cuota: "0.00",
+      total_distribuido: "34.27",
+      cantidad_liquidaciones: 2,
     }),
   ).toThrow("Modalidad no concilia");
 });
@@ -359,6 +400,7 @@ test("una modalidad con composición o destinos descuadrados no se publica", () 
     total_isr: "0.35",
     total_cuota: "4.65",
     total_distribuido: "54.65",
+    cantidad_liquidaciones: 1,
   };
   expect(() =>
     assertModeReconciliation({ ...base, total_distribuido: "54.64" }),

--- a/apps/cartera-back/src/controllers/reinvestmentReport.test.ts
+++ b/apps/cartera-back/src/controllers/reinvestmentReport.test.ts
@@ -114,19 +114,37 @@ describe("buildNetInterestDetail", () => {
 });
 
 describe("buildInvestorPosition", () => {
-  test("capital activo suma monto posterior y reinversión", () => {
-    expect(buildInvestorPosition(770_924.47, 29_075.53, false)).toEqual({
+  test("capital activo incluye otro crédito vigente sin alterar el monto del período", () => {
+    expect(buildInvestorPosition(770_924.47, 900_000, 29_075.53, false)).toEqual({
       monto_aportado: "770924.47",
-      capital_activo: "800000.00",
+      capital_activo: "900000.00",
     });
   });
 
   test("mayo 2026 normaliza el histórico sin duplicar la reinversión", () => {
-    expect(buildInvestorPosition(800_000, 29_075.53, true)).toEqual({
+    expect(buildInvestorPosition(800_000, 900_000, 29_075.53, true)).toEqual({
       monto_aportado: "770924.47",
-      capital_activo: "800000.00",
+      capital_activo: "900000.00",
     });
   });
+});
+
+test("capital activo usa el espejo completo y excluye créditos cerrados", async () => {
+  const source = await Bun.file(
+    new URL("./reportes.ts", import.meta.url),
+  ).text();
+  const activeCapitalQuery = source.slice(
+    source.indexOf("const capitalActivoRows"),
+    source.indexOf("const montoAportadoRows"),
+  );
+
+  expect(activeCapitalQuery).toContain(
+    "FROM cartera.creditos_inversionistas_espejo ce",
+  );
+  expect(activeCapitalQuery).toContain(
+    "cr.\"statusCredit\" IN ('ACTIVO', 'MOROSO', 'EN_CONVENIO')",
+  );
+  expect(activeCapitalQuery).toContain("GROUP BY ce.inversionista_id");
 });
 
 test("respuesta completa concilia los tres detalles y no duplica CUBE", () => {

--- a/apps/cartera-back/src/controllers/reinvestmentReport.ts
+++ b/apps/cartera-back/src/controllers/reinvestmentReport.ts
@@ -105,6 +105,13 @@ export function shouldIncludeInvestorPosition(position: InvestorPosition) {
   );
 }
 
+export function calculateActiveCapital(
+  mirrorAmount: number | string,
+  pendingPurchaseAmount: number | string,
+) {
+  return Number(mirrorAmount) - Number(pendingPurchaseAmount);
+}
+
 type NoVerificadoInterestDetail = {
   tratamiento_fiscal: "no_verificado";
   interes: string;

--- a/apps/cartera-back/src/controllers/reinvestmentReport.ts
+++ b/apps/cartera-back/src/controllers/reinvestmentReport.ts
@@ -10,6 +10,16 @@ type NetInterestInput = {
 const cents = (value: number | string) => Math.round(Number(value) * 100);
 const money = (valueInCents: number) => (valueInCents / 100).toFixed(2);
 
+export function buildCubeNetInterest(value: number) {
+  const interest = cents(value);
+  const tax = cents(value * 0.12);
+  return {
+    interes: money(interest),
+    iva: money(tax),
+    neto: money(interest + tax),
+  };
+}
+
 export function allocateRoundedAmounts(values: (number | string)[]) {
   const rawCents = values.map((value) => Number(value) * 100);
   const allocated = rawCents.map(Math.round);

--- a/apps/cartera-back/src/controllers/reinvestmentReport.ts
+++ b/apps/cartera-back/src/controllers/reinvestmentReport.ts
@@ -1,0 +1,194 @@
+type NetInterestInput = {
+  inversionista_id: number;
+  inversionista: string;
+  referencia: string;
+  interes: number;
+  iva: number;
+  isr: number;
+};
+
+const cents = (value: number | string) => Math.round(Number(value) * 100);
+const money = (valueInCents: number) => (valueInCents / 100).toFixed(2);
+
+export const PUBLIC_REINVESTMENT_DETAIL_ERROR =
+  "Los detalles no están disponibles para este período. Intenta nuevamente más tarde.";
+
+export function getPublicReinvestmentDetailError(_error: unknown) {
+  return PUBLIC_REINVESTMENT_DETAIL_ERROR;
+}
+
+export function buildNetInterestDetail(input: NetInterestInput) {
+  const sinFactura = cents(input.isr) > 0;
+  const interest = cents(input.interes);
+  const tax = sinFactura ? cents(input.isr) : cents(input.iva);
+  return {
+    inversionista_id: input.inversionista_id,
+    inversionista: input.inversionista,
+    referencia: input.referencia,
+    tratamiento_fiscal: sinFactura ? "sin_factura" : "con_factura",
+    interes: money(interest),
+    iva: money(sinFactura ? 0 : tax),
+    isr: money(sinFactura ? tax : 0),
+    neto: money(sinFactura ? interest - tax : interest + tax),
+  };
+}
+
+export function buildInvestorPosition(
+  historicalAmount: number,
+  reinvestment: number,
+  isMay2026: boolean,
+) {
+  const historical = cents(historicalAmount);
+  const reinvested = cents(reinvestment);
+  const contributed = isMay2026 ? historical - reinvested : historical;
+  return {
+    monto_aportado: money(contributed),
+    capital_activo: money(contributed + reinvested),
+  };
+}
+
+type ReconciliationResponse = {
+  interesNeto: {
+    conFactura: { neto: string };
+    sinFactura: { neto: string };
+    cube: { neto: string };
+  };
+  pagosExtras: { abonos_capital: string; cancelaciones: string };
+  comprasMes: { tipo: string; cantidad: number; monto: string }[];
+  detalleInteresNeto: {
+    tratamiento_fiscal: string;
+    neto: string;
+  }[];
+  detallePagosExtras: { tipo: string; monto: string }[];
+  detalleComprasMes: { modalidad: string; monto: string }[];
+};
+
+const sumCents = (values: (number | string)[]) =>
+  values.reduce((total, value) => total + cents(value), 0);
+
+export function assertReportReconciliation(response: ReconciliationResponse) {
+  const cubeRows = response.detalleInteresNeto.filter(
+    (row) => row.tratamiento_fiscal === "cube",
+  );
+  const interestSummary = sumCents([
+    response.interesNeto.conFactura.neto,
+    response.interesNeto.sinFactura.neto,
+    response.interesNeto.cube.neto,
+  ]);
+  const interestDetail = sumCents(
+    response.detalleInteresNeto.map((row) => row.neto),
+  );
+  const interestCategories = [
+    ["con_factura", response.interesNeto.conFactura.neto],
+    ["sin_factura", response.interesNeto.sinFactura.neto],
+    ["cube", response.interesNeto.cube.neto],
+  ] as const;
+  const interestByCategory = interestCategories.every(
+    ([category, summary]) =>
+      sumCents(
+        response.detalleInteresNeto
+          .filter((row) => row.tratamiento_fiscal === category)
+          .map((row) => row.neto),
+      ) === cents(summary),
+  );
+  const hasUnknownInterestCategory = response.detalleInteresNeto.some(
+    (row) =>
+      !interestCategories.some(
+        ([category]) => category === row.tratamiento_fiscal,
+      ),
+  );
+  if (
+    interestDetail !== interestSummary ||
+    !interestByCategory ||
+    hasUnknownInterestCategory ||
+    cubeRows.length > 1
+  ) {
+    throw new Error("Detalle de interés neto no concilia");
+  }
+
+  const extrasSummary = sumCents([
+    response.pagosExtras.abonos_capital,
+    response.pagosExtras.cancelaciones,
+  ]);
+  const extrasByCategory =
+    sumCents(
+      response.detallePagosExtras
+        .filter((row) => row.tipo === "abono_capital")
+        .map((row) => row.monto),
+    ) === cents(response.pagosExtras.abonos_capital) &&
+    sumCents(
+      response.detallePagosExtras
+        .filter((row) => row.tipo === "cancelacion")
+        .map((row) => row.monto),
+    ) === cents(response.pagosExtras.cancelaciones);
+  const hasUnknownExtraCategory = response.detallePagosExtras.some(
+    (row) => row.tipo !== "abono_capital" && row.tipo !== "cancelacion",
+  );
+  if (
+    sumCents(response.detallePagosExtras.map((row) => row.monto)) !==
+      extrasSummary ||
+    !extrasByCategory ||
+    hasUnknownExtraCategory
+  ) {
+    throw new Error("Detalle de pagos extras no concilia");
+  }
+
+  const purchasesByMode = response.comprasMes.every(
+    (summary) =>
+      response.detalleComprasMes.filter(
+        (row) => row.modalidad === summary.tipo,
+      ).length === summary.cantidad &&
+      sumCents(
+        response.detalleComprasMes
+          .filter((row) => row.modalidad === summary.tipo)
+          .map((row) => row.monto),
+      ) === cents(summary.monto),
+  );
+  const hasUnknownPurchaseMode = response.detalleComprasMes.some(
+    (row) => !response.comprasMes.some((summary) => summary.tipo === row.modalidad),
+  );
+  if (
+    sumCents(response.detalleComprasMes.map((row) => row.monto)) !==
+      sumCents(response.comprasMes.map((row) => row.monto)) ||
+    !purchasesByMode ||
+    hasUnknownPurchaseMode
+  ) {
+    throw new Error("Detalle de compras del mes no concilia");
+  }
+
+  return {
+    interesNeto: true,
+    pagosExtras: true,
+    comprasMes: true,
+  };
+}
+
+type ModeReconciliation = {
+  reinversion_capital: string;
+  reinversion_interes: string;
+  reinversion_total: string;
+  total_capital: string;
+  total_interes: string;
+  iva_facturado: string;
+  total_isr: string;
+  total_cuota: string;
+  total_distribuido: string;
+};
+
+export function assertModeReconciliation(mode: ModeReconciliation) {
+  const distributed = cents(mode.total_distribuido);
+  const destinations = sumCents([
+    mode.total_cuota,
+    mode.reinversion_total,
+  ]);
+  const composition =
+    sumCents([
+      mode.total_capital,
+      mode.total_interes,
+      mode.iva_facturado,
+    ]) - cents(mode.total_isr);
+  if (distributed !== destinations || distributed !== composition) {
+    throw new Error("Modalidad no concilia");
+  }
+  return true;
+}

--- a/apps/cartera-back/src/controllers/reinvestmentReport.ts
+++ b/apps/cartera-back/src/controllers/reinvestmentReport.ts
@@ -10,6 +10,23 @@ type NetInterestInput = {
 const cents = (value: number | string) => Math.round(Number(value) * 100);
 const money = (valueInCents: number) => (valueInCents / 100).toFixed(2);
 
+export function allocateRoundedAmounts(values: (number | string)[]) {
+  const rawCents = values.map((value) => Number(value) * 100);
+  const allocated = rawCents.map(Math.round);
+  const remainder = cents(values.reduce((total, value) => total + Number(value), 0)) -
+    allocated.reduce((total, value) => total + value, 0);
+  const direction = Math.sign(remainder);
+  const order = rawCents
+    .map((value, index) => ({ index, remainder: value - allocated[index] }))
+    .sort((a, b) => direction * (b.remainder - a.remainder));
+
+  for (let index = 0; index < Math.abs(remainder); index++) {
+    allocated[order[index].index] += direction;
+  }
+
+  return allocated.map(money);
+}
+
 export const PUBLIC_REINVESTMENT_DETAIL_ERROR =
   "Los detalles no están disponibles para este período. Intenta nuevamente más tarde.";
 
@@ -187,7 +204,12 @@ export function assertModeReconciliation(mode: ModeReconciliation) {
       mode.total_interes,
       mode.iva_facturado,
     ]) - cents(mode.total_isr);
-  if (distributed !== destinations || distributed !== composition) {
+  // Stored components are rounded independently, so their composition can
+  // differ by one cent even while the stored destinations reconcile exactly.
+  if (
+    distributed !== destinations ||
+    Math.abs(distributed - composition) > 1
+  ) {
     throw new Error("Modalidad no concilia");
   }
   return true;

--- a/apps/cartera-back/src/controllers/reinvestmentReport.ts
+++ b/apps/cartera-back/src/controllers/reinvestmentReport.ts
@@ -27,6 +27,20 @@ export function allocateRoundedAmounts(values: (number | string)[]) {
   return allocated.map(money);
 }
 
+export function allocateRoundedPurchaseAmounts<
+  T extends { modalidad: string; monto: number | string },
+>(rows: T[]) {
+  const allocated = rows.map((row) => ({ ...row, monto: String(row.monto) }));
+  for (const modalidad of new Set(rows.map((row) => row.modalidad))) {
+    const modeRows = allocated.filter((row) => row.modalidad === modalidad);
+    const amounts = allocateRoundedAmounts(modeRows.map((row) => row.monto));
+    modeRows.forEach((row, index) => {
+      row.monto = amounts[index];
+    });
+  }
+  return allocated;
+}
+
 export const PUBLIC_REINVESTMENT_DETAIL_ERROR =
   "Los detalles no están disponibles para este período. Intenta nuevamente más tarde.";
 
@@ -190,6 +204,7 @@ type ModeReconciliation = {
   total_isr: string;
   total_cuota: string;
   total_distribuido: string;
+  cantidad_liquidaciones: number;
 };
 
 export function assertModeReconciliation(mode: ModeReconciliation) {
@@ -204,11 +219,11 @@ export function assertModeReconciliation(mode: ModeReconciliation) {
       mode.total_interes,
       mode.iva_facturado,
     ]) - cents(mode.total_isr);
-  // Stored components are rounded independently, so their composition can
-  // differ by one cent even while the stored destinations reconcile exactly.
+  // Each liquidation can contribute at most one cent of independent component
+  // rounding while the stored destinations still reconcile exactly.
   if (
     distributed !== destinations ||
-    Math.abs(distributed - composition) > 1
+    Math.abs(distributed - composition) > mode.cantidad_liquidaciones
   ) {
     throw new Error("Modalidad no concilia");
   }

--- a/apps/cartera-back/src/controllers/reinvestmentReport.ts
+++ b/apps/cartera-back/src/controllers/reinvestmentReport.ts
@@ -51,6 +51,24 @@ export function allocateRoundedPurchaseAmounts<
   return allocated;
 }
 
+export function canonicalizePurchaseSummaries(
+  rows: { tipo: string | null; cantidad: number; monto: string }[],
+) {
+  const summaries = new Map<string, { cantidad: number; monto: number }>();
+  for (const row of rows) {
+    const tipo = row.tipo ?? "sin_reinversion";
+    const current = summaries.get(tipo) ?? { cantidad: 0, monto: 0 };
+    current.cantidad += row.cantidad;
+    current.monto += Number(row.monto);
+    summaries.set(tipo, current);
+  }
+  return [...summaries.entries()].map(([tipo, summary]) => ({
+    tipo,
+    cantidad: summary.cantidad,
+    monto: summary.monto.toFixed(2),
+  }));
+}
+
 export const PUBLIC_REINVESTMENT_DETAIL_ERROR =
   "Los detalles no están disponibles para este período. Intenta nuevamente más tarde.";
 
@@ -59,39 +77,23 @@ export function getPublicReinvestmentDetailError(_error: unknown) {
 }
 
 export function buildNetInterestDetail(input: NetInterestInput) {
-  const sinFactura = cents(input.isr) > 0;
   const interest = cents(input.interes);
-  const tax = sinFactura ? cents(input.isr) : cents(input.iva);
   return {
     inversionista_id: input.inversionista_id,
     inversionista: input.inversionista,
     referencia: input.referencia,
-    tratamiento_fiscal: sinFactura ? "sin_factura" : "con_factura",
+    // No existe una marca fiscal inmutable en la liquidación. ISR e IVA por sí
+    // solos no prueban que se emitió factura, por lo que no se asignan fiscalmente.
+    tratamiento_fiscal: "no_verificado",
     interes: money(interest),
-    iva: money(sinFactura ? 0 : tax),
-    isr: money(sinFactura ? tax : 0),
-    neto: money(sinFactura ? interest - tax : interest + tax),
-  };
-}
-
-export function buildInvestorPosition(
-  historicalAmount: number,
-  currentActiveCapital: number,
-  reinvestment: number,
-  isMay2026: boolean,
-) {
-  const historical = cents(historicalAmount);
-  const contributed = isMay2026 ? historical - cents(reinvestment) : historical;
-  return {
-    monto_aportado: money(contributed),
-    capital_activo: money(cents(currentActiveCapital)),
+    iva: money(cents(input.iva)),
+    isr: money(cents(input.isr)),
   };
 }
 
 type InvestorPosition = {
   reinversion: string;
   a_recibir: string;
-  monto_aportado: string;
   capital_activo: string;
 };
 
@@ -99,23 +101,32 @@ export function shouldIncludeInvestorPosition(position: InvestorPosition) {
   return (
     Number(position.reinversion) !== 0 ||
     Number(position.a_recibir) !== 0 ||
-    Number(position.monto_aportado) !== 0 ||
     Number(position.capital_activo) !== 0
   );
 }
 
+type NoVerificadoInterestDetail = {
+  tratamiento_fiscal: "no_verificado";
+  interes: string;
+  iva: string;
+  isr: string;
+  neto?: never;
+};
+type CubeInterestDetail = {
+  tratamiento_fiscal: "cube";
+  interes: string;
+  iva: string;
+  isr: string;
+  neto: string;
+};
 type ReconciliationResponse = {
   interesNeto: {
-    conFactura: { neto: string };
-    sinFactura: { neto: string };
+    noVerificado: { interes: string };
     cube: { neto: string };
   };
   pagosExtras: { abonos_capital: string; cancelaciones: string };
   comprasMes: { tipo: string; cantidad: number; monto: string }[];
-  detalleInteresNeto: {
-    tratamiento_fiscal: string;
-    neto: string;
-  }[];
+  detalleInteresNeto: (NoVerificadoInterestDetail | CubeInterestDetail)[];
   detallePagosExtras: { tipo: string; monto: string }[];
   detalleComprasMes: { modalidad: string; monto: string }[];
 };
@@ -125,39 +136,20 @@ const sumCents = (values: (number | string)[]) =>
 
 export function assertReportReconciliation(response: ReconciliationResponse) {
   const cubeRows = response.detalleInteresNeto.filter(
-    (row) => row.tratamiento_fiscal === "cube",
+    (row): row is CubeInterestDetail => row.tratamiento_fiscal === "cube",
   );
-  const interestSummary = sumCents([
-    response.interesNeto.conFactura.neto,
-    response.interesNeto.sinFactura.neto,
-    response.interesNeto.cube.neto,
-  ]);
-  const interestDetail = sumCents(
-    response.detalleInteresNeto.map((row) => row.neto),
+  const noVerificadoRows = response.detalleInteresNeto.filter(
+    (row): row is NoVerificadoInterestDetail =>
+      row.tratamiento_fiscal === "no_verificado",
   );
-  const interestCategories = [
-    ["con_factura", response.interesNeto.conFactura.neto],
-    ["sin_factura", response.interesNeto.sinFactura.neto],
-    ["cube", response.interesNeto.cube.neto],
-  ] as const;
-  const interestByCategory = interestCategories.every(
-    ([category, summary]) =>
-      sumCents(
-        response.detalleInteresNeto
-          .filter((row) => row.tratamiento_fiscal === category)
-          .map((row) => row.neto),
-      ) === cents(summary),
-  );
-  const hasUnknownInterestCategory = response.detalleInteresNeto.some(
-    (row) =>
-      !interestCategories.some(
-        ([category]) => category === row.tratamiento_fiscal,
-      ),
-  );
+  const noVerificadoMatches =
+    sumCents(noVerificadoRows.map((row) => row.interes)) ===
+      cents(response.interesNeto.noVerificado.interes);
+  const cubeMatches = sumCents(cubeRows.map((row) => row.neto)) ===
+    cents(response.interesNeto.cube.neto);
   if (
-    interestDetail !== interestSummary ||
-    !interestByCategory ||
-    hasUnknownInterestCategory ||
+    !noVerificadoMatches ||
+    !cubeMatches ||
     cubeRows.length > 1
   ) {
     throw new Error("Detalle de interés neto no concilia");
@@ -239,18 +231,7 @@ export function assertModeReconciliation(mode: ModeReconciliation) {
     mode.total_cuota,
     mode.reinversion_total,
   ]);
-  const composition =
-    sumCents([
-      mode.total_capital,
-      mode.total_interes,
-      mode.iva_facturado,
-    ]) - cents(mode.total_isr);
-  // Each liquidation can contribute at most one cent of independent component
-  // rounding while the stored destinations still reconcile exactly.
-  if (
-    distributed !== destinations ||
-    Math.abs(distributed - composition) > mode.cantidad_liquidaciones
-  ) {
+  if (distributed !== destinations) {
     throw new Error("Modalidad no concilia");
   }
   return true;

--- a/apps/cartera-back/src/controllers/reinvestmentReport.ts
+++ b/apps/cartera-back/src/controllers/reinvestmentReport.ts
@@ -66,15 +66,15 @@ export function buildNetInterestDetail(input: NetInterestInput) {
 
 export function buildInvestorPosition(
   historicalAmount: number,
+  currentActiveCapital: number,
   reinvestment: number,
   isMay2026: boolean,
 ) {
   const historical = cents(historicalAmount);
-  const reinvested = cents(reinvestment);
-  const contributed = isMay2026 ? historical - reinvested : historical;
+  const contributed = isMay2026 ? historical - cents(reinvestment) : historical;
   return {
     monto_aportado: money(contributed),
-    capital_activo: money(contributed + reinvested),
+    capital_activo: money(cents(currentActiveCapital)),
   };
 }
 

--- a/apps/cartera-back/src/controllers/reinvestmentReport.ts
+++ b/apps/cartera-back/src/controllers/reinvestmentReport.ts
@@ -78,6 +78,22 @@ export function buildInvestorPosition(
   };
 }
 
+type InvestorPosition = {
+  reinversion: string;
+  a_recibir: string;
+  monto_aportado: string;
+  capital_activo: string;
+};
+
+export function shouldIncludeInvestorPosition(position: InvestorPosition) {
+  return (
+    Number(position.reinversion) !== 0 ||
+    Number(position.a_recibir) !== 0 ||
+    Number(position.monto_aportado) !== 0 ||
+    Number(position.capital_activo) !== 0
+  );
+}
+
 type ReconciliationResponse = {
   interesNeto: {
     conFactura: { neto: string };

--- a/apps/cartera-back/src/controllers/reportes.participacion.test.ts
+++ b/apps/cartera-back/src/controllers/reportes.participacion.test.ts
@@ -1,0 +1,11 @@
+import { expect, test } from "bun:test";
+
+test("la CTE de participación usa el porcentaje autoritativo de créditos_inversionistas", async () => {
+	const source = await Bun.file(new URL("./reportes.ts", import.meta.url)).text();
+
+	expect(source).toContain(
+		"ci.porcentaje_participacion_inversionista::numeric / 100",
+	);
+	expect(source).not.toContain("ci.porcentaje::numeric / 100");
+	expect(source).toContain("FILTER (WHERE i.permite_distribucion = false)");
+});

--- a/apps/cartera-back/src/controllers/reportes.ts
+++ b/apps/cartera-back/src/controllers/reportes.ts
@@ -1001,6 +1001,31 @@ export async function getReinversionLiquidaciones({
     ORDER BY i.nombre
   `);
 
+  // Capital operativo actual desde el espejo canónico. La reinversión ya está
+  // reflejada aquí, por lo que no se suma nuevamente desde la liquidación.
+  const capitalActivoRows = await db.execute(sql`
+    SELECT
+      ce.inversionista_id,
+      COALESCE(SUM(ce.monto_aportado::numeric), 0) AS capital_activo
+    FROM cartera.creditos_inversionistas_espejo ce
+    JOIN cartera.creditos cr ON cr.credito_id = ce.credito_id
+    WHERE ce.inversionista_id IN (
+      SELECT DISTINCT l.inversionista_id
+      FROM cartera.liquidaciones l
+      WHERE (l.fecha_liquidacion AT TIME ZONE 'America/Guatemala')::date >= ${inicioMes}::date
+        AND (l.fecha_liquidacion AT TIME ZONE 'America/Guatemala')::date < ${inicioMesSiguiente}::date
+    )
+      AND cr."statusCredit" IN ('ACTIVO', 'MOROSO', 'EN_CONVENIO')
+    GROUP BY ce.inversionista_id
+  `);
+  const capitalActivoPorInv = new Map<number, number>();
+  for (const r of capitalActivoRows.rows as Record<string, unknown>[]) {
+    capitalActivoPorInv.set(
+      Number(r.inversionista_id),
+      Number(r.capital_activo ?? 0)
+    );
+  }
+
   // Monto aportado que le quedó al inversionista DESPUÉS de la liquidación
   // (sin reinversiones), desde historico_liquidaciones_espejo.
   // ⚠️ Mayo 2026 fue la primera vez que se usó y el histórico quedó CON la
@@ -1031,6 +1056,7 @@ export async function getReinversionLiquidaciones({
       const montoHist = montoAportadoPorInv.get(id) ?? 0;
       const position = buildInvestorPosition(
         montoHist,
+        capitalActivoPorInv.get(id) ?? 0,
         reinversion,
         esMayo2026
       );

--- a/apps/cartera-back/src/controllers/reportes.ts
+++ b/apps/cartera-back/src/controllers/reportes.ts
@@ -10,6 +10,7 @@ import { snapCte } from "./moraSnapshotSql";
 import {
 	assertModeReconciliation,
 	assertReportReconciliation,
+	allocateRoundedAmounts,
 	buildInvestorPosition,
 	buildNetInterestDetail,
 	getPublicReinvestmentDetailError,
@@ -1155,7 +1156,7 @@ export async function getReinversionLiquidaciones({
       fecha: String(r.fecha),
       credito: String(r.credito),
       tipo: String(r.tipo) as "abono_capital" | "cancelacion",
-      monto: Number(r.monto ?? 0).toFixed(2),
+      monto: String(r.monto ?? 0),
     }));
     const manualDetalleRows = await db.execute(sql`
     SELECT
@@ -1184,9 +1185,16 @@ export async function getReinversionLiquidaciones({
         fecha: String(r.fecha),
         credito: String(r.credito),
         tipo: "cancelacion" as const,
-        monto: Number(r.monto ?? 0).toFixed(2),
+        monto: String(r.monto ?? 0),
       }))
     );
+    for (const tipo of ["abono_capital", "cancelacion"] as const) {
+      const rows = detallePagosExtras.filter((row) => row.tipo === tipo);
+      const amounts = allocateRoundedAmounts(rows.map((row) => row.monto));
+      rows.forEach((row, index) => {
+        row.monto = amounts[index];
+      });
+    }
 
     const comprasDetalleRows = await db.execute(sql`
     SELECT

--- a/apps/cartera-back/src/controllers/reportes.ts
+++ b/apps/cartera-back/src/controllers/reportes.ts
@@ -8,13 +8,13 @@ import {
 } from "./moraRecuperacion";
 import { snapCte } from "./moraSnapshotSql";
 import {
-	allocateRoundedAmounts,
-	allocateRoundedPurchaseAmounts,
+  allocateRoundedAmounts,
+  allocateRoundedPurchaseAmounts,
+  canonicalizePurchaseSummaries,
 	assertModeReconciliation,
 	assertReportReconciliation,
-	buildCubeNetInterest,
-	buildInvestorPosition,
-	buildNetInterestDetail,
+  buildCubeNetInterest,
+  buildNetInterestDetail,
 	getPublicReinvestmentDetailError,
 	shouldIncludeInvestorPosition,
 } from "./reinvestmentReport";
@@ -810,10 +810,7 @@ export async function getReinversionLiquidaciones({
       COALESCE(SUM(l.total_capital::numeric), 0)            AS total_capital,
       COALESCE(SUM(l.total_interes::numeric), 0)            AS total_interes,
       COALESCE(SUM(l.total_iva::numeric), 0)                AS total_iva,
-      COALESCE(SUM(CASE
-        WHEN l.total_isr::numeric > 0 THEN 0
-        ELSE l.total_iva::numeric
-      END), 0)                                              AS iva_facturado,
+      0                                                     AS iva_facturado,
       COALESCE(SUM(l.total_isr::numeric), 0)                AS total_isr,
       COALESCE(SUM(l.total_cuota::numeric), 0)              AS total_cuota,
       COALESCE(SUM(
@@ -863,35 +860,19 @@ export async function getReinversionLiquidaciones({
     cantidad += Number(r.cantidad ?? 0);
   }
 
-  // Interés neto, agrupado según el tratamiento fiscal *guardado en la propia
-  // liquidación* (no según el flag actual del inversionista, que puede cambiar
-  // y reclasificaría meses históricos). Una liquidación sin factura es la que
-  // tiene ISR retenido (`total_isr > 0`); las con factura tienen IVA y sin ISR.
-  //   - Con factura:  neto = interés + IVA
-  //   - Sin factura:  neto = interés − ISR
+  // No hay una marca fiscal inmutable en las liquidaciones. ISR/IVA no bastan
+  // para probar facturación, por lo que el interés se publica sin asignación.
   const facturaRows = await db.execute(sql`
     SELECT
-      (l.total_isr::numeric > 0)                   AS sin_factura,
-      COALESCE(SUM(l.total_interes::numeric), 0)   AS total_interes,
-      COALESCE(SUM(l.total_iva::numeric), 0)       AS total_iva,
-      COALESCE(SUM(l.total_isr::numeric), 0)       AS total_isr
+      COALESCE(SUM(l.total_interes::numeric), 0) AS total_interes
     FROM cartera.liquidaciones l
     WHERE (l.fecha_liquidacion AT TIME ZONE 'America/Guatemala')::date >= ${inicioMes}::date
       AND (l.fecha_liquidacion AT TIME ZONE 'America/Guatemala')::date < ${inicioMesSiguiente}::date
-    GROUP BY (l.total_isr::numeric > 0)
   `);
 
-  const conFactura = { interes: 0, iva: 0 };
-  const sinFactura = { interes: 0, isr: 0 };
+  let interesNoVerificado = 0;
   for (const r of facturaRows.rows as Record<string, unknown>[]) {
-    const interes = Number(r.total_interes ?? 0);
-    if (r.sin_factura === true) {
-      sinFactura.interes += interes;
-      sinFactura.isr += Number(r.total_isr ?? 0);
-    } else {
-      conFactura.interes += interes;
-      conFactura.iva += Number(r.total_iva ?? 0);
-    }
+    interesNoVerificado += Number(r.total_interes ?? 0);
   }
 
   // Interés de CUBE: no se almacena como tal sino que se deriva de las filas de
@@ -1029,49 +1010,18 @@ export async function getReinversionLiquidaciones({
     );
   }
 
-  // Monto aportado que le quedó al inversionista DESPUÉS de la liquidación
-  // (sin reinversiones), desde historico_liquidaciones_espejo.
-  // ⚠️ Mayo 2026 fue la primera vez que se usó y el histórico quedó CON la
-  // reinversión sumada; para ese mes se descuenta la reinversión.
-  const montoAportadoRows = await db.execute(sql`
-    SELECT
-      h.inversionista_id,
-      COALESCE(SUM(h.monto_aportado::numeric), 0) AS monto_aportado
-    FROM cartera.historico_liquidaciones_espejo h
-    JOIN cartera.liquidaciones l ON l.liquidacion_id = h.liquidacion_id
-    WHERE (l.fecha_liquidacion AT TIME ZONE 'America/Guatemala')::date >= ${inicioMes}::date
-      AND (l.fecha_liquidacion AT TIME ZONE 'America/Guatemala')::date < ${inicioMesSiguiente}::date
-    GROUP BY h.inversionista_id
-  `);
-  const montoAportadoPorInv = new Map<number, number>();
-  for (const r of montoAportadoRows.rows as Record<string, unknown>[]) {
-    montoAportadoPorInv.set(
-      Number(r.inversionista_id),
-      Number(r.monto_aportado ?? 0)
-    );
-  }
-  const esMayo2026 = anio === 2026 && mes === 5;
-
   const porInversionista = (porInvRows.rows as Record<string, unknown>[]).map(
     (r) => {
       const id = Number(r.inversionista_id);
-      const reinversion = Number(r.reinversion ?? 0);
-      const montoHist = montoAportadoPorInv.get(id) ?? 0;
-      const position = buildInvestorPosition(
-        montoHist,
-        capitalActivoPorInv.get(id) ?? 0,
-        reinversion,
-        esMayo2026
-      );
       return {
         inversionista_id: id,
         nombre: String(r.nombre),
         tipo_reinversion: String(r.tipo_reinversion ?? "sin_reinversion"),
         reinversion_capital: Number(r.reinversion_capital ?? 0).toFixed(2),
         reinversion_interes: Number(r.reinversion_interes ?? 0).toFixed(2),
-        reinversion: reinversion.toFixed(2),
+        reinversion: Number(r.reinversion ?? 0).toFixed(2),
         a_recibir: Number(r.a_recibir ?? 0).toFixed(2),
-        ...position,
+        capital_activo: Number(capitalActivoPorInv.get(id) ?? 0).toFixed(2),
       };
     }
   ).filter(shouldIncludeInvestorPosition);
@@ -1094,15 +1044,15 @@ export async function getReinversionLiquidaciones({
       COALESCE(SUM(c.monto_aportado::numeric), 0) AS monto
     FROM cartera.compras_credito_inversionista c
     WHERE ${comprasMesPredicate}
-    GROUP BY c.tipo_reinversion
+    GROUP BY COALESCE(c.tipo_reinversion::text, 'sin_reinversion')
     ORDER BY monto DESC
   `);
-  const comprasMes = (comprasRows.rows as Record<string, unknown>[]).map(
-    (r) => ({
+  const comprasMes = canonicalizePurchaseSummaries(
+    (comprasRows.rows as Record<string, unknown>[]).map((r) => ({
       tipo: String(r.tipo ?? "sin_reinversion"),
       cantidad: Number(r.cantidad ?? 0),
       monto: Number(r.monto ?? 0).toFixed(2),
-    })
+    })),
   );
 
   let detalleInteresNeto: ReturnType<typeof buildNetInterestDetail>[] = [];
@@ -1256,15 +1206,8 @@ export async function getReinversionLiquidaciones({
   }
 
   const interesNeto = {
-    conFactura: {
-      interes: conFactura.interes.toFixed(2),
-      iva: conFactura.iva.toFixed(2),
-      neto: (conFactura.interes + conFactura.iva).toFixed(2),
-    },
-    sinFactura: {
-      interes: sinFactura.interes.toFixed(2),
-      isr: sinFactura.isr.toFixed(2),
-      neto: (sinFactura.interes - sinFactura.isr).toFixed(2),
+    noVerificado: {
+      interes: interesNoVerificado.toFixed(2),
     },
     cube: interesNetoCube,
   };

--- a/apps/cartera-back/src/controllers/reportes.ts
+++ b/apps/cartera-back/src/controllers/reportes.ts
@@ -132,6 +132,14 @@ export async function getMontoACobrarPeriodo({
         AND pc.fecha_vencimiento::date >= ${fechaInicio}::date
         AND pc.fecha_vencimiento::date <= ${fechaFin}::date
     ),
+    participacion_externa_actual AS (
+      SELECT
+        ci.credito_id,
+        COALESCE(SUM(ci.porcentaje_participacion_inversionista::numeric / 100) FILTER (WHERE i.permite_distribucion = false), 0) AS participacion_externa_actual
+      FROM cartera.creditos_inversionistas ci
+      INNER JOIN cartera.inversionistas i ON i.inversionista_id = ci.inversionista_id
+      GROUP BY ci.credito_id
+    ),
     per_credito AS (
       SELECT
         p.fecha_venc::date                                             AS bucket,
@@ -142,6 +150,7 @@ export async function getMontoACobrarPeriodo({
         COALESCE(c.seguro_10_cuotas::numeric, 0)                       AS seguro,
         COALESCE(c.gps::numeric, 0)                                    AS gps,
         COALESCE(c.membresias_pago::numeric, 0)                        AS mem,
+        COALESCE(MAX(pea.participacion_externa_actual), 0)             AS participacion_externa_actual,
         COALESCE(cap_anterior.total_restante, c.capital::numeric)       AS cap_ant,
         MAX(mora_real.cuotas_atrasadas)                                 AS cuotas_atrasadas,
         CASE WHEN MAX(mora_real.cuotas_atrasadas) > 0
@@ -151,6 +160,7 @@ export async function getMontoACobrarPeriodo({
       INNER JOIN cartera.creditos c ON p.credito_id = c.credito_id
       INNER JOIN cartera.usuarios u ON c.usuario_id = u.usuario_id
       INNER JOIN cartera.asesores a ON c.asesor_id = a.asesor_id
+      LEFT JOIN participacion_externa_actual pea ON pea.credito_id = c.credito_id
       LEFT JOIN LATERAL (
         SELECT COALESCE(mh.monto_nuevo, 0) AS monto_mora
         FROM cartera.moras_historial mh
@@ -300,9 +310,24 @@ export async function getMontoACobrarPeriodo({
         MAX(acum_seguro)                        AS acum_seguro,
         MAX(acum_gps)                           AS acum_gps,
         MAX(acum_mem)                           AS acum_mem,
+        MAX(participacion_externa_actual)       AS participacion_externa_actual,
         COUNT(*)::int                           AS cuotas_count
       FROM calc_acum
       GROUP BY DATE_TRUNC(${pg}, bucket::timestamp), credito_id
+    ),
+    split_participacion_actual AS (
+      SELECT
+        pbc.*,
+        (participacion_externa_actual < 0 OR participacion_externa_actual > 1) AS participacion_invalida,
+        ROUND((CASE WHEN NOT excluido_factura THEN exp_capital ELSE 0 END) * participacion_externa_actual, 2) AS capital_inv_participacion_actual,
+        (CASE WHEN NOT excluido_factura THEN exp_capital ELSE 0 END) - ROUND((CASE WHEN NOT excluido_factura THEN exp_capital ELSE 0 END) * participacion_externa_actual, 2) AS capital_cube_participacion_actual,
+        ROUND((CASE WHEN NOT excluido_factura THEN interes + iva ELSE 0 END) * participacion_externa_actual, 2) AS interes_iva_inv_participacion_actual,
+        (CASE WHEN NOT excluido_factura THEN interes + iva ELSE 0 END) - ROUND((CASE WHEN NOT excluido_factura THEN interes + iva ELSE 0 END) * participacion_externa_actual, 2) AS interes_iva_cube_participacion_actual,
+        ROUND((CASE WHEN excluido_mora THEN 0 WHEN cuotas_atrasadas > 0 THEN LEAST(acum_capital, cap_ant) ELSE exp_capital END) * participacion_externa_actual, 2) AS acum_capital_inv_participacion_actual,
+        (CASE WHEN excluido_mora THEN 0 WHEN cuotas_atrasadas > 0 THEN LEAST(acum_capital, cap_ant) ELSE exp_capital END) - ROUND((CASE WHEN excluido_mora THEN 0 WHEN cuotas_atrasadas > 0 THEN LEAST(acum_capital, cap_ant) ELSE exp_capital END) * participacion_externa_actual, 2) AS acum_capital_cube_participacion_actual,
+        ROUND((CASE WHEN excluido_mora THEN 0 WHEN cuotas_atrasadas > 0 THEN acum_interes + acum_iva ELSE interes + iva END) * participacion_externa_actual, 2) AS acum_interes_iva_inv_participacion_actual,
+        (CASE WHEN excluido_mora THEN 0 WHEN cuotas_atrasadas > 0 THEN acum_interes + acum_iva ELSE interes + iva END) - ROUND((CASE WHEN excluido_mora THEN 0 WHEN cuotas_atrasadas > 0 THEN acum_interes + acum_iva ELSE interes + iva END) * participacion_externa_actual, 2) AS acum_interes_iva_cube_participacion_actual
+      FROM per_bucket_credit pbc
     ),
     -- Interés a inversionistas: lo efectivamente distribuido a inversionistas EXTERNOS
     -- (inversionistas.permite_distribucion = false → se ignoran los nuestros), tomado de
@@ -321,7 +346,7 @@ export async function getMontoACobrarPeriodo({
       GROUP BY DATE_TRUNC(${pg}, (pci.fecha_pago AT TIME ZONE 'America/Guatemala')::timestamp)
     )
     SELECT
-      COALESCE(per_bucket_credit.bucket, ip.pagos_bucket) AS bucket,
+      COALESCE(split_participacion_actual.bucket, ip.pagos_bucket) AS bucket,
       COALESCE(SUM(cuotas_count), 0)::int                                                        AS cuotas_count,
       COALESCE(SUM(CASE WHEN NOT excluido_factura THEN exp_capital ELSE 0 END), 0)               AS total_cuota,
       COALESCE(SUM(CASE WHEN NOT excluido_factura THEN interes     ELSE 0 END), 0)               AS total_interes,
@@ -360,14 +385,25 @@ export async function getMontoACobrarPeriodo({
       -- Interés a inversionistas (lo distribuido a externos). Por período: lo pagado en ese
       -- bucket. Acumulado: suma corrida hasta el bucket (el último bucket = gran total).
       COALESCE(MAX(ip.total_interes_inversionista), 0)                                            AS total_interes_inversionista,
-      COALESCE(SUM(COALESCE(MAX(ip.total_interes_inversionista), 0)) OVER (ORDER BY COALESCE(per_bucket_credit.bucket, ip.pagos_bucket)), 0)   AS acum_total_interes_inversionista
+      COALESCE(SUM(COALESCE(MAX(ip.total_interes_inversionista), 0)) OVER (ORDER BY COALESCE(split_participacion_actual.bucket, ip.pagos_bucket)), 0)   AS acum_total_interes_inversionista,
     -- FULL JOIN: el resultado se arma desde la unión de buckets de ambas fuentes, para que un
     -- período con pagos a inversionistas pero SIN cuotas pendientes (posible en vista
     -- día/semana) no se pierda ni subestime la columna.
-    FROM per_bucket_credit
-    FULL JOIN inv_pagos_por_bucket ip ON ip.pagos_bucket = per_bucket_credit.bucket
-    GROUP BY COALESCE(per_bucket_credit.bucket, ip.pagos_bucket)
-    ORDER BY COALESCE(per_bucket_credit.bucket, ip.pagos_bucket) ASC
+      COALESCE(SUM(capital_inv_participacion_actual) FILTER (WHERE NOT participacion_invalida), 0) AS capital_inv_participacion_actual,
+      COALESCE(SUM(capital_cube_participacion_actual) FILTER (WHERE NOT participacion_invalida), 0) AS capital_cube_participacion_actual,
+      COALESCE(SUM(interes_iva_inv_participacion_actual) FILTER (WHERE NOT participacion_invalida), 0) AS interes_iva_inv_participacion_actual,
+      COALESCE(SUM(interes_iva_cube_participacion_actual) FILTER (WHERE NOT participacion_invalida), 0) AS interes_iva_cube_participacion_actual,
+      COALESCE(SUM(acum_capital_inv_participacion_actual) FILTER (WHERE NOT participacion_invalida), 0) AS acum_capital_inv_participacion_actual,
+      COALESCE(SUM(acum_capital_cube_participacion_actual) FILTER (WHERE NOT participacion_invalida), 0) AS acum_capital_cube_participacion_actual,
+      COALESCE(SUM(acum_interes_iva_inv_participacion_actual) FILTER (WHERE NOT participacion_invalida), 0) AS acum_interes_iva_inv_participacion_actual,
+      COALESCE(SUM(acum_interes_iva_cube_participacion_actual) FILTER (WHERE NOT participacion_invalida), 0) AS acum_interes_iva_cube_participacion_actual,
+      COUNT(credito_id) FILTER (WHERE participacion_invalida)::int AS creditos_participacion_invalida,
+      COALESCE(SUM(cuotas_count) FILTER (WHERE participacion_invalida), 0)::int AS cuotas_participacion_invalida,
+      true AS participacion_actual
+    FROM split_participacion_actual
+    FULL JOIN inv_pagos_por_bucket ip ON ip.pagos_bucket = split_participacion_actual.bucket
+    GROUP BY COALESCE(split_participacion_actual.bucket, ip.pagos_bucket)
+    ORDER BY COALESCE(split_participacion_actual.bucket, ip.pagos_bucket) ASC
   `);
 
   return result.rows;

--- a/apps/cartera-back/src/controllers/reportes.ts
+++ b/apps/cartera-back/src/controllers/reportes.ts
@@ -12,6 +12,7 @@ import {
 	allocateRoundedPurchaseAmounts,
 	assertModeReconciliation,
 	assertReportReconciliation,
+	buildCubeNetInterest,
 	buildInvestorPosition,
 	buildNetInterestDetail,
 	getPublicReinvestmentDetailError,
@@ -923,6 +924,7 @@ export async function getReinversionLiquidaciones({
   const interesCube = Number(
     (cubeRows.rows[0] as Record<string, unknown>)?.interes_cube ?? 0
   );
+  const interesNetoCube = buildCubeNetInterest(interesCube);
 
   // Pagos extras recibidos (abonos a capital / cancelaciones) de las
   // liquidaciones del mes, leídos directo del abono.
@@ -1154,10 +1156,10 @@ export async function getReinversionLiquidaciones({
         inversionista: "CUBE",
         referencia: "Participación CUBE",
         tratamiento_fiscal: "cube",
-        interes: interesCube.toFixed(2),
-        iva: (interesCube * 0.12).toFixed(2),
+        interes: interesNetoCube.interes,
+        iva: interesNetoCube.iva,
         isr: "0.00",
-        neto: (interesCube * 1.12).toFixed(2),
+        neto: interesNetoCube.neto,
       });
     }
 
@@ -1264,11 +1266,7 @@ export async function getReinversionLiquidaciones({
       isr: sinFactura.isr.toFixed(2),
       neto: (sinFactura.interes - sinFactura.isr).toFixed(2),
     },
-    cube: {
-      interes: interesCube.toFixed(2),
-      iva: (interesCube * 0.12).toFixed(2),
-      neto: (interesCube * 1.12).toFixed(2),
-    },
+    cube: interesNetoCube,
   };
   const pagosExtras = {
     abonos_capital: abonosCapital.toFixed(2),

--- a/apps/cartera-back/src/controllers/reportes.ts
+++ b/apps/cartera-back/src/controllers/reportes.ts
@@ -1,6 +1,12 @@
 import { sql } from "drizzle-orm";
 import { db } from "../database";
-import { snapCte } from "./moraHistorial";
+import {
+  type MoraRecoverySourceRow,
+  buildMoraRecoveryQuery,
+  buildMoraRecoveryReport,
+  getMoraRecoveryPeriod,
+} from "./moraRecuperacion";
+import { snapCte } from "./moraSnapshotSql";
 
 type Periodo = "anio" | "trimestre" | "mes" | "semana" | "dia";
 
@@ -1369,6 +1375,39 @@ export async function getMoraCobradaPorAsesor({
   const totalCobrado = porAsesor.reduce((s, r) => s + Number(r.cobrado), 0).toFixed(2);
 
   return { periodo: { inicio, fin }, porAsesor, totalCobrado };
+}
+
+export async function getMoraRecuperacionPorAsesor({
+  mes,
+  anio,
+  asesores,
+  emailCobrador,
+}: {
+  mes: number;
+  anio: number;
+  asesores?: number[];
+  emailCobrador?: string;
+}) {
+  const period = getMoraRecoveryPeriod({ mes, anio, hoy: hoyGTStr() });
+
+  const result = await db.execute<{
+    asesor_id: number | null;
+    nombre: string | null;
+    esperado: string;
+    cobrado_en_snapshot: string;
+    cobrado_fuera_snapshot: string;
+  }>(buildMoraRecoveryQuery({ ...period, asesores, emailCobrador }));
+
+  return buildMoraRecoveryReport(
+    result.rows.map((row): MoraRecoverySourceRow => ({
+      asesorId: row.asesor_id,
+      nombre: row.nombre ?? "Sin asignar",
+      esperado: row.esperado,
+      cobradoEnSnapshot: row.cobrado_en_snapshot,
+      cobradoFueraSnapshot: row.cobrado_fuera_snapshot,
+    })),
+    period,
+  );
 }
 
 export async function getCuotasPorFecha({

--- a/apps/cartera-back/src/controllers/reportes.ts
+++ b/apps/cartera-back/src/controllers/reportes.ts
@@ -8,9 +8,10 @@ import {
 } from "./moraRecuperacion";
 import { snapCte } from "./moraSnapshotSql";
 import {
+	allocateRoundedAmounts,
+	allocateRoundedPurchaseAmounts,
 	assertModeReconciliation,
 	assertReportReconciliation,
-	allocateRoundedAmounts,
 	buildInvestorPosition,
 	buildNetInterestDetail,
 	getPublicReinvestmentDetailError,
@@ -837,6 +838,7 @@ export async function getReinversionLiquidaciones({
       total_isr: string;
       total_cuota: string;
       total_distribuido: string;
+      cantidad_liquidaciones: number;
     }
   > = {};
   let cantidad = 0;
@@ -854,6 +856,7 @@ export async function getReinversionLiquidaciones({
       total_isr: Number(r.total_isr ?? 0).toFixed(2),
       total_cuota: Number(r.total_cuota ?? 0).toFixed(2),
       total_distribuido: Number(r.total_distribuido ?? 0).toFixed(2),
+      cantidad_liquidaciones: Number(r.cantidad ?? 0),
     };
     cantidad += Number(r.cantidad ?? 0);
   }
@@ -1207,14 +1210,14 @@ export async function getReinversionLiquidaciones({
     WHERE ${comprasMesPredicate}
     ORDER BY ${fechaCompra}, i.nombre
   `);
-    detalleComprasMes = (
-      comprasDetalleRows.rows as Record<string, unknown>[]
-    ).map((r) => ({
-      fecha: String(r.fecha),
-      inversionista: String(r.inversionista),
-      modalidad: String(r.modalidad),
-      monto: Number(r.monto ?? 0).toFixed(2),
-    }));
+    detalleComprasMes = allocateRoundedPurchaseAmounts(
+      (comprasDetalleRows.rows as Record<string, unknown>[]).map((r) => ({
+        fecha: String(r.fecha),
+        inversionista: String(r.inversionista),
+        modalidad: String(r.modalidad),
+        monto: String(r.monto ?? 0),
+      }))
+    );
   } catch (error) {
     console.error(
       "No fue posible recuperar el detalle del reporte de reinversión",

--- a/apps/cartera-back/src/controllers/reportes.ts
+++ b/apps/cartera-back/src/controllers/reportes.ts
@@ -15,6 +15,7 @@ import {
 	buildInvestorPosition,
 	buildNetInterestDetail,
 	getPublicReinvestmentDetailError,
+	shouldIncludeInvestorPosition,
 } from "./reinvestmentReport";
 
 type Periodo = "anio" | "trimestre" | "mes" | "semana" | "dia";
@@ -1071,13 +1072,7 @@ export async function getReinversionLiquidaciones({
         ...position,
       };
     }
-  ).filter(
-    // La liquidación manda: si no aportó nada (todo en cero), no se muestra.
-    (p) =>
-      Number(p.reinversion) !== 0 ||
-      Number(p.a_recibir) !== 0 ||
-      Number(p.monto_aportado) !== 0
-  );
+  ).filter(shouldIncludeInvestorPosition);
 
   // Compras del mes: solo operación de compra (no reinversión) y solo las
   // COMPLETADAS (status = 'completado'); las pendientes no se cuentan. La fecha

--- a/apps/cartera-back/src/controllers/reportes.ts
+++ b/apps/cartera-back/src/controllers/reportes.ts
@@ -1,12 +1,19 @@
 import { sql } from "drizzle-orm";
 import { db } from "../database";
 import {
-  type MoraRecoverySourceRow,
-  buildMoraRecoveryQuery,
-  buildMoraRecoveryReport,
-  getMoraRecoveryPeriod,
+	type MoraRecoverySourceRow,
+	buildMoraRecoveryQuery,
+	buildMoraRecoveryReport,
+	getMoraRecoveryPeriod,
 } from "./moraRecuperacion";
 import { snapCte } from "./moraSnapshotSql";
+import {
+	assertModeReconciliation,
+	assertReportReconciliation,
+	buildInvestorPosition,
+	buildNetInterestDetail,
+	getPublicReinvestmentDetailError,
+} from "./reinvestmentReport";
 
 type Periodo = "anio" | "trimestre" | "mes" | "semana" | "dia";
 
@@ -799,8 +806,15 @@ export async function getReinversionLiquidaciones({
       COALESCE(SUM(l.total_capital::numeric), 0)            AS total_capital,
       COALESCE(SUM(l.total_interes::numeric), 0)            AS total_interes,
       COALESCE(SUM(l.total_iva::numeric), 0)                AS total_iva,
+      COALESCE(SUM(CASE
+        WHEN l.total_isr::numeric > 0 THEN 0
+        ELSE l.total_iva::numeric
+      END), 0)                                              AS iva_facturado,
       COALESCE(SUM(l.total_isr::numeric), 0)                AS total_isr,
       COALESCE(SUM(l.total_cuota::numeric), 0)              AS total_cuota,
+      COALESCE(SUM(
+        l.total_cuota::numeric + l.reinversion_total::numeric
+      ), 0)                                                 AS total_distribuido,
       COUNT(*)::int                                          AS cantidad
     FROM cartera.liquidaciones l
     JOIN cartera.inversionistas i ON l.inversionista_id = i.inversionista_id
@@ -818,8 +832,10 @@ export async function getReinversionLiquidaciones({
       total_capital: string;
       total_interes: string;
       total_iva: string;
+      iva_facturado: string;
       total_isr: string;
       total_cuota: string;
+      total_distribuido: string;
     }
   > = {};
   let cantidad = 0;
@@ -833,8 +849,10 @@ export async function getReinversionLiquidaciones({
       total_capital: Number(r.total_capital ?? 0).toFixed(2),
       total_interes: Number(r.total_interes ?? 0).toFixed(2),
       total_iva: Number(r.total_iva ?? 0).toFixed(2),
+      iva_facturado: Number(r.iva_facturado ?? 0).toFixed(2),
       total_isr: Number(r.total_isr ?? 0).toFixed(2),
       total_cuota: Number(r.total_cuota ?? 0).toFixed(2),
+      total_distribuido: Number(r.total_distribuido ?? 0).toFixed(2),
     };
     cantidad += Number(r.cantidad ?? 0);
   }
@@ -1007,7 +1025,11 @@ export async function getReinversionLiquidaciones({
       const id = Number(r.inversionista_id);
       const reinversion = Number(r.reinversion ?? 0);
       const montoHist = montoAportadoPorInv.get(id) ?? 0;
-      const montoAportado = esMayo2026 ? montoHist - reinversion : montoHist;
+      const position = buildInvestorPosition(
+        montoHist,
+        reinversion,
+        esMayo2026
+      );
       return {
         inversionista_id: id,
         nombre: String(r.nombre),
@@ -1016,7 +1038,7 @@ export async function getReinversionLiquidaciones({
         reinversion_interes: Number(r.reinversion_interes ?? 0).toFixed(2),
         reinversion: reinversion.toFixed(2),
         a_recibir: Number(r.a_recibir ?? 0).toFixed(2),
-        monto_aportado: montoAportado.toFixed(2),
+        ...position,
       };
     }
   ).filter(
@@ -1032,16 +1054,19 @@ export async function getReinversionLiquidaciones({
   // efectiva prioriza fecha_completada y cae a updated_at cuando es NULL
   // (columna nueva, registros viejos) — mismo criterio que utils/comprasAjuste.ts.
   const fechaCompra = sql`COALESCE(c.fecha_completada, c.updated_at)`;
+  const comprasMesPredicate = sql`
+    c.tipo_operacion = 'compra_cartera'
+    AND c.status = 'completado'
+    AND (${fechaCompra} AT TIME ZONE 'America/Guatemala')::date >= ${inicioMes}::date
+    AND (${fechaCompra} AT TIME ZONE 'America/Guatemala')::date < ${inicioMesSiguiente}::date
+  `;
   const comprasRows = await db.execute(sql`
     SELECT
       COALESCE(c.tipo_reinversion::text, 'sin_reinversion') AS tipo,
-      COUNT(DISTINCT (c.inversionista_id, ${fechaCompra}))::int AS cantidad,
+      COUNT(*)::int AS cantidad,
       COALESCE(SUM(c.monto_aportado::numeric), 0) AS monto
     FROM cartera.compras_credito_inversionista c
-    WHERE c.tipo_operacion = 'compra_cartera'
-      AND c.status = 'completado'
-      AND (${fechaCompra} AT TIME ZONE 'America/Guatemala')::date >= ${inicioMes}::date
-      AND (${fechaCompra} AT TIME ZONE 'America/Guatemala')::date < ${inicioMesSiguiente}::date
+    WHERE ${comprasMesPredicate}
     GROUP BY c.tipo_reinversion
     ORDER BY monto DESC
   `);
@@ -1053,31 +1078,196 @@ export async function getReinversionLiquidaciones({
     })
   );
 
+  let detalleInteresNeto: ReturnType<typeof buildNetInterestDetail>[] = [];
+  let detallePagosExtras: {
+    fecha: string;
+    credito: string;
+    tipo: "abono_capital" | "cancelacion";
+    monto: string;
+  }[] = [];
+  let detalleComprasMes: {
+    fecha: string;
+    inversionista: string;
+    modalidad: string;
+    monto: string;
+  }[] = [];
+  let detalleEstado: { disponible: boolean; error: string | null } = {
+    disponible: true,
+    error: null,
+  };
+
+  try {
+    const interesDetalleRows = await db.execute(sql`
+    SELECT
+      l.inversionista_id,
+      i.nombre AS inversionista,
+      'LIQ-' || l.liquidacion_id::text AS referencia,
+      l.total_interes AS interes,
+      l.total_iva AS iva,
+      l.total_isr AS isr
+    FROM cartera.liquidaciones l
+    JOIN cartera.inversionistas i ON i.inversionista_id = l.inversionista_id
+    WHERE (l.fecha_liquidacion AT TIME ZONE 'America/Guatemala')::date >= ${inicioMes}::date
+      AND (l.fecha_liquidacion AT TIME ZONE 'America/Guatemala')::date < ${inicioMesSiguiente}::date
+    ORDER BY i.nombre, l.liquidacion_id
+  `);
+    detalleInteresNeto = (
+      interesDetalleRows.rows as Record<string, unknown>[]
+    ).map((r) =>
+      buildNetInterestDetail({
+        inversionista_id: Number(r.inversionista_id),
+        inversionista: String(r.inversionista),
+        referencia: String(r.referencia),
+        interes: Number(r.interes ?? 0),
+        iva: Number(r.iva ?? 0),
+        isr: Number(r.isr ?? 0),
+      })
+    );
+    if (interesCube !== 0) {
+      detalleInteresNeto.push({
+        inversionista_id: 86,
+        inversionista: "CUBE",
+        referencia: "Participación CUBE",
+        tratamiento_fiscal: "cube",
+        interes: interesCube.toFixed(2),
+        iva: (interesCube * 0.12).toFixed(2),
+        isr: "0.00",
+        neto: (interesCube * 1.12).toFixed(2),
+      });
+    }
+
+    const extrasDetalleRows = await db.execute(sql`
+    SELECT
+      (l.fecha_liquidacion AT TIME ZONE 'America/Guatemala')::date::text AS fecha,
+      cr.numero_credito_sifco AS credito,
+      CASE WHEN a.tipo = 'CAPITAL' THEN 'abono_capital' ELSE 'cancelacion' END AS tipo,
+      a.monto
+    FROM cartera.abonos_capital a
+    JOIN cartera.liquidaciones l ON l.liquidacion_id = a.liquidacion_id
+    JOIN cartera.creditos cr ON cr.credito_id = a.credito_id
+    WHERE (l.fecha_liquidacion AT TIME ZONE 'America/Guatemala')::date >= ${inicioMes}::date
+      AND (l.fecha_liquidacion AT TIME ZONE 'America/Guatemala')::date < ${inicioMesSiguiente}::date
+    ORDER BY l.fecha_liquidacion, cr.numero_credito_sifco
+  `);
+    detallePagosExtras = (
+      extrasDetalleRows.rows as Record<string, unknown>[]
+    ).map((r) => ({
+      fecha: String(r.fecha),
+      credito: String(r.credito),
+      tipo: String(r.tipo) as "abono_capital" | "cancelacion",
+      monto: Number(r.monto ?? 0).toFixed(2),
+    }));
+    const manualDetalleRows = await db.execute(sql`
+    SELECT
+      (MAX(l.fecha_liquidacion) AT TIME ZONE 'America/Guatemala')::date::text AS fecha,
+      cr.numero_credito_sifco AS credito,
+      SUM(pe.abono_capital::numeric) AS monto,
+      COALESCE(MAX(ce.monto_aportado::numeric), 0) AS monto_aportado,
+      bool_and(ce.id IS NULL) AS sin_fila
+    FROM cartera.pagos_credito_inversionistas_espejo pe
+    JOIN cartera.liquidaciones l ON l.liquidacion_id = pe.liquidacion_id
+    JOIN cartera.creditos cr ON cr.credito_id = pe.credito_id
+    LEFT JOIN cartera.creditos_inversionistas_espejo ce
+      ON ce.credito_id = pe.credito_id
+     AND ce.inversionista_id = pe.inversionista_id
+    WHERE (l.fecha_liquidacion AT TIME ZONE 'America/Guatemala')::date >= ${inicioMes}::date
+      AND (l.fecha_liquidacion AT TIME ZONE 'America/Guatemala')::date < ${inicioMesSiguiente}::date
+      AND pe.abono_capital::numeric >= 2000
+      AND pe.abono_capital_id IS NULL
+      AND cr."statusCredit" <> 'ACTIVO'
+    GROUP BY pe.credito_id, pe.inversionista_id, cr.numero_credito_sifco
+    HAVING COALESCE(MAX(ce.monto_aportado::numeric), 0) = 0 OR bool_and(ce.id IS NULL)
+    ORDER BY fecha, cr.numero_credito_sifco
+  `);
+    detallePagosExtras.push(
+      ...(manualDetalleRows.rows as Record<string, unknown>[]).map((r) => ({
+        fecha: String(r.fecha),
+        credito: String(r.credito),
+        tipo: "cancelacion" as const,
+        monto: Number(r.monto ?? 0).toFixed(2),
+      }))
+    );
+
+    const comprasDetalleRows = await db.execute(sql`
+    SELECT
+      (${fechaCompra} AT TIME ZONE 'America/Guatemala')::date::text AS fecha,
+      i.nombre AS inversionista,
+      COALESCE(c.tipo_reinversion::text, 'sin_reinversion') AS modalidad,
+      c.monto_aportado AS monto
+    FROM cartera.compras_credito_inversionista c
+    JOIN cartera.inversionistas i ON i.inversionista_id = c.inversionista_id
+    WHERE ${comprasMesPredicate}
+    ORDER BY ${fechaCompra}, i.nombre
+  `);
+    detalleComprasMes = (
+      comprasDetalleRows.rows as Record<string, unknown>[]
+    ).map((r) => ({
+      fecha: String(r.fecha),
+      inversionista: String(r.inversionista),
+      modalidad: String(r.modalidad),
+      monto: Number(r.monto ?? 0).toFixed(2),
+    }));
+  } catch (error) {
+    console.error(
+      "No fue posible recuperar el detalle del reporte de reinversión",
+      error,
+    );
+    detalleInteresNeto = [];
+    detallePagosExtras = [];
+    detalleComprasMes = [];
+    detalleEstado = {
+      disponible: false,
+      error: getPublicReinvestmentDetailError(error),
+    };
+  }
+
+  const interesNeto = {
+    conFactura: {
+      interes: conFactura.interes.toFixed(2),
+      iva: conFactura.iva.toFixed(2),
+      neto: (conFactura.interes + conFactura.iva).toFixed(2),
+    },
+    sinFactura: {
+      interes: sinFactura.interes.toFixed(2),
+      isr: sinFactura.isr.toFixed(2),
+      neto: (sinFactura.interes - sinFactura.isr).toFixed(2),
+    },
+    cube: {
+      interes: interesCube.toFixed(2),
+      iva: (interesCube * 0.12).toFixed(2),
+      neto: (interesCube * 1.12).toFixed(2),
+    },
+  };
+  const pagosExtras = {
+    abonos_capital: abonosCapital.toFixed(2),
+    cancelaciones: cancelaciones.toFixed(2),
+  };
+
+  if (detalleEstado.disponible) {
+    assertReportReconciliation({
+      interesNeto,
+      pagosExtras,
+      comprasMes,
+      detalleInteresNeto,
+      detallePagosExtras,
+      detalleComprasMes,
+    });
+  }
+  for (const modalidad of Object.values(porTipo)) {
+    assertModeReconciliation(modalidad);
+  }
+
   return {
+    contrato_version: 2 as const,
     porTipo,
     porInversionista,
     comprasMes,
-    interesNeto: {
-      conFactura: {
-        interes: conFactura.interes.toFixed(2),
-        iva: conFactura.iva.toFixed(2),
-        neto: (conFactura.interes + conFactura.iva).toFixed(2),
-      },
-      sinFactura: {
-        interes: sinFactura.interes.toFixed(2),
-        isr: sinFactura.isr.toFixed(2),
-        neto: (sinFactura.interes - sinFactura.isr).toFixed(2),
-      },
-      cube: {
-        interes: interesCube.toFixed(2),
-        iva: (interesCube * 0.12).toFixed(2),
-        neto: (interesCube * 1.12).toFixed(2),
-      },
-    },
-    pagosExtras: {
-      abonos_capital: abonosCapital.toFixed(2),
-      cancelaciones: cancelaciones.toFixed(2),
-    },
+    detalleInteresNeto,
+    detallePagosExtras,
+    detalleComprasMes,
+    detalle_estado: detalleEstado,
+    interesNeto,
+    pagosExtras,
     cantidad_liquidaciones: cantidad,
   };
 }

--- a/apps/cartera-back/src/controllers/reportes.ts
+++ b/apps/cartera-back/src/controllers/reportes.ts
@@ -11,6 +11,7 @@ import {
   allocateRoundedAmounts,
   allocateRoundedPurchaseAmounts,
   canonicalizePurchaseSummaries,
+	calculateActiveCapital,
 	assertModeReconciliation,
 	assertReportReconciliation,
   buildCubeNetInterest,
@@ -986,13 +987,28 @@ export async function getReinversionLiquidaciones({
   `);
 
   // Capital operativo actual desde el espejo canónico. La reinversión ya está
-  // reflejada aquí, por lo que no se suma nuevamente desde la liquidación.
+  // reflejada aquí, por lo que no se suma nuevamente desde la liquidación. Las
+  // compras aún no aceptadas ya incrementaron el espejo y se restan por posición.
   const capitalActivoRows = await db.execute(sql`
+    WITH pending_purchase_deltas AS (
+      SELECT
+        c.credito_id,
+        c.inversionista_id,
+        SUM(c.monto_aportado::numeric) AS monto_pendiente
+      FROM cartera.compras_credito_inversionista c
+      WHERE c.tipo_operacion = 'compra_cartera'
+        AND c.status = 'pendiente_compra_cartera'
+      GROUP BY c.credito_id, c.inversionista_id
+    )
     SELECT
       ce.inversionista_id,
-      COALESCE(SUM(ce.monto_aportado::numeric), 0) AS capital_activo
+      COALESCE(SUM(ce.monto_aportado::numeric), 0) AS monto_espejo,
+      COALESCE(SUM(ppd.monto_pendiente), 0) AS monto_compra_pendiente
     FROM cartera.creditos_inversionistas_espejo ce
     JOIN cartera.creditos cr ON cr.credito_id = ce.credito_id
+    LEFT JOIN pending_purchase_deltas ppd
+      ON ppd.credito_id = ce.credito_id
+     AND ppd.inversionista_id = ce.inversionista_id
     WHERE ce.inversionista_id IN (
       SELECT DISTINCT l.inversionista_id
       FROM cartera.liquidaciones l
@@ -1006,7 +1022,10 @@ export async function getReinversionLiquidaciones({
   for (const r of capitalActivoRows.rows as Record<string, unknown>[]) {
     capitalActivoPorInv.set(
       Number(r.inversionista_id),
-      Number(r.capital_activo ?? 0)
+      calculateActiveCapital(
+        Number(r.monto_espejo ?? 0),
+        Number(r.monto_compra_pendiente ?? 0),
+      )
     );
   }
 

--- a/apps/cartera-back/src/controllers/reportes.ts
+++ b/apps/cartera-back/src/controllers/reportes.ts
@@ -329,6 +329,10 @@ export async function getMontoACobrarPeriodo({
         (CASE WHEN excluido_mora THEN 0 WHEN cuotas_atrasadas > 0 THEN acum_interes + acum_iva ELSE interes + iva END) - ROUND((CASE WHEN excluido_mora THEN 0 WHEN cuotas_atrasadas > 0 THEN acum_interes + acum_iva ELSE interes + iva END) * participacion_externa_actual, 2) AS acum_interes_iva_cube_participacion_actual
       FROM per_bucket_credit pbc
     ),
+    participacion_invalida_rango AS (
+      SELECT COUNT(DISTINCT credito_id) FILTER (WHERE participacion_invalida)::int AS creditos_participacion_invalida_rango
+      FROM split_participacion_actual
+    ),
     -- Interés a inversionistas: lo efectivamente distribuido a inversionistas EXTERNOS
     -- (inversionistas.permite_distribucion = false → se ignoran los nuestros), tomado de
     -- pagos_credito_inversionistas como interés + IVA (abono_interes + abono_iva_12),
@@ -398,10 +402,12 @@ export async function getMontoACobrarPeriodo({
       COALESCE(SUM(acum_interes_iva_inv_participacion_actual) FILTER (WHERE NOT participacion_invalida), 0) AS acum_interes_iva_inv_participacion_actual,
       COALESCE(SUM(acum_interes_iva_cube_participacion_actual) FILTER (WHERE NOT participacion_invalida), 0) AS acum_interes_iva_cube_participacion_actual,
       COUNT(credito_id) FILTER (WHERE participacion_invalida)::int AS creditos_participacion_invalida,
+      COALESCE(MAX(pir.creditos_participacion_invalida_rango), 0)::int AS creditos_participacion_invalida_rango,
       COALESCE(SUM(cuotas_count) FILTER (WHERE participacion_invalida), 0)::int AS cuotas_participacion_invalida,
       true AS participacion_actual
     FROM split_participacion_actual
     FULL JOIN inv_pagos_por_bucket ip ON ip.pagos_bucket = split_participacion_actual.bucket
+    CROSS JOIN participacion_invalida_rango pir
     GROUP BY COALESCE(split_participacion_actual.bucket, ip.pagos_bucket)
     ORDER BY COALESCE(split_participacion_actual.bucket, ip.pagos_bucket) ASC
   `);

--- a/apps/cartera-back/src/routers/reportes.test.ts
+++ b/apps/cartera-back/src/routers/reportes.test.ts
@@ -1,0 +1,51 @@
+import { describe, expect, it, mock } from "bun:test";
+import jwt from "jsonwebtoken";
+import { getMoraRecoveryPeriod } from "../controllers/moraRecuperacion";
+
+const execute = mock(() => Promise.resolve({ rows: [] }));
+
+mock.module("../database", () => ({ db: { execute } }));
+
+const { reportesRouter } = await import("./reportes");
+
+describe("GET /reportes/mora-recuperacion-por-asesor", () => {
+	it("responde 400 para un ciclo futuro antes de consultar la base de datos", async () => {
+		execute.mockClear();
+		const token = jwt.sign({ role: "ADMIN" }, "supersecreto");
+		const response = await reportesRouter.handle(
+			new Request(
+				"http://localhost/reportes/mora-recuperacion-por-asesor?mes=1&anio=2100",
+				{ headers: { authorization: `Bearer ${token}` } },
+			),
+		);
+
+		expect(response.status).toBe(400);
+		expect(await response.json()).toEqual({
+			error: "No se puede consultar un ciclo futuro",
+		});
+		expect(execute).not.toHaveBeenCalled();
+	});
+
+	it("responde 500 para un error inesperado", async () => {
+		execute.mockRejectedValueOnce(new Error("fallo de base de datos"));
+		const token = jwt.sign({ role: "ADMIN" }, "supersecreto");
+		const response = await reportesRouter.handle(
+			new Request(
+				"http://localhost/reportes/mora-recuperacion-por-asesor?mes=1&anio=2000",
+				{ headers: { authorization: `Bearer ${token}` } },
+			),
+		);
+
+		expect(response.status).toBe(500);
+	});
+
+	it("marca el ciclo futuro con una señal estable", () => {
+		let error: unknown;
+		try {
+			getMoraRecoveryPeriod({ mes: 1, anio: 2100, hoy: "2026-07-29" });
+		} catch (caughtError) {
+			error = caughtError;
+		}
+		expect(error).toMatchObject({ name: "MoraRecoveryFuturePeriodError" });
+	});
+});

--- a/apps/cartera-back/src/routers/reportes.ts
+++ b/apps/cartera-back/src/routers/reportes.ts
@@ -1,6 +1,7 @@
 import { Elysia } from "elysia";
 import { buildActivePortfolioRows, buildActivePortfolioWorkbook, getActivePortfolioCredits } from "../controllers/activePortfolioReport";
 import { getCobranzaDiaria, getCobranzaDiariaDetalle } from "../controllers/cobranzaDiariaReporte";
+import { MoraRecoveryFuturePeriodError } from "../controllers/moraRecuperacion";
 import { getCobradoDelMesSnapshot, getColocacionPorPeriodo, getComparativoHistorico, getCuotasPorFecha, getEsperadoDelMesMeta, getFlujoCuotasInversiones, getFlujoCuotasPorInversionista, getMontoACobrar, getMontoACobrarPeriodo, getMoraByEtapaYAsesor, getMoraCobradaPorAsesor, getMoraRecuperacionPorAsesor, getReinversionLiquidaciones } from "../controllers/reportes";
 import { db } from "../database";
 import { getVehiclesBySifcoMap } from "../services/crm.service";
@@ -387,13 +388,17 @@ export const reportesRouter = new Elysia().use(authMiddleware)
         set.status = 400;
         return { error: "Parámetro 'asesores' inválido" };
       }
-      return getMoraRecuperacionPorAsesor({
+      return await getMoraRecuperacionPorAsesor({
         mes: mesNum,
         anio: anioNum,
         asesores: asesoresIds,
         emailCobrador: email_cobrador,
       });
     } catch (error) {
+      if (error instanceof MoraRecoveryFuturePeriodError) {
+        set.status = 400;
+        return { error: error.message };
+      }
       console.error("[/reportes/mora-recuperacion-por-asesor]", error);
       set.status = 500;
       return { error: "Error interno del servidor" };

--- a/apps/cartera-back/src/routers/reportes.ts
+++ b/apps/cartera-back/src/routers/reportes.ts
@@ -1,9 +1,9 @@
 import { Elysia } from "elysia";
-import { db } from "../database";
 import { buildActivePortfolioRows, buildActivePortfolioWorkbook, getActivePortfolioCredits } from "../controllers/activePortfolioReport";
-import { getCobradoDelMesSnapshot, getColocacionPorPeriodo, getComparativoHistorico, getCuotasPorFecha, getEsperadoDelMesMeta, getFlujoCuotasInversiones, getFlujoCuotasPorInversionista, getMoraByEtapaYAsesor, getMoraCobradaPorAsesor, getMontoACobrar, getMontoACobrarPeriodo, getReinversionLiquidaciones } from "../controllers/reportes";
-import { getVehiclesBySifcoMap } from "../services/crm.service";
 import { getCobranzaDiaria, getCobranzaDiariaDetalle } from "../controllers/cobranzaDiariaReporte";
+import { getCobradoDelMesSnapshot, getColocacionPorPeriodo, getComparativoHistorico, getCuotasPorFecha, getEsperadoDelMesMeta, getFlujoCuotasInversiones, getFlujoCuotasPorInversionista, getMontoACobrar, getMontoACobrarPeriodo, getMoraByEtapaYAsesor, getMoraCobradaPorAsesor, getMoraRecuperacionPorAsesor, getReinversionLiquidaciones } from "../controllers/reportes";
+import { db } from "../database";
+import { getVehiclesBySifcoMap } from "../services/crm.service";
 import { authMiddleware } from "./midleware";
 
 const PERIODOS_VALIDOS = ["anio", "trimestre", "mes", "semana", "dia"] as const;
@@ -362,6 +362,39 @@ export const reportesRouter = new Elysia().use(authMiddleware)
       return data;
     } catch (error) {
       console.error("[/reportes/mora-cobrada-por-asesor]", error);
+      set.status = 500;
+      return { error: "Error interno del servidor" };
+    }
+  })
+
+  .get("/reportes/mora-recuperacion-por-asesor", async ({ query, set }) => {
+    try {
+      const { mes, anio, asesores, email_cobrador } = query as Record<string, string>;
+      const mesNum = Number(mes);
+      const anioNum = Number(anio);
+      if (!Number.isInteger(mesNum) || mesNum < 1 || mesNum > 12) {
+        set.status = 400;
+        return { error: "Parámetro 'mes' inválido (1-12)" };
+      }
+      if (!Number.isInteger(anioNum) || anioNum < 2000 || anioNum > 2100) {
+        set.status = 400;
+        return { error: "Parámetro 'anio' inválido" };
+      }
+      const asesoresIds = asesores
+        ? asesores.split(",").map((value) => Number(value.trim())).filter((id) => Number.isInteger(id) && id > 0)
+        : undefined;
+      if (asesores && !asesoresIds?.length) {
+        set.status = 400;
+        return { error: "Parámetro 'asesores' inválido" };
+      }
+      return getMoraRecuperacionPorAsesor({
+        mes: mesNum,
+        anio: anioNum,
+        asesores: asesoresIds,
+        emailCobrador: email_cobrador,
+      });
+    } catch (error) {
+      console.error("[/reportes/mora-recuperacion-por-asesor]", error);
       set.status = 500;
       return { error: "Error interno del servidor" };
     }

--- a/apps/carteraFront/src/private/cartera/components/PaymentsCredits.tsx
+++ b/apps/carteraFront/src/private/cartera/components/PaymentsCredits.tsx
@@ -516,6 +516,34 @@ const handleDownloadExcel = async () => {
       return mesOk && anioOk;
     })
     : [];
+
+  // Último pago aplicado de cada cuota abierta: sus "restantes" son el estado real de la cuota
+  const ultimosAplicados = React.useMemo(() => {
+    const porCuota = new Map<number, { pago_id: number; fecha: number }>();
+    for (const item of pagosFiltrados as any[]) {
+      const p = item?.pago;
+      if (!p || p.cuota_pagada === true || p.paymentFalse === true) continue;
+      if (!p.fecha_aplicado || Number(p.monto_aplicado ?? 0) <= 0) continue;
+      // Los abonos a capital no cargan los restantes de la cuota
+      if (p.validationStatus === "capital" || p.validationStatus === "capital_validated") continue;
+      // Si la fila ya no tiene restantes (cuota cubierta esperando validación de
+      // un cierre pendiente), no hay "restantes actuales" que señalar
+      const restantesCuota =
+        Number(p.capital_restante ?? 0) +
+        Number(p.interes_restante ?? 0) +
+        Number(p.iva_12_restante ?? 0) +
+        Number(p.seguro_restante ?? 0) +
+        Number(p.gps_restante ?? 0);
+      if (restantesCuota <= 0) continue;
+      const fecha = new Date(p.fecha_aplicado).getTime();
+      const actual = porCuota.get(p.numero_cuota);
+      if (!actual || fecha > actual.fecha || (fecha === actual.fecha && p.pago_id > actual.pago_id)) {
+        porCuota.set(p.numero_cuota, { pago_id: p.pago_id, fecha });
+      }
+    }
+    return new Set([...porCuota.values()].map((v) => v.pago_id));
+  }, [pagosFiltrados]);
+
   return (
     <div className="fixed inset-x-0 top-16 xl:top-20 bottom-0 flex flex-col items-center justify-start bg-gradient-to-br from-blue-50 to-white px-2 overflow-auto pt-8 pb-8">
       <div className="w-full max-w-[1600px] mx-auto">
@@ -744,6 +772,11 @@ const handleDownloadExcel = async () => {
                       </TableCell>
                       <TableCell className="text-center text-green-700 font-bold">
                         {formatCurrency(item.pago.monto_aplicado)}
+                        {ultimosAplicados.has(item.pago.pago_id) && (
+                          <span className="block mx-auto mt-1 w-fit px-2 py-0.5 rounded-full bg-emerald-100 text-emerald-700 text-xs font-bold whitespace-nowrap">
+                            Último aplicado · restantes actuales
+                          </span>
+                        )}
                       </TableCell>
                       <TableCell className="text-center font-semibold">
                         {formatDate(item.pago.fecha_pago)}

--- a/apps/crm/apps/server/src/lib/orpc.ts
+++ b/apps/crm/apps/server/src/lib/orpc.ts
@@ -261,6 +261,35 @@ const requireClosedCreditsReport = o.middleware(async ({ context, next }) => {
 	});
 });
 
+const requireCobranzaReport = o.middleware(async ({ context, next }) => {
+	if (!context.session?.user) {
+		throw new ORPCError("UNAUTHORIZED");
+	}
+
+	const userId = context.session.user.id;
+	const userData = await db
+		.select()
+		.from(user)
+		.where(eq(user.id, userId))
+		.limit(1);
+	const userRole = userData[0]?.role;
+
+	if (!PERMISSIONS.canAccessCobranzaReport(userRole)) {
+		throw new ORPCError("FORBIDDEN", {
+			message: "Cobranza report access required",
+		});
+	}
+
+	return next({
+		context: {
+			session: context.session,
+			user: userData[0],
+			userId,
+			userRole,
+		},
+	});
+});
+
 const requireTiempoCierreReport = o.middleware(async ({ context, next }) => {
 	if (!context.session?.user) {
 		throw new ORPCError("UNAUTHORIZED");
@@ -598,6 +627,7 @@ export const cobrosSupervisorProcedure = publicProcedure.use(
 export const closedCreditsReportProcedure = publicProcedure.use(
 	requireClosedCreditsReport,
 );
+export const cobranzaReportProcedure = publicProcedure.use(requireCobranzaReport);
 export const tiempoCierreReportProcedure = publicProcedure.use(
 	requireTiempoCierreReport,
 );

--- a/apps/crm/apps/server/src/lib/roles.test.ts
+++ b/apps/crm/apps/server/src/lib/roles.test.ts
@@ -23,3 +23,14 @@ describe("taller role permissions", () => {
 		expect(PERMISSIONS.canAccessVehicles(ROLES.INVESTMENT_MANAGER)).toBe(false);
 	});
 });
+
+describe("cobranza report permissions", () => {
+	it("limits the cobranza report to admin and cobros supervisors", () => {
+		expect(PERMISSIONS.canAccessCobranzaReport(ROLES.ADMIN)).toBe(true);
+		expect(PERMISSIONS.canAccessCobranzaReport(ROLES.COBROS_SUPERVISOR)).toBe(
+			true,
+		);
+		expect(PERMISSIONS.canAccessCobranzaReport(ROLES.COBROS)).toBe(false);
+		expect(PERMISSIONS.canAccessCobranzaReport(ROLES.ANALYST)).toBe(false);
+	});
+});

--- a/apps/crm/apps/server/src/lib/roles.ts
+++ b/apps/crm/apps/server/src/lib/roles.ts
@@ -162,6 +162,9 @@ export const PERMISSIONS = {
 	canAccessClosedCreditsReport: (role: UserRole | string): boolean =>
 		role === ROLES.ADMIN || role === ROLES.COBROS_SUPERVISOR,
 
+	canAccessCobranzaReport: (role: UserRole | string): boolean =>
+		role === ROLES.ADMIN || role === ROLES.COBROS_SUPERVISOR,
+
 	canAccessTiempoCierreReport: (role: UserRole | string): boolean =>
 		role === ROLES.ADMIN || role === ROLES.SALES_SUPERVISOR,
 

--- a/apps/crm/apps/server/src/routers/cobros.moraRecuperacion.test.ts
+++ b/apps/crm/apps/server/src/routers/cobros.moraRecuperacion.test.ts
@@ -1,0 +1,99 @@
+import { describe, expect, mock, test } from "bun:test";
+import { os } from "@orpc/server";
+
+const response = {
+	periodo: { inicio: "2026-06-06", fin: "2026-07-06" },
+	metadata: {
+		alcance: "historico" as const,
+		atribucionAsesor: "actual" as const,
+	},
+	totales: {
+		esperado: "150.00",
+		cobradoEnSnapshot: "90.00",
+		cobradoFueraSnapshot: "10.00",
+		excedenteEnSnapshot: "0.00",
+		pendiente: "60.00",
+	},
+	porAsesor: [
+		{
+			asesorId: null,
+			nombre: "Sin asignar",
+			esperado: "50.00",
+			cobradoEnSnapshot: "20.00",
+			cobradoFueraSnapshot: "0.00",
+			excedenteEnSnapshot: "0.00",
+			pendiente: "30.00",
+		},
+	],
+};
+const getMoraRecuperacionPorAsesor = mock(async () => response);
+const procedure = os.$context<Record<string, never>>();
+
+mock.module("@cci/email", () => ({ sendPlainEmail: mock() }));
+mock.module("@repo/sms", () => ({ SMSClient: class {} }));
+mock.module("../lib/orpc", () => ({
+	adminProcedure: procedure,
+	analystProcedure: procedure,
+	closedCreditsReportProcedure: procedure,
+	cobrosProcedure: procedure,
+	cobrosSupervisorProcedure: procedure,
+	crmCobrosOrInvestmentsProcedure: procedure,
+	crmOrCobrosProcedure: procedure,
+	crmProcedure: procedure,
+	efectividadPorEtapaReportProcedure: procedure,
+	juridicoProcedure: procedure,
+	metaColocacionReportProcedure: procedure,
+	protectedProcedure: procedure,
+	publicProcedure: procedure,
+	tallerOrCrmProcedure: procedure,
+	tallerProcedure: procedure,
+	tiempoCierreReportProcedure: procedure,
+	vehiclesProcedure: procedure,
+	viewOpportunityContractsProcedure: procedure,
+}));
+mock.module("../lib/simpletech", () => ({
+	sendWhatsappTemplate: mock(),
+	sendWhatsappTemplateBatch: mock(),
+}));
+mock.module("../db", () => ({
+	db: {
+		select: () => ({
+			from: () => ({
+				where: () => ({ limit: async () => [{ role: "COBROS_SUPERVISOR" }] }),
+			}),
+		}),
+	},
+}));
+mock.module("../services/cartera-back-client", () => ({
+	carteraBackClient: { getMoraRecuperacionPorAsesor },
+}));
+mock.module("../services/cartera-back-integration", () => ({
+	createPagoInCarteraBack: mock(),
+	getCreditoReferenceByNumeroSifco: mock(),
+	isCarteraBackEnabled: () => true,
+	isCarteraBackPaymentsEnabled: () => true,
+}));
+
+const { call } = await import("@orpc/server");
+const { cobrosRouter } = await import("./cobros");
+
+describe("cobrosRouter.getMoraRecuperacionPorAsesor", () => {
+	test("transmite el input validado y conserva el shape de cartera-back", async () => {
+		const input = {
+			mes: 6,
+			anio: 2026,
+			asesores: [7, 8],
+			emailCobrador: "cashin@example.com",
+		};
+
+		const output = await call(
+			cobrosRouter.getMoraRecuperacionPorAsesor,
+			input,
+			{
+				context: { headers: new Headers(), session: null },
+			},
+		);
+		expect(output).toEqual(response);
+		expect(getMoraRecuperacionPorAsesor).toHaveBeenCalledWith(input);
+	});
+});

--- a/apps/crm/apps/server/src/routers/cobros.ts
+++ b/apps/crm/apps/server/src/routers/cobros.ts
@@ -4059,6 +4059,24 @@ export const cobrosRouter = {
 			});
 		}),
 
+	getMoraRecuperacionPorAsesor: cobrosSupervisorProcedure
+		.input(
+			z.object({
+				mes: z.number(),
+				anio: z.number(),
+				asesores: z.array(z.number()).optional(),
+				emailCobrador: z.string().optional(),
+			}),
+		)
+		.handler(async ({ input }) => {
+			if (!isCarteraBackEnabled()) {
+				throw new ORPCError("BAD_REQUEST", {
+					message: "Integración con cartera-back no está habilitada",
+				});
+			}
+			return carteraBackClient.getMoraRecuperacionPorAsesor(input);
+		}),
+
 	// ========================================================================
 	// CUOTAS POR FECHA (reemplaza Pagos Esperados + Pagos No Recibidos)
 	// ========================================================================

--- a/apps/crm/apps/server/src/routers/index.ts
+++ b/apps/crm/apps/server/src/routers/index.ts
@@ -173,6 +173,7 @@ export const cobrosAppRouter = {
 	// CRM Cobros — nuevas vistas
 	getMoraByEtapaYAsesor: cobrosRouter.getMoraByEtapaYAsesor,
 	getMoraCobradaPorAsesor: cobrosRouter.getMoraCobradaPorAsesor,
+	getMoraRecuperacionPorAsesor: cobrosRouter.getMoraRecuperacionPorAsesor,
 	getCuotasPorFecha: cobrosRouter.getCuotasPorFecha,
 	getCobranzaDiaria: cobrosRouter.getCobranzaDiaria,
 	getCobranzaDiariaDetalle: cobrosRouter.getCobranzaDiariaDetalle,

--- a/apps/crm/apps/server/src/routers/reportes-cartera.ts
+++ b/apps/crm/apps/server/src/routers/reportes-cartera.ts
@@ -15,7 +15,7 @@ import {
 	gtDateStrToDate,
 } from "../lib/guatemala-month-window";
 import { calcularDiasMoraExactos } from "../lib/mora-utils";
-import { adminProcedure } from "../lib/orpc";
+import { adminProcedure, cobranzaReportProcedure } from "../lib/orpc";
 import {
 	carteraBackClient,
 	type FacturacionMesResponse,
@@ -444,7 +444,7 @@ export const reportesCarteraRouter = {
 	// REPORTE: MONTO A COBRARSE POR PERÍODO (lógica cartera web, con acumulado)
 	// ========================================================================
 
-	getMontoACobrarPeriodo: adminProcedure
+	getMontoACobrarPeriodo: cobranzaReportProcedure
 		.input(
 			z.object({
 				periodo: z
@@ -474,7 +474,7 @@ export const reportesCarteraRouter = {
 	// REPORTE: FACTURADO DEL MES VS ESPERADO
 	// ========================================================================
 
-	getFacturacionMes: adminProcedure
+	getFacturacionMes: cobranzaReportProcedure
 		.input(
 			z.object({
 				mes: z.number().min(1).max(12),

--- a/apps/crm/apps/server/src/routers/reportes-cartera.ts
+++ b/apps/crm/apps/server/src/routers/reportes-cartera.ts
@@ -27,6 +27,14 @@ import {
 } from "../services/cartera-back-client";
 import { isCarteraBackEnabled } from "../services/cartera-back-integration";
 
+export function fetchReinvestmentLiquidaciones(
+	input: { mes: number; anio: number },
+	client: Pick<typeof carteraBackClient, "getReinversionLiquidaciones"> =
+		carteraBackClient,
+) {
+	return client.getReinversionLiquidaciones(input);
+}
+
 export const reportesCarteraRouter = {
 	// ========================================================================
 	// REPORTE DE CARTERA COMPLETO
@@ -532,7 +540,7 @@ export const reportesCarteraRouter = {
 				});
 			}
 
-			return carteraBackClient.getReinversionLiquidaciones({
+			return fetchReinvestmentLiquidaciones({
 				mes: input.mes,
 				anio: input.anio,
 			});

--- a/apps/crm/apps/server/src/routers/reports.authorization.test.ts
+++ b/apps/crm/apps/server/src/routers/reports.authorization.test.ts
@@ -1,0 +1,122 @@
+import { call } from "@orpc/server";
+import { describe, expect, mock, test } from "bun:test";
+import { ROLES } from "../lib/roles";
+
+let currentRole: (typeof ROLES)[keyof typeof ROLES] = ROLES.ADMIN;
+
+mock.module("../db", () => ({
+	db: {
+		select: () => ({
+			from: () => ({
+				where: () => ({
+					limit: async () => [{ id: "test-user", role: currentRole }],
+				}),
+			}),
+		}),
+	},
+}));
+
+mock.module("../services/cartera-back-integration", () => ({
+	isCarteraBackEnabled: () => true,
+}));
+
+mock.module("../services/cartera-back-client", () => ({
+	carteraBackClient: {
+		getMontoACobrarPeriodo: async () => [],
+		getFacturacionMes: async () => ({
+			cobrado: {
+				interes: "0",
+				membresias: "0",
+				seguro_gps: "0",
+				royalti: "0",
+				mora: "0",
+				otros: "0",
+			},
+			esperado: { meta_mensual: "0" },
+		}),
+		getFlujoCuotasInversiones: async () => ({}),
+	},
+}));
+
+const contextForCurrentRole = () =>
+	({
+		context: { session: { user: { id: "test-user" } } },
+	}) as never;
+
+const { adminProcedure } = await import("../lib/orpc");
+const { getDashboardExecutivo } = await import("./reports");
+const { reportesCarteraRouter } = await import("./reportes-cartera");
+
+describe("report authorization", () => {
+	test("allows admins through the administrative middleware", async () => {
+		currentRole = ROLES.ADMIN;
+		const procedure = adminProcedure.handler(() => "allowed");
+
+		await expect(call(procedure, undefined, contextForCurrentRole())).resolves.toBe(
+			"allowed",
+		);
+	});
+
+	test("allows a cobros supervisor only through the two Cobranza endpoints", async () => {
+		currentRole = ROLES.COBROS_SUPERVISOR;
+
+		await expect(
+			call(
+				reportesCarteraRouter.getMontoACobrarPeriodo,
+				{ periodo: "mes", fechaInicio: "2026-07-01", fechaFin: "2026-07-31" },
+				contextForCurrentRole(),
+			),
+		).resolves.toEqual({ data: [] });
+		await expect(
+			call(
+				reportesCarteraRouter.getFacturacionMes,
+				{ mes: 7, anio: 2026 },
+				contextForCurrentRole(),
+			),
+		).resolves.toEqual({
+			cobrado: {
+				interes: "0",
+				membresias: "0",
+				seguro_gps: "0",
+				royalti: "0",
+				mora: "0",
+				otros: "0",
+			},
+			esperado: { meta_mensual: "0" },
+		});
+		await expect(
+			call(
+				reportesCarteraRouter.getFlujoCuotasInversiones,
+				{ fechaInicio: "2026-07-01", fechaFin: "2026-07-31" },
+				contextForCurrentRole(),
+			),
+		).rejects.toMatchObject({ code: "FORBIDDEN" });
+	});
+
+	test("rejects a cobros supervisor from the executive dashboard", async () => {
+		currentRole = ROLES.COBROS_SUPERVISOR;
+
+		await expect(
+			call(getDashboardExecutivo, {}, contextForCurrentRole()),
+		).rejects.toMatchObject({ code: "FORBIDDEN" });
+	});
+
+	test("rejects non-supervisor roles from both Cobranza endpoints", async () => {
+		currentRole = ROLES.ANALYST;
+
+		await expect(
+			call(
+				reportesCarteraRouter.getMontoACobrarPeriodo,
+				{ periodo: "mes", fechaInicio: "2026-07-01", fechaFin: "2026-07-31" },
+				contextForCurrentRole(),
+			),
+		).rejects.toMatchObject({ code: "FORBIDDEN" });
+		await expect(
+			call(
+				reportesCarteraRouter.getFacturacionMes,
+				{ mes: 7, anio: 2026 },
+				contextForCurrentRole(),
+			),
+		).rejects.toMatchObject({ code: "FORBIDDEN" });
+	});
+});

--- a/apps/crm/apps/server/src/routers/reports.ts
+++ b/apps/crm/apps/server/src/routers/reports.ts
@@ -25,6 +25,7 @@ import {
 	type LeadSourceChannelType,
 } from "../lib/lead-sources";
 import {
+	adminProcedure,
 	closedCreditsReportProcedure,
 	efectividadPorEtapaReportProcedure,
 	metaColocacionReportProcedure,
@@ -248,7 +249,7 @@ function parseGuatemalaDateRange(startDate: string, endDate: string) {
  * Dashboard Ejecutivo
  * KPIs principales del negocio
  */
-export const getDashboardExecutivo = protectedProcedure
+export const getDashboardExecutivo = adminProcedure
 	.input(dateRangeSchema)
 	.handler(async () => {
 		// KPI 1: Cartera total activa

--- a/apps/crm/apps/server/src/services/cartera-back-client.moraRecuperacion.test.ts
+++ b/apps/crm/apps/server/src/services/cartera-back-client.moraRecuperacion.test.ts
@@ -1,0 +1,61 @@
+import { afterEach, describe, expect, test } from "bun:test";
+import { clearCarteraTokens } from "./cartera-auth.service";
+import { CarteraBackClient } from "./cartera-back-client";
+
+const originalFetch = globalThis.fetch;
+const originalCarteraUser = process.env.CARTERA_USER;
+const originalCarteraPassword = process.env.CARTERA_PASSWORD;
+
+afterEach(() => {
+	globalThis.fetch = originalFetch;
+	clearCarteraTokens();
+	process.env.CARTERA_USER = originalCarteraUser;
+	process.env.CARTERA_PASSWORD = originalCarteraPassword;
+});
+
+describe("CarteraBackClient.getMoraRecuperacionPorAsesor", () => {
+	test("serializa el ciclo y filtros del reporte antes del límite de red", async () => {
+		const requests: string[] = [];
+		globalThis.fetch = Object.assign(
+			async (input: RequestInfo | URL) => {
+				const url = String(input);
+				requests.push(url);
+				if (url.endsWith("/auth/login")) {
+					return Response.json({
+						data: { accessToken: "test-token", refreshToken: "test-refresh" },
+					});
+				}
+				return Response.json({
+					periodo: { inicio: "2026-06-06", fin: "2026-07-06" },
+					metadata: { alcance: "historico", atribucionAsesor: "actual" },
+					totales: {
+						esperado: "0.00",
+						cobradoEnSnapshot: "0.00",
+						cobradoFueraSnapshot: "0.00",
+						excedenteEnSnapshot: "0.00",
+						pendiente: "0.00",
+					},
+					porAsesor: [],
+				});
+			},
+			{ preconnect: originalFetch.preconnect },
+		);
+		process.env.CARTERA_USER = "test@example.com";
+		process.env.CARTERA_PASSWORD = "secret";
+
+		await new CarteraBackClient({
+			baseUrl: "http://cartera.test",
+			retryAttempts: 0,
+		}).getMoraRecuperacionPorAsesor({
+			mes: 6,
+			anio: 2026,
+			asesores: [7, 8],
+			emailCobrador: "cashin@example.com",
+		});
+
+		expect(requests).toEqual([
+			"http://localhost:7000/auth/login",
+			"http://cartera.test/reportes/mora-recuperacion-por-asesor?mes=6&anio=2026&asesores=7%2C8&email_cobrador=cashin%40example.com",
+		]);
+	});
+});

--- a/apps/crm/apps/server/src/services/cartera-back-client.reinvestment.test.ts
+++ b/apps/crm/apps/server/src/services/cartera-back-client.reinvestment.test.ts
@@ -3,6 +3,12 @@ import { fetchReinvestmentLiquidaciones } from "../routers/reportes-cartera";
 import type { ReinversionLiquidacionesResponse } from "./cartera-back-client";
 import { CarteraBackClient } from "./cartera-back-client";
 
+const fetchTransport = (
+	handler: (
+		...args: Parameters<typeof globalThis.fetch>
+	) => ReturnType<typeof globalThis.fetch>,
+) => Object.assign(handler, { preconnect: globalThis.fetch.preconnect });
+
 const response = (): ReinversionLiquidacionesResponse => ({
 	contrato_version: 2,
 	porTipo: {
@@ -21,8 +27,7 @@ const response = (): ReinversionLiquidacionesResponse => ({
 		},
 	},
 	interesNeto: {
-		conFactura: { interes: "0.00", iva: "0.00", neto: "0.00" },
-		sinFactura: { interes: "5.00", isr: "0.35", neto: "4.65" },
+		noVerificado: { interes: "5.00" },
 		cube: { interes: "0.00", iva: "0.00", neto: "0.00" },
 	},
 	pagosExtras: { abonos_capital: "0.00", cancelaciones: "0.00" },
@@ -35,23 +40,19 @@ const response = (): ReinversionLiquidacionesResponse => ({
 			reinversion_interes: "0.00",
 			reinversion: "40.00",
 			a_recibir: "4.65",
-			monto_aportado: "960.00",
 			capital_activo: "1000.00",
 		},
 	],
-	comprasMes: [
-		{ tipo: "reinversion_capital", cantidad: 2, monto: "80.00" },
-	],
+	comprasMes: [{ tipo: "reinversion_capital", cantidad: 2, monto: "80.00" }],
 	detalleInteresNeto: [
 		{
 			inversionista_id: 7,
 			inversionista: "Ana",
 			referencia: "LIQ-7",
-			tratamiento_fiscal: "sin_factura",
+			tratamiento_fiscal: "no_verificado",
 			interes: "5.00",
 			iva: "0.00",
-			isr: "0.35",
-			neto: "4.65",
+			isr: "0.00",
 		},
 	],
 	detallePagosExtras: [],
@@ -69,7 +70,10 @@ const response = (): ReinversionLiquidacionesResponse => ({
 			monto: "40.00",
 		},
 	],
-	detalle_estado: { disponible: false, error: "Detalle temporalmente no disponible." },
+	detalle_estado: {
+		disponible: false,
+		error: "Detalle temporalmente no disponible.",
+	},
 	cantidad_liquidaciones: 1,
 });
 
@@ -83,13 +87,13 @@ test("cliente HTTP propaga íntegro el contrato real de reinversión sin reconst
 		baseUrl: "https://cartera.test",
 		retryAttempts: 0,
 		accessTokenProvider: async () => "test-token",
-		fetchTransport: async (input, init) => {
+		fetchTransport: fetchTransport(async (input, init) => {
 			requestedUrl = String(input);
 			requestedMethod = init?.method ?? "";
 			authorization = new Headers(init?.headers).get("authorization") ?? "";
 			requestedBody = init?.body;
 			return Response.json(expected);
-		},
+		}),
 	});
 	const actual = await client.getReinversionLiquidaciones({
 		mes: 7,
@@ -118,7 +122,7 @@ test("router CRM devuelve sin pérdida el contrato recibido de cartera-back", as
 		baseUrl: "https://cartera.test",
 		retryAttempts: 0,
 		accessTokenProvider: async () => "router-test-token",
-		fetchTransport: async () => Response.json(expected),
+		fetchTransport: fetchTransport(async () => Response.json(expected)),
 	});
 	const actual = await fetchReinvestmentLiquidaciones(
 		{ mes: 7, anio: 2026 },
@@ -141,14 +145,74 @@ test("error total de cartera-back se propaga y no se convierte en datos parciale
 		baseUrl: "https://cartera.test",
 		retryAttempts: 0,
 		accessTokenProvider: async () => "error-test-token",
-		fetchTransport: async () =>
+		fetchTransport: fetchTransport(async () =>
 			Response.json(
 				{ error: "No fue posible generar el reporte" },
 				{ status: 503 },
 			),
+		),
 	});
 
 	await expect(
 		fetchReinvestmentLiquidaciones({ mes: 7, anio: 2026 }, client),
 	).rejects.toThrow("No fue posible generar el reporte");
+});
+
+test("cliente HTTP rechaza un contrato malformado antes de republicarlo por ORPC", async () => {
+	const malformed = response() as unknown as Record<string, unknown>;
+	malformed.cantidad_liquidaciones = -1;
+	const client = new CarteraBackClient({
+		baseUrl: "https://cartera.test",
+		retryAttempts: 0,
+		accessTokenProvider: async () => "test-token",
+		fetchTransport: fetchTransport(async () => Response.json(malformed)),
+	});
+
+	await expect(
+		client.getReinversionLiquidaciones({ mes: 7, anio: 2026 }),
+	).rejects.toThrow("Contrato de reinversión inválido");
+});
+
+test("cliente HTTP rechaza categorías, ids, cantidades, montos y estados de detalle inválidos", async () => {
+	const invalid = [
+		(data: Record<string, unknown>) => {
+			data.porTipo = { inventado: response().porTipo.reinversion_capital };
+		},
+		(data: Record<string, unknown>) => {
+			(data.porInversionista as Record<string, unknown>[])[0].inversionista_id =
+				1.5;
+		},
+		(data: Record<string, unknown>) => {
+			(data.comprasMes as Record<string, unknown>[])[0].cantidad = -1;
+		},
+		(data: Record<string, unknown>) => {
+			(data.pagosExtras as Record<string, unknown>).abonos_capital = "-0.01";
+		},
+		(data: Record<string, unknown>) => {
+			(data.pagosExtras as Record<string, unknown>).abonos_capital = "1e2";
+		},
+		(data: Record<string, unknown>) => {
+			(data.pagosExtras as Record<string, unknown>).abonos_capital = "0x10";
+		},
+		(data: Record<string, unknown>) => {
+			data.detalle_estado = { disponible: true, error: "contradictorio" };
+		},
+		(data: Record<string, unknown>) => {
+			data.detalle_estado = { disponible: false, error: " " };
+		},
+	];
+
+	for (const mutate of invalid) {
+		const malformed = response() as unknown as Record<string, unknown>;
+		mutate(malformed);
+		const client = new CarteraBackClient({
+			baseUrl: "https://cartera.test",
+			retryAttempts: 0,
+			accessTokenProvider: async () => "test-token",
+			fetchTransport: fetchTransport(async () => Response.json(malformed)),
+		});
+		await expect(
+			client.getReinversionLiquidaciones({ mes: 7, anio: 2026 }),
+		).rejects.toThrow("Contrato de reinversión inválido");
+	}
 });

--- a/apps/crm/apps/server/src/services/cartera-back-client.reinvestment.test.ts
+++ b/apps/crm/apps/server/src/services/cartera-back-client.reinvestment.test.ts
@@ -1,0 +1,151 @@
+import { expect, test } from "bun:test";
+import { fetchReinvestmentLiquidaciones } from "../routers/reportes-cartera";
+import type { ReinversionLiquidacionesResponse } from "./cartera-back-client";
+import { CarteraBackClient } from "./cartera-back-client";
+
+const response = (): ReinversionLiquidacionesResponse => ({
+	contrato_version: 2,
+	porTipo: {
+		reinversion_capital: {
+			reinversion_capital: "40.00",
+			reinversion_interes: "0.00",
+			reinversion_total: "40.00",
+			total_capital: "40.00",
+			total_interes: "5.00",
+			total_iva: "0.00",
+			total_isr: "0.35",
+			total_cuota: "4.65",
+			iva_facturado: "0.00",
+			total_distribuido: "44.65",
+		},
+	},
+	interesNeto: {
+		conFactura: { interes: "0.00", iva: "0.00", neto: "0.00" },
+		sinFactura: { interes: "5.00", isr: "0.35", neto: "4.65" },
+		cube: { interes: "0.00", iva: "0.00", neto: "0.00" },
+	},
+	pagosExtras: { abonos_capital: "0.00", cancelaciones: "0.00" },
+	porInversionista: [
+		{
+			inversionista_id: 7,
+			nombre: "Ana",
+			tipo_reinversion: "reinversion_capital",
+			reinversion_capital: "40.00",
+			reinversion_interes: "0.00",
+			reinversion: "40.00",
+			a_recibir: "4.65",
+			monto_aportado: "960.00",
+			capital_activo: "1000.00",
+		},
+	],
+	comprasMes: [
+		{ tipo: "reinversion_capital", cantidad: 2, monto: "80.00" },
+	],
+	detalleInteresNeto: [
+		{
+			inversionista_id: 7,
+			inversionista: "Ana",
+			referencia: "LIQ-7",
+			tratamiento_fiscal: "sin_factura",
+			interes: "5.00",
+			iva: "0.00",
+			isr: "0.35",
+			neto: "4.65",
+		},
+	],
+	detallePagosExtras: [],
+	detalleComprasMes: [
+		{
+			fecha: "2026-07-03",
+			inversionista: "Ana",
+			modalidad: "reinversion_capital",
+			monto: "40.00",
+		},
+		{
+			fecha: "2026-07-03",
+			inversionista: "Ana",
+			modalidad: "reinversion_capital",
+			monto: "40.00",
+		},
+	],
+	detalle_estado: { disponible: false, error: "Detalle temporalmente no disponible." },
+	cantidad_liquidaciones: 1,
+});
+
+test("cliente HTTP propaga íntegro el contrato real de reinversión sin reconstruir detalles", async () => {
+	const expected = response();
+	let requestedUrl = "";
+	let requestedMethod = "";
+	let authorization = "";
+	let requestedBody: BodyInit | null | undefined;
+	const client = new CarteraBackClient({
+		baseUrl: "https://cartera.test",
+		retryAttempts: 0,
+		accessTokenProvider: async () => "test-token",
+		fetchTransport: async (input, init) => {
+			requestedUrl = String(input);
+			requestedMethod = init?.method ?? "";
+			authorization = new Headers(init?.headers).get("authorization") ?? "";
+			requestedBody = init?.body;
+			return Response.json(expected);
+		},
+	});
+	const actual = await client.getReinversionLiquidaciones({
+		mes: 7,
+		anio: 2026,
+	});
+
+	expect(actual).toEqual(expected);
+	expect(actual.contrato_version).toBe(2);
+	expect(actual.porInversionista[0]?.capital_activo).toBe("1000.00");
+	expect(actual.detalle_estado).toEqual(expected.detalle_estado);
+	expect(actual.detalleInteresNeto).toEqual(expected.detalleInteresNeto);
+	expect(actual.detallePagosExtras).toEqual(expected.detallePagosExtras);
+	expect(actual.detalleComprasMes).toEqual(expected.detalleComprasMes);
+	expect(requestedUrl).toBe(
+		"https://cartera.test/reportes/reinversion-liquidaciones?mes=7&anio=2026",
+	);
+	expect(requestedMethod).toBe("GET");
+	expect(authorization).toBe("Bearer test-token");
+	expect(requestedBody).toBeUndefined();
+});
+
+test("router CRM devuelve sin pérdida el contrato recibido de cartera-back", async () => {
+	const expected = response();
+	const client = new CarteraBackClient({
+		baseUrl: "https://cartera.test",
+		retryAttempts: 0,
+		accessTokenProvider: async () => "router-test-token",
+		fetchTransport: async () => Response.json(expected),
+	});
+	const actual = await fetchReinvestmentLiquidaciones(
+		{ mes: 7, anio: 2026 },
+		client,
+	);
+
+	expect(actual).toEqual(expected);
+	expect(actual.comprasMes[0]).toMatchObject({
+		cantidad: 2,
+		monto: "80.00",
+	});
+	expect(actual.detalleComprasMes).toHaveLength(2);
+	expect(actual.porInversionista[0]?.capital_activo).toBe("1000.00");
+	expect(actual.detalle_estado.disponible).toBe(false);
+});
+
+test("error total de cartera-back se propaga y no se convierte en datos parciales", async () => {
+	const client = new CarteraBackClient({
+		baseUrl: "https://cartera.test",
+		retryAttempts: 0,
+		accessTokenProvider: async () => "error-test-token",
+		fetchTransport: async () =>
+			Response.json(
+				{ error: "No fue posible generar el reporte" },
+				{ status: 503 },
+			),
+	});
+
+	await expect(
+		fetchReinvestmentLiquidaciones({ mes: 7, anio: 2026 }, client),
+	).rejects.toThrow("No fue posible generar el reporte");
+});

--- a/apps/crm/apps/server/src/services/cartera-back-client.reinvestment.test.ts
+++ b/apps/crm/apps/server/src/services/cartera-back-client.reinvestment.test.ts
@@ -17,6 +17,7 @@ const response = (): ReinversionLiquidacionesResponse => ({
 			total_cuota: "4.65",
 			iva_facturado: "0.00",
 			total_distribuido: "44.65",
+			cantidad_liquidaciones: 1,
 		},
 	},
 	interesNeto: {
@@ -102,6 +103,7 @@ test("cliente HTTP propaga íntegro el contrato real de reinversión sin reconst
 	expect(actual.detalleInteresNeto).toEqual(expected.detalleInteresNeto);
 	expect(actual.detallePagosExtras).toEqual(expected.detallePagosExtras);
 	expect(actual.detalleComprasMes).toEqual(expected.detalleComprasMes);
+	expect(actual.porTipo.reinversion_capital.cantidad_liquidaciones).toBe(1);
 	expect(requestedUrl).toBe(
 		"https://cartera.test/reportes/reinversion-liquidaciones?mes=7&anio=2026",
 	);
@@ -131,6 +133,7 @@ test("router CRM devuelve sin pérdida el contrato recibido de cartera-back", as
 	expect(actual.detalleComprasMes).toHaveLength(2);
 	expect(actual.porInversionista[0]?.capital_activo).toBe("1000.00");
 	expect(actual.detalle_estado.disponible).toBe(false);
+	expect(actual.porTipo.reinversion_capital.cantidad_liquidaciones).toBe(1);
 });
 
 test("error total de cartera-back se propaga y no se convierte en datos parciales", async () => {

--- a/apps/crm/apps/server/src/services/cartera-back-client.ts
+++ b/apps/crm/apps/server/src/services/cartera-back-client.ts
@@ -397,6 +397,7 @@ export type ReinversionLiquidacionesResponse = {
 			/** IVA real facturado; excluye el IVA referencial sin factura. */
 			iva_facturado: string;
 			total_distribuido: string;
+			cantidad_liquidaciones: number;
 		}
 	>;
 	/**

--- a/apps/crm/apps/server/src/services/cartera-back-client.ts
+++ b/apps/crm/apps/server/src/services/cartera-back-client.ts
@@ -104,6 +104,8 @@ interface CarteraBackClientConfig {
 	circuitBreakerTimeout: number;
 	enableCache: boolean;
 	cacheTtl: number;
+	accessTokenProvider: () => Promise<string>;
+	fetchTransport: typeof globalThis.fetch;
 }
 
 export interface ResumenGlobalInversionistasFilters {
@@ -124,6 +126,8 @@ const DEFAULT_CONFIG: CarteraBackClientConfig = {
 	circuitBreakerTimeout: 60000,
 	enableCache: process.env.CARTERA_BACK_ENABLE_CACHE === "true",
 	cacheTtl: Number.parseInt(process.env.CARTERA_BACK_CACHE_TTL || "300000"), // 5 minutes
+	accessTokenProvider: getCarteraAccessToken,
+	fetchTransport: globalThis.fetch,
 };
 
 // ============================================================================
@@ -373,11 +377,11 @@ export type FlujoCuotasInversionesResponse = {
 };
 
 export type ReinversionLiquidacionesResponse = {
+	/** Versión runtime del contrato de conciliación por modalidad. */
+	contrato_version: 2;
 	/**
-	 * Por modalidad (`tipo_reinversion`), campos crudos de la liquidación:
-	 * - `reinversion_total` → sección "Cuotas → Reinversión".
-	 * - `total_capital` / `total_interes` / `total_iva` / `total_isr` / `total_cuota`
-	 *   → sección "Cuotas → A Recibir".
+	 * Distribución mensual por modalidad. `total_cuota` es el pago neto y
+	 * `reinversion_total` el capital que permanece colocado.
 	 */
 	porTipo: Record<
 		string,
@@ -390,6 +394,9 @@ export type ReinversionLiquidacionesResponse = {
 			total_iva: string;
 			total_isr: string;
 			total_cuota: string;
+			/** IVA real facturado; excluye el IVA referencial sin factura. */
+			iva_facturado: string;
+			total_distribuido: string;
 		}
 	>;
 	/**
@@ -414,9 +421,36 @@ export type ReinversionLiquidacionesResponse = {
 		reinversion: string;
 		a_recibir: string;
 		monto_aportado: string;
+		capital_activo: string;
 	}[];
 	/** Compras del mes (operación de compra) agrupadas por modalidad de reinversión. */
 	comprasMes: { tipo: string; cantidad: number; monto: string }[];
+	detalleInteresNeto: {
+		inversionista_id: number;
+		inversionista: string;
+		referencia: string;
+		tratamiento_fiscal: "con_factura" | "sin_factura" | "cube";
+		interes: string;
+		iva: string;
+		isr: string;
+		neto: string;
+	}[];
+	detallePagosExtras: {
+		fecha: string;
+		credito: string;
+		tipo: "abono_capital" | "cancelacion";
+		monto: string;
+	}[];
+	detalleComprasMes: {
+		fecha: string;
+		inversionista: string;
+		modalidad: string;
+		monto: string;
+	}[];
+	detalle_estado: {
+		disponible: boolean;
+		error: string | null;
+	};
 	cantidad_liquidaciones: number;
 };
 
@@ -557,7 +591,7 @@ export class CarteraBackClient {
 		): Promise<RequestInit> => {
 			const token = forceRefresh
 				? await invalidateAndReauth()
-				: await getCarteraAccessToken();
+				: await this.config.accessTokenProvider();
 			return {
 				...options,
 				headers: {
@@ -576,7 +610,7 @@ export class CarteraBackClient {
 			try {
 				const response = await this.circuitBreaker.execute(async () => {
 					const requestOptions = await buildRequestOptions();
-					const res = await fetch(url, requestOptions);
+					const res = await this.config.fetchTransport(url, requestOptions);
 
 					if (!res.ok) {
 						const errorText = await res.text();
@@ -592,7 +626,10 @@ export class CarteraBackClient {
 							if (!didReauth) {
 								didReauth = true;
 								const retryOptions = await buildRequestOptions(true);
-								const retryRes = await fetch(url, retryOptions);
+								const retryRes = await this.config.fetchTransport(
+									url,
+									retryOptions,
+								);
 								if (retryRes.ok) return retryRes;
 								const retryText = await retryRes.text();
 								let retryData: { error?: string; message?: string } = {};

--- a/apps/crm/apps/server/src/services/cartera-back-client.ts
+++ b/apps/crm/apps/server/src/services/cartera-back-client.ts
@@ -328,6 +328,17 @@ export type MontoACobrarPeriodoRow = {
 	acum_total_membresias: string;
 	total_interes_inversionista: string;
 	acum_total_interes_inversionista: string;
+	capital_inv_participacion_actual: string;
+	capital_cube_participacion_actual: string;
+	interes_iva_inv_participacion_actual: string;
+	interes_iva_cube_participacion_actual: string;
+	acum_capital_inv_participacion_actual: string;
+	acum_capital_cube_participacion_actual: string;
+	acum_interes_iva_inv_participacion_actual: string;
+	acum_interes_iva_cube_participacion_actual: string;
+	creditos_participacion_invalida: number;
+	cuotas_participacion_invalida: number;
+	participacion_actual: boolean;
 };
 
 export type FlujoCuotasRubro = {

--- a/apps/crm/apps/server/src/services/cartera-back-client.ts
+++ b/apps/crm/apps/server/src/services/cartera-back-client.ts
@@ -337,6 +337,7 @@ export type MontoACobrarPeriodoRow = {
 	acum_interes_iva_inv_participacion_actual: string;
 	acum_interes_iva_cube_participacion_actual: string;
 	creditos_participacion_invalida: number;
+	creditos_participacion_invalida_rango?: number;
 	cuotas_participacion_invalida: number;
 	participacion_actual: boolean;
 };

--- a/apps/crm/apps/server/src/services/cartera-back-client.ts
+++ b/apps/crm/apps/server/src/services/cartera-back-client.ts
@@ -480,6 +480,27 @@ export type MoraCobradaPorAsesorResponse = {
 	totalCobrado: string;
 };
 
+export type MoraRecuperacionPorAsesorResponse = {
+	periodo: { inicio: string; fin: string };
+	metadata: {
+		alcance: "live" | "historico";
+		atribucionAsesor: "actual";
+	};
+	totales: MoraRecoveryMetric;
+	porAsesor: (MoraRecoveryMetric & {
+		asesorId: number | null;
+		nombre: string;
+	})[];
+};
+
+export type MoraRecoveryMetric = {
+	esperado: string;
+	cobradoEnSnapshot: string;
+	cobradoFueraSnapshot: string;
+	excedenteEnSnapshot: string;
+	pendiente: string;
+};
+
 // ============================================================================
 // HTTP CLIENT
 // ============================================================================
@@ -1783,6 +1804,27 @@ export class CarteraBackClient {
 		// "Actualizar" podría devolver un hit stale tras registrar/ajustar un pago.
 		return this.request<MoraCobradaPorAsesorResponse>(
 			`/reportes/mora-cobrada-por-asesor?${queryParams}`,
+			{ method: "GET" },
+			false,
+		);
+	}
+
+	async getMoraRecuperacionPorAsesor(params: {
+		mes: number;
+		anio: number;
+		asesores?: number[];
+		emailCobrador?: string;
+	}): Promise<MoraRecuperacionPorAsesorResponse> {
+		const queryParams = new URLSearchParams({
+			mes: String(params.mes),
+			anio: String(params.anio),
+		});
+		if (params.asesores?.length)
+			queryParams.set("asesores", params.asesores.join(","));
+		if (params.emailCobrador)
+			queryParams.set("email_cobrador", params.emailCobrador);
+		return this.request<MoraRecuperacionPorAsesorResponse>(
+			`/reportes/mora-recuperacion-por-asesor?${queryParams}`,
 			{ method: "GET" },
 			false,
 		);

--- a/apps/crm/apps/server/src/services/cartera-back-client.ts
+++ b/apps/crm/apps/server/src/services/cartera-back-client.ts
@@ -3,6 +3,7 @@
  * Type-safe HTTP client with retry logic, circuit breaker, and caching
  */
 
+import { z } from "zod";
 import type {
 	BoletaPagoInversionista,
 	CarteraAsesor,
@@ -400,14 +401,8 @@ export type ReinversionLiquidacionesResponse = {
 			cantidad_liquidaciones: number;
 		}
 	>;
-	/**
-	 * Interés neto agrupado por si el inversionista emite factura:
-	 * - `conFactura`: neto = interés + IVA.
-	 * - `sinFactura`: neto = interés − ISR.
-	 */
 	interesNeto: {
-		conFactura: { interes: string; iva: string; neto: string };
-		sinFactura: { interes: string; isr: string; neto: string };
+		noVerificado: { interes: string };
 		cube: { interes: string; iva: string; neto: string };
 	};
 	/** Pagos extras recibidos del mes (vía liquidación → pago espejo → abono). */
@@ -421,21 +416,31 @@ export type ReinversionLiquidacionesResponse = {
 		reinversion_interes: string;
 		reinversion: string;
 		a_recibir: string;
-		monto_aportado: string;
 		capital_activo: string;
 	}[];
 	/** Compras del mes (operación de compra) agrupadas por modalidad de reinversión. */
 	comprasMes: { tipo: string; cantidad: number; monto: string }[];
-	detalleInteresNeto: {
-		inversionista_id: number;
-		inversionista: string;
-		referencia: string;
-		tratamiento_fiscal: "con_factura" | "sin_factura" | "cube";
-		interes: string;
-		iva: string;
-		isr: string;
-		neto: string;
-	}[];
+	detalleInteresNeto: (
+		| {
+				inversionista_id: number;
+				inversionista: string;
+				referencia: string;
+				interes: string;
+				iva: string;
+				isr: string;
+				tratamiento_fiscal: "no_verificado";
+		  }
+		| {
+				inversionista_id: number;
+				inversionista: string;
+				referencia: string;
+				tratamiento_fiscal: "cube";
+				interes: string;
+				iva: string;
+				isr: string;
+				neto: string;
+		  }
+	)[];
 	detallePagosExtras: {
 		fecha: string;
 		credito: string;
@@ -454,6 +459,111 @@ export type ReinversionLiquidacionesResponse = {
 	};
 	cantidad_liquidaciones: number;
 };
+
+const reinversionModes = [
+	"sin_reinversion",
+	"reinversion_capital",
+	"reinversion_interes",
+	"reinversion_total",
+	"reinversion_variable",
+	"reinversion_excedente",
+	"reinversion_combinada",
+] as const;
+const moneySchema = z.string().regex(/^\d+(?:\.\d+)?$/);
+const countSchema = z.number().int().nonnegative();
+const idSchema = z.number().int().nonnegative();
+const modeSummarySchema = z.object({
+	reinversion_capital: moneySchema,
+	reinversion_interes: moneySchema,
+	reinversion_total: moneySchema,
+	total_capital: moneySchema,
+	total_interes: moneySchema,
+	total_iva: moneySchema,
+	total_isr: moneySchema,
+	total_cuota: moneySchema,
+	iva_facturado: moneySchema,
+	total_distribuido: moneySchema,
+	cantidad_liquidaciones: countSchema,
+});
+const reinversionLiquidacionesSchema = z.object({
+	contrato_version: z.literal(2),
+	porTipo: z.record(z.enum(reinversionModes), modeSummarySchema),
+	interesNeto: z.object({
+		noVerificado: z.object({ interes: moneySchema }),
+		cube: z.object({
+			interes: moneySchema,
+			iva: moneySchema,
+			neto: moneySchema,
+		}),
+	}),
+	pagosExtras: z.object({
+		abonos_capital: moneySchema,
+		cancelaciones: moneySchema,
+	}),
+	porInversionista: z.array(
+		z.object({
+			inversionista_id: idSchema,
+			nombre: z.string().trim().min(1),
+			tipo_reinversion: z.enum(reinversionModes),
+			reinversion_capital: moneySchema,
+			reinversion_interes: moneySchema,
+			reinversion: moneySchema,
+			a_recibir: moneySchema,
+			capital_activo: moneySchema,
+		}),
+	),
+	comprasMes: z.array(
+		z.object({
+			tipo: z.enum(reinversionModes),
+			cantidad: countSchema,
+			monto: moneySchema,
+		}),
+	),
+	detalleInteresNeto: z.array(
+		z.discriminatedUnion("tratamiento_fiscal", [
+			z.object({
+				inversionista_id: idSchema,
+				inversionista: z.string().trim().min(1),
+				referencia: z.string().trim().min(1),
+				tratamiento_fiscal: z.literal("no_verificado"),
+				interes: moneySchema,
+				iva: moneySchema,
+				isr: moneySchema,
+			}),
+			z.object({
+				inversionista_id: idSchema,
+				inversionista: z.string().trim().min(1),
+				referencia: z.string().trim().min(1),
+				tratamiento_fiscal: z.literal("cube"),
+				interes: moneySchema,
+				iva: moneySchema,
+				isr: moneySchema,
+				neto: moneySchema,
+			}),
+		]),
+	),
+	detallePagosExtras: z.array(
+		z.object({
+			fecha: z.string().trim().min(1),
+			credito: z.string().trim().min(1),
+			tipo: z.enum(["abono_capital", "cancelacion"]),
+			monto: moneySchema,
+		}),
+	),
+	detalleComprasMes: z.array(
+		z.object({
+			fecha: z.string().trim().min(1),
+			inversionista: z.string().trim().min(1),
+			modalidad: z.enum(reinversionModes),
+			monto: moneySchema,
+		}),
+	),
+	detalle_estado: z.discriminatedUnion("disponible", [
+		z.object({ disponible: z.literal(true), error: z.null() }),
+		z.object({ disponible: z.literal(false), error: z.string().trim().min(1) }),
+	]),
+	cantidad_liquidaciones: countSchema,
+});
 
 export type FlujoPorInversionistaRow = {
 	inversionista_id: number;
@@ -1792,11 +1902,14 @@ export class CarteraBackClient {
 		// Sin cache: el reporte debe reflejar liquidaciones recién creadas/ajustadas.
 		// Con cache activo, tras crear liquidaciones el mes podía seguir devolviendo
 		// los totales previos hasta expirar el TTL.
-		return this.request<ReinversionLiquidacionesResponse>(
+		const data = await this.request<unknown>(
 			`/reportes/reinversion-liquidaciones?${qp}`,
 			{ method: "GET" },
 			false,
 		);
+		const parsed = reinversionLiquidacionesSchema.safeParse(data);
+		if (!parsed.success) throw new Error("Contrato de reinversión inválido");
+		return parsed.data;
 	}
 
 	async getFlujoCuotasPorInversionista(params: {

--- a/apps/crm/apps/web/src/components/reports/reinvestment-report.tsx
+++ b/apps/crm/apps/web/src/components/reports/reinvestment-report.tsx
@@ -1,0 +1,799 @@
+import {
+	AlertCircle,
+	CheckCircle2,
+	ChevronDown,
+	Download,
+	X,
+} from "lucide-react";
+import { Fragment, type ReactNode, useId, useState } from "react";
+import { Button } from "@/components/ui/button";
+import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
+import {
+	Table,
+	TableBody,
+	TableCell,
+	TableHead,
+	TableHeader,
+	TableRow,
+} from "@/components/ui/table";
+import {
+	buildReinvestmentReportModel,
+	buildSecondarySummaryPresentation,
+	canRenderSecondaryDetails,
+	getMonthlyFooterPresentation,
+	getModePresentation,
+	getPublicPartialDetailMessage,
+	getReconciliationPresentation,
+	getReportState,
+	REGISTERED_ZERO_ACTIVITY_COPY,
+} from "@/lib/reports/reinvestment-report";
+import type {
+	DestinationFormula,
+	ReinvestmentModeRow,
+} from "@/lib/reports/reinvestment-report";
+import type { ReinversionLiquidacionesResponse } from "@/lib/reports/scenario";
+
+type DetailKey = "interest" | "extras" | "purchases";
+
+export function ReinvestmentReport({
+	data,
+	isPending,
+	isError,
+	periodLabel,
+	onRetry,
+	onExportInvestors,
+}: {
+	data?: unknown;
+	isPending: boolean;
+	isError: boolean;
+	periodLabel: string;
+	onRetry: () => void;
+	onExportInvestors?: () => void;
+}) {
+	const [showInvestors, setShowInvestors] = useState(false);
+	const [detail, setDetail] = useState<DetailKey | null>(null);
+	const [selectedMode, setSelectedMode] = useState<string | null>(null);
+	const detailId = useId();
+	const state = getReportState({
+		pending: isPending,
+		error: isError,
+		data,
+	});
+
+	if (state === "loading")
+		return (
+			<div className="py-14 text-center text-muted-foreground" aria-live="polite">
+				Cargando distribución de {periodLabel}…
+			</div>
+		);
+	if (state === "error" || state === "incompatible")
+		return (
+			<div className="space-y-3 py-14 text-center" role="alert">
+				<AlertCircle className="mx-auto h-6 w-6 text-destructive" />
+				<p>
+					{state === "incompatible"
+						? "La respuesta del reporte no es compatible con esta versión. No se mostraron cifras ni conciliaciones."
+						: `No fue posible cargar la distribución de ${periodLabel}.`}
+				</p>
+				<Button variant="outline" onClick={onRetry}>
+					Reintentar
+				</Button>
+			</div>
+		);
+	if (state === "empty")
+		return (
+			<div className="py-14 text-center text-muted-foreground">
+				<p className="font-medium text-foreground">
+					No hay liquidaciones para {periodLabel}.
+				</p>
+				<p className="mt-1 text-sm">
+					Selecciona otro período para consultar movimientos.
+				</p>
+			</div>
+		);
+	if (state === "registered-zero")
+		return (
+			<div className="space-y-2 py-14 text-center" role="status">
+				<p className="font-medium text-foreground">
+					{REGISTERED_ZERO_ACTIVITY_COPY}
+				</p>
+				<p className="text-muted-foreground text-sm">
+					El período {periodLabel} contiene registros, pero su posición y flujo
+					liquidado son Q0.00.
+				</p>
+			</div>
+		);
+
+	const model = buildReinvestmentReportModel(data);
+	if (!model.compatible) return null;
+	const safeData = model.data;
+	const reconciliation = getReconciliationPresentation(state, model.reconciled);
+	const showSecondaryDetails = canRenderSecondaryDetails(state);
+	const currency = (value: number | string) =>
+		new Intl.NumberFormat("es-GT", {
+			style: "currency",
+			currency: "GTQ",
+		}).format(Number(value));
+	const details = buildSecondarySummaryPresentation(safeData);
+	const monthlyFooter = getMonthlyFooterPresentation(model);
+	const selectedModeRow =
+		model.rows.find((row) => row.type === selectedMode) ?? model.rows[0];
+
+	return (
+		<div className="space-y-8">
+			<section aria-labelledby="investment-summary">
+				<div className="mb-4">
+					<p className="text-muted-foreground text-sm">Período liquidado</p>
+					<h3 id="investment-summary" className="font-semibold text-xl">
+						{periodLabel}
+					</h3>
+				</div>
+				<div className="grid gap-3 sm:grid-cols-3">
+					<Metric label="Pagado a inversionistas" value={model.totals.paid} />
+					<Metric label="Reinvertido" value={model.totals.reinvested} />
+					<Metric label="Flujo liquidado" value={model.totals.distributed} />
+				</div>
+				{reconciliation === "verified" ? (
+					<div className="mt-3 flex flex-wrap items-center gap-2 rounded-md border border-emerald-300 bg-emerald-50 px-4 py-3 text-emerald-900 text-sm">
+						<CheckCircle2 className="h-4 w-4" />
+						<strong>Conciliación verificada:</strong>
+						<span>
+							{currency(model.totals.paid)} pagado +{" "}
+							{currency(model.totals.reinvested)} reinvertido ={" "}
+							{currency(model.totals.distributed)} flujo liquidado
+						</span>
+					</div>
+				) : (
+					<div
+						className="mt-3 flex items-center gap-2 rounded-md border border-amber-300 bg-amber-50 px-4 py-3 text-amber-900 text-sm"
+						role="status"
+					>
+						<AlertCircle className="h-4 w-4 shrink-0" />
+						<strong>Conciliación no disponible para este período.</strong>
+					</div>
+				)}
+			</section>
+
+			<section aria-labelledby="investment-modes">
+				<div className="mb-3 flex flex-wrap items-center justify-between gap-3">
+					<div>
+						<h3 id="investment-modes" className="font-semibold text-lg">
+							Destino del flujo por modalidad
+						</h3>
+						<p className="text-muted-foreground text-sm">
+							Cada fila concilia lo pagado y reinvertido con el flujo
+							liquidado.
+						</p>
+					</div>
+					<div className="flex flex-wrap gap-2">
+						{onExportInvestors ? (
+							<Button variant="outline" onClick={onExportInvestors}>
+								<Download className="mr-2 h-4 w-4" />
+								Exportar Excel
+							</Button>
+						) : null}
+						<Button
+							variant="outline"
+							onClick={() => setShowInvestors((visible) => !visible)}
+							aria-expanded={showInvestors}
+						>
+							Detalle por inversionista
+							<ChevronDown className="ml-2 h-4 w-4" />
+						</Button>
+					</div>
+				</div>
+				<TableOverflow label="Destino del flujo por modalidad">
+					<Table className="min-w-[720px]">
+						<TableHeader>
+							<TableRow>
+								<TableHead>Modalidad</TableHead>
+								<TableHead className="text-right">Pagado</TableHead>
+								<TableHead className="text-right">Reinvertido</TableHead>
+								<TableHead className="text-right">Flujo liquidado</TableHead>
+								<TableHead>Detalle</TableHead>
+							</TableRow>
+						</TableHeader>
+						<TableBody>
+							{model.rows.map((row) => (
+								<TableRow
+									key={row.type}
+									data-state={selectedModeRow?.type === row.type ? "selected" : undefined}
+								>
+									<TableCell className="font-medium">{row.label}</TableCell>
+									<TableCell className="text-right">
+										{currency(row.paid)}
+									</TableCell>
+									<TableCell className="text-right">
+										{currency(row.reinvested)}
+									</TableCell>
+									<TableCell className="text-right">
+										<strong>{currency(row.distributed)}</strong>
+									</TableCell>
+									<TableCell>
+										<Button
+											variant="ghost"
+											size="sm"
+											onClick={() => setSelectedMode(row.type)}
+											aria-expanded={selectedModeRow?.type === row.type}
+										>
+											Ver composición
+										</Button>
+									</TableCell>
+								</TableRow>
+							))}
+						</TableBody>
+						<tfoot className="border-t bg-muted/50 font-medium">
+							<TableRow>
+								<TableCell className="font-semibold">
+									Total mensual
+									<span className="sr-only">{monthlyFooter.equation}</span>
+								</TableCell>
+								<TableCell className="text-right font-semibold">
+									{currency(monthlyFooter.paid)}
+								</TableCell>
+								<TableCell className="text-right font-semibold">
+									{currency(monthlyFooter.reinvested)}
+								</TableCell>
+								<TableCell className="text-right font-semibold">
+									{currency(monthlyFooter.distributed)}
+								</TableCell>
+								<TableCell className="text-muted-foreground text-xs">
+									Pagado + Reinvertido = Flujo
+								</TableCell>
+							</TableRow>
+						</tfoot>
+					</Table>
+				</TableOverflow>
+				{selectedModeRow ? (
+					<ModeReconciliation
+						row={selectedModeRow}
+						currency={currency}
+					/>
+				) : null}
+				{showInvestors ? (
+					<div className="mt-4">
+						<TableOverflow label="Detalle por inversionista">
+							<Table className="min-w-[720px]">
+							<TableHeader>
+								<TableRow>
+									<TableHead>Inversionista</TableHead>
+									<TableHead>Modalidad</TableHead>
+									<TableHead className="text-right">Pagado</TableHead>
+									<TableHead className="text-right">Reinvertido</TableHead>
+									<TableHead className="text-right">Capital activo</TableHead>
+								</TableRow>
+							</TableHeader>
+							<TableBody>
+								{safeData.porInversionista.map((item) => (
+									<TableRow key={item.inversionista_id}>
+										<TableCell className="font-medium">{item.nombre}</TableCell>
+										<TableCell>{item.tipo_reinversion}</TableCell>
+										<TableCell className="text-right">
+											{currency(item.a_recibir)}
+										</TableCell>
+										<TableCell className="text-right">
+											{currency(item.reinversion)}
+										</TableCell>
+										<TableCell className="text-right">
+											{currency(item.capital_activo)}
+										</TableCell>
+									</TableRow>
+								))}
+							</TableBody>
+							</Table>
+						</TableOverflow>
+					</div>
+				) : null}
+			</section>
+
+			<section aria-labelledby="investment-secondary">
+				<h3 id="investment-secondary" className="mb-3 font-semibold text-lg">
+					Rendimiento y movimientos del mes
+				</h3>
+				{!showSecondaryDetails ? (
+					<p
+						className="rounded-md border border-amber-300 bg-amber-50 p-3 text-amber-900 text-sm"
+						role="status"
+					>
+						{getPublicPartialDetailMessage()}
+					</p>
+				) : (
+					<>
+						<div className="grid gap-3 lg:grid-cols-3">
+							{details.map((item) => (
+								<Card key={item.key} className="shadow-none">
+									<CardHeader className="pb-2">
+										<CardTitle className="text-base">{item.label}</CardTitle>
+									</CardHeader>
+									<CardContent className="space-y-3">
+										{item.items.length > 0 ? (
+											<dl className="divide-y rounded-md border text-sm">
+												{item.items.map((summary) => (
+													<div
+														key={summary.label}
+														className="grid grid-cols-[minmax(0,1fr)_auto] gap-x-3 gap-y-1 px-3 py-2"
+													>
+														<dt className="min-w-0 font-medium">
+															{summary.label}
+															{summary.meta ? (
+																<span className="ml-2 font-normal text-muted-foreground text-xs">
+																	{summary.meta}
+																</span>
+															) : null}
+														</dt>
+														<dd className="text-right font-medium tabular-nums">
+															{currency(summary.value)}
+														</dd>
+														{summary.formula ? (
+															<dd className="col-span-2 text-muted-foreground text-xs">
+																{summary.formula}
+															</dd>
+														) : null}
+													</div>
+												))}
+											</dl>
+										) : (
+											<p className="text-muted-foreground text-sm">
+												Sin compras registradas.
+											</p>
+										)}
+										<div className="flex min-h-11 flex-wrap items-center justify-between gap-2 border-t pt-3">
+											<div>
+												<span className="text-muted-foreground text-xs">
+													Total
+												</span>
+												<strong className="block text-lg tabular-nums">
+													{currency(item.total)}
+												</strong>
+											</div>
+											<Button
+												variant="ghost"
+												size="sm"
+												aria-expanded={detail === item.key}
+												aria-controls={detailId}
+												onClick={() => setDetail(item.key)}
+											>
+												Ver detalle
+											</Button>
+										</div>
+									</CardContent>
+								</Card>
+							))}
+						</div>
+						{detail ? (
+							<div
+								id={detailId}
+								className="mt-4 rounded-md border p-4"
+								aria-live="polite"
+							>
+								<div className="mb-3 flex items-center justify-between">
+									<h4 className="font-semibold">
+										Detalle de{" "}
+										{details.find((item) => item.key === detail)?.label}
+									</h4>
+									<Button
+										variant="ghost"
+										size="sm"
+										onClick={() => setDetail(null)}
+										aria-label="Cerrar detalle"
+									>
+										<X className="h-4 w-4" />
+									</Button>
+								</div>
+								<DetailTable
+									detail={detail}
+									data={safeData}
+									currency={currency}
+								/>
+							</div>
+						) : null}
+					</>
+				)}
+			</section>
+		</div>
+	);
+}
+
+function ModeReconciliation({
+	row,
+	currency,
+}: {
+	row: ReinvestmentModeRow;
+	currency: (value: number | string) => string;
+}) {
+	const presentation = getModePresentation(row);
+	return (
+		<section
+			className="mt-4 rounded-lg border bg-muted/20 p-4 sm:p-5"
+			aria-labelledby={`mode-${row.type}`}
+			aria-live="polite"
+		>
+			<div className="grid gap-5 lg:grid-cols-[minmax(0,1.35fr)_minmax(280px,0.65fr)]">
+				<div className="space-y-4">
+					<div>
+						<p className="text-muted-foreground text-xs uppercase tracking-wide">
+							Conciliación por modalidad
+						</p>
+						<h4 id={`mode-${row.type}`} className="mt-1 font-semibold text-lg">
+							{row.label}
+						</h4>
+					</div>
+					<div className="grid gap-3 sm:grid-cols-2">
+						<Destination
+							label="Pagado a inversionistas"
+							value={currency(row.paid)}
+							description="Salida de caja del período."
+							formula={presentation.destinations?.paid}
+							currency={currency}
+						/>
+						<Destination
+							label="Reinvertido"
+							value={currency(row.reinvested)}
+							description="Flujo que permanece colocado."
+							formula={presentation.destinations?.reinvested}
+							currency={currency}
+						/>
+					</div>
+					<div
+						className="flex flex-wrap items-stretch gap-2"
+						aria-hidden="true"
+					>
+						<EquationTerm label="Pagado" value={currency(row.paid)} />
+						<Operator>+</Operator>
+						<EquationTerm
+							label="Reinvertido"
+							value={currency(row.reinvested)}
+						/>
+						<Operator>=</Operator>
+						<EquationTerm
+							label="Flujo liquidado"
+							value={currency(row.distributed)}
+							result
+						/>
+					</div>
+					<p className="sr-only">{presentation.equation}</p>
+					{presentation.splitAvailable ? null : (
+						<p
+							className="rounded-md border border-amber-300 bg-amber-50 p-3 text-amber-900 text-sm"
+							role="note"
+						>
+							{presentation.splitNote}
+						</p>
+					)}
+				</div>
+				<div>
+					<h5 className="font-semibold">Composición contable del flujo</h5>
+					<dl className="mt-3 divide-y rounded-md border bg-background">
+						<LedgerRow
+							label="Capital liquidado"
+							value={currency(row.composition.capital)}
+						/>
+						<LedgerRow
+							label="+ Interés bruto"
+							value={currency(row.composition.interest)}
+						/>
+						<LedgerRow
+							label="+ IVA facturado"
+							value={currency(row.composition.billedVat)}
+						/>
+						<LedgerRow
+							label="− ISR retenido"
+							value={currency(row.composition.withheldIsr)}
+						/>
+						<LedgerRow
+							label="= Flujo liquidado"
+							value={currency(row.composition.distributed)}
+							total
+						/>
+					</dl>
+					<p className="mt-3 text-muted-foreground text-sm">
+						Esta composición explica el flujo distribuido entre efectivo y
+						reinversión. No representa montos adicionales.
+					</p>
+				</div>
+			</div>
+		</section>
+	);
+}
+
+function Destination({
+	label,
+	value,
+	description,
+	formula,
+	currency,
+}: {
+	label: string;
+	value: string;
+	description: string;
+	formula?: DestinationFormula;
+	currency: (value: number | string) => string;
+}) {
+	return (
+		<div className="rounded-md border bg-background p-4">
+			<p className="font-medium text-sm">{label}</p>
+			<strong className="mt-1 block text-2xl">{value}</strong>
+			<p className="mt-1 text-muted-foreground text-sm">{description}</p>
+			{formula ? (
+				<div
+					className="mt-4 border-t pt-3"
+					role="group"
+					aria-label={formula.sentence}
+				>
+					<div
+						className="flex flex-wrap items-stretch gap-1.5"
+						aria-hidden="true"
+					>
+						{formula.parts.length === 0 ? (
+							<FormulaPart label="Sin componentes" value={currency(0)} />
+						) : (
+							formula.parts.map((part, index) => (
+								<Fragment key={part.label}>
+									{index > 0 ? <FormulaOperator>+</FormulaOperator> : null}
+									<FormulaPart
+										label={part.label}
+										value={currency(part.value)}
+									/>
+								</Fragment>
+							))
+						)}
+						<FormulaOperator>=</FormulaOperator>
+						<FormulaPart
+							label={label}
+							value={currency(formula.result)}
+							result
+						/>
+					</div>
+					<p className="sr-only">{formula.sentence}</p>
+				</div>
+			) : null}
+		</div>
+	);
+}
+
+function FormulaPart({
+	label,
+	value,
+	result = false,
+}: {
+	label: string;
+	value: string;
+	result?: boolean;
+}) {
+	return (
+		<div
+			className={
+				result
+					? "min-w-0 flex-[1_1_8rem] rounded border border-emerald-300 bg-emerald-50 px-2.5 py-2 text-emerald-950"
+					: "min-w-0 flex-[1_1_7rem] rounded border bg-muted/30 px-2.5 py-2"
+			}
+		>
+			<span className="block break-words text-muted-foreground text-xs">
+				{label}
+			</span>
+			<strong className="block tabular-nums text-sm">{value}</strong>
+		</div>
+	);
+}
+
+function FormulaOperator({ children }: { children: ReactNode }) {
+	return (
+		<span
+			className="flex min-h-12 min-w-5 flex-none items-center justify-center font-semibold"
+			aria-hidden="true"
+		>
+			{children}
+		</span>
+	);
+}
+
+function EquationTerm({
+	label,
+	value,
+	result = false,
+}: {
+	label: string;
+	value: string;
+	result?: boolean;
+}) {
+	return (
+		<div
+			className={
+				result
+					? "min-w-36 flex-1 rounded-md border border-emerald-300 bg-emerald-50 p-3 text-emerald-950"
+					: "min-w-32 flex-1 rounded-md border bg-background p-3"
+			}
+		>
+			<strong className="block text-lg">{value}</strong>
+			<span className="text-sm">{label}</span>
+		</div>
+	);
+}
+
+function Operator({ children }: { children: ReactNode }) {
+	return (
+		<span
+			className="flex min-h-14 min-w-7 items-center justify-center font-semibold text-lg"
+			aria-hidden="true"
+		>
+			{children}
+		</span>
+	);
+}
+
+function LedgerRow({
+	label,
+	value,
+	total = false,
+}: {
+	label: string;
+	value: string;
+	total?: boolean;
+}) {
+	return (
+		<div
+			className={
+				total
+					? "flex items-center justify-between gap-4 bg-muted/50 px-3 py-2 font-semibold"
+					: "flex items-center justify-between gap-4 px-3 py-2 text-sm"
+			}
+		>
+			<dt>{label}</dt>
+			<dd className="tabular-nums">{value}</dd>
+		</div>
+	);
+}
+
+function Metric({ label, value }: { label: string; value: number }) {
+	return (
+		<div className="rounded-md border p-4">
+			<p className="text-muted-foreground text-sm">{label}</p>
+			<p className="mt-1 font-semibold text-2xl">
+				{new Intl.NumberFormat("es-GT", {
+					style: "currency",
+					currency: "GTQ",
+				}).format(value)}
+			</p>
+		</div>
+	);
+}
+
+function DetailTable({
+	detail,
+	data,
+	currency,
+}: {
+	detail: DetailKey;
+	data: ReinversionLiquidacionesResponse;
+	currency: (value: number | string) => string;
+}) {
+	if (detail === "interest") {
+		if (data.detalleInteresNeto.length === 0) return <NoDetail />;
+		return (
+			<TableOverflow label="Detalle de interés neto">
+				<Table className="min-w-[760px]">
+					<TableHeader>
+						<TableRow>
+							<TableHead>Inversionista / referencia</TableHead>
+							<TableHead>Tratamiento fiscal</TableHead>
+							<TableHead className="text-right">Interés</TableHead>
+							<TableHead className="text-right">IVA</TableHead>
+							<TableHead className="text-right">ISR</TableHead>
+							<TableHead className="text-right">Neto</TableHead>
+						</TableRow>
+					</TableHeader>
+					<TableBody>
+						{data.detalleInteresNeto.map((row) => (
+							<TableRow key={`${row.inversionista_id}-${row.referencia}`}>
+								<TableCell>
+									<strong>{row.inversionista}</strong>
+									<span className="block text-muted-foreground text-xs">
+										{row.referencia}
+									</span>
+								</TableCell>
+								<TableCell>
+									{row.tratamiento_fiscal.replaceAll("_", " ")}
+								</TableCell>
+								<TableCell className="text-right">
+									{currency(row.interes)}
+								</TableCell>
+								<TableCell className="text-right">
+									{currency(row.iva)}
+								</TableCell>
+								<TableCell className="text-right">
+									{currency(row.isr)}
+								</TableCell>
+								<TableCell className="text-right font-medium">
+									{currency(row.neto)}
+								</TableCell>
+							</TableRow>
+						))}
+					</TableBody>
+				</Table>
+			</TableOverflow>
+		);
+	}
+	if (detail === "extras") {
+		if (data.detallePagosExtras.length === 0) return <NoDetail />;
+		return (
+			<TableOverflow label="Detalle de pagos extras">
+				<Table className="min-w-[620px]">
+					<TableHeader>
+						<TableRow>
+							<TableHead>Fecha</TableHead>
+							<TableHead>Crédito</TableHead>
+							<TableHead>Tipo</TableHead>
+							<TableHead className="text-right">Monto</TableHead>
+						</TableRow>
+					</TableHeader>
+					<TableBody>
+						{data.detallePagosExtras.map((row, index) => (
+							<TableRow key={`${row.credito}-${row.fecha}-${index}`}>
+								<TableCell>{row.fecha}</TableCell>
+								<TableCell>{row.credito}</TableCell>
+								<TableCell>{row.tipo.replaceAll("_", " ")}</TableCell>
+								<TableCell className="text-right">
+									{currency(row.monto)}
+								</TableCell>
+							</TableRow>
+						))}
+					</TableBody>
+				</Table>
+			</TableOverflow>
+		);
+	}
+	if (data.detalleComprasMes.length === 0) return <NoDetail />;
+	return (
+		<TableOverflow label="Detalle de compras del mes">
+			<Table className="min-w-[660px]">
+				<TableHeader>
+					<TableRow>
+						<TableHead>Fecha</TableHead>
+						<TableHead>Inversionista</TableHead>
+						<TableHead>Modalidad</TableHead>
+						<TableHead className="text-right">Monto</TableHead>
+					</TableRow>
+				</TableHeader>
+				<TableBody>
+					{data.detalleComprasMes.map((row, index) => (
+						<TableRow key={`${row.inversionista}-${row.fecha}-${index}`}>
+							<TableCell>{row.fecha}</TableCell>
+							<TableCell>{row.inversionista}</TableCell>
+							<TableCell>{row.modalidad}</TableCell>
+							<TableCell className="text-right">
+								{currency(row.monto)}
+							</TableCell>
+						</TableRow>
+					))}
+				</TableBody>
+			</Table>
+		</TableOverflow>
+	);
+}
+
+function TableOverflow({
+	children,
+	label,
+}: {
+	children: ReactNode;
+	label: string;
+}) {
+	return (
+		<div
+			className="w-full overflow-x-auto rounded-md border"
+			role="region"
+			aria-label={label}
+			tabIndex={0}
+		>
+			{children}
+		</div>
+	);
+}
+
+function NoDetail() {
+	return (
+		<p className="py-6 text-center text-muted-foreground text-sm">
+			No hay detalle para este período.
+		</p>
+	);
+}

--- a/apps/crm/apps/web/src/components/reports/reinvestment-report.tsx
+++ b/apps/crm/apps/web/src/components/reports/reinvestment-report.tsx
@@ -16,20 +16,20 @@ import {
 	TableHeader,
 	TableRow,
 } from "@/components/ui/table";
+import type {
+	DestinationFormula,
+	ReinvestmentModeRow,
+} from "@/lib/reports/reinvestment-report";
 import {
 	buildReinvestmentReportModel,
 	buildSecondarySummaryPresentation,
 	canRenderSecondaryDetails,
-	getMonthlyFooterPresentation,
 	getModePresentation,
+	getMonthlyFooterPresentation,
 	getPublicPartialDetailMessage,
 	getReconciliationPresentation,
 	getReportState,
 	REGISTERED_ZERO_ACTIVITY_COPY,
-} from "@/lib/reports/reinvestment-report";
-import type {
-	DestinationFormula,
-	ReinvestmentModeRow,
 } from "@/lib/reports/reinvestment-report";
 import type { ReinversionLiquidacionesResponse } from "@/lib/reports/scenario";
 
@@ -62,7 +62,10 @@ export function ReinvestmentReport({
 
 	if (state === "loading")
 		return (
-			<div className="py-14 text-center text-muted-foreground" aria-live="polite">
+			<div
+				className="py-14 text-center text-muted-foreground"
+				aria-live="polite"
+			>
 				Cargando distribución de {periodLabel}…
 			</div>
 		);
@@ -93,21 +96,25 @@ export function ReinvestmentReport({
 		);
 	if (state === "registered-zero")
 		return (
-			<div className="space-y-2 py-14 text-center" role="status">
-				<p className="font-medium text-foreground">
+			<output className="block space-y-2 py-14 text-center">
+				<span className="block font-medium text-foreground">
 					{REGISTERED_ZERO_ACTIVITY_COPY}
-				</p>
-				<p className="text-muted-foreground text-sm">
+				</span>
+				<span className="block text-muted-foreground text-sm">
 					El período {periodLabel} contiene registros, pero su posición y flujo
 					liquidado son Q0.00.
-				</p>
-			</div>
+				</span>
+			</output>
 		);
 
 	const model = buildReinvestmentReportModel(data);
 	if (!model.compatible) return null;
 	const safeData = model.data;
-	const reconciliation = getReconciliationPresentation(state, model.reconciled);
+	const reconciliation = getReconciliationPresentation(
+		state,
+		model.reconciled,
+		model,
+	);
 	const showSecondaryDetails = canRenderSecondaryDetails(state);
 	const currency = (value: number | string) =>
 		new Intl.NumberFormat("es-GT", {
@@ -133,10 +140,14 @@ export function ReinvestmentReport({
 					<Metric label="Reinvertido" value={model.totals.reinvested} />
 					<Metric label="Flujo liquidado" value={model.totals.distributed} />
 				</div>
-				{reconciliation === "verified" ? (
+				{reconciliation === "verified" || reconciliation === "tolerance" ? (
 					<div className="mt-3 flex flex-wrap items-center gap-2 rounded-md border border-emerald-300 bg-emerald-50 px-4 py-3 text-emerald-900 text-sm">
 						<CheckCircle2 className="h-4 w-4" />
-						<strong>Conciliación verificada:</strong>
+						<strong>
+							{reconciliation === "verified"
+								? "Conciliación verificada:"
+								: "Dentro de tolerancia de redondeo:"}
+						</strong>
 						<span>
 							{currency(model.totals.paid)} pagado +{" "}
 							{currency(model.totals.reinvested)} reinvertido ={" "}
@@ -144,13 +155,10 @@ export function ReinvestmentReport({
 						</span>
 					</div>
 				) : (
-					<div
-						className="mt-3 flex items-center gap-2 rounded-md border border-amber-300 bg-amber-50 px-4 py-3 text-amber-900 text-sm"
-						role="status"
-					>
+					<output className="mt-3 flex items-center gap-2 rounded-md border border-amber-300 bg-amber-50 px-4 py-3 text-amber-900 text-sm">
 						<AlertCircle className="h-4 w-4 shrink-0" />
 						<strong>Conciliación no disponible para este período.</strong>
-					</div>
+					</output>
 				)}
 			</section>
 
@@ -158,11 +166,11 @@ export function ReinvestmentReport({
 				<div className="mb-3 flex flex-wrap items-center justify-between gap-3">
 					<div>
 						<h3 id="investment-modes" className="font-semibold text-lg">
-							Destino del flujo por modalidad
+							Destino del flujo por modalidad actual
 						</h3>
 						<p className="text-muted-foreground text-sm">
-							Cada fila concilia lo pagado y reinvertido con el flujo
-							liquidado.
+							La modalidad es la actual; no existe snapshot histórico para
+							verificar el destino.
 						</p>
 					</div>
 					<div className="flex flex-wrap gap-2">
@@ -186,7 +194,7 @@ export function ReinvestmentReport({
 					<Table className="min-w-[720px]">
 						<TableHeader>
 							<TableRow>
-								<TableHead>Modalidad</TableHead>
+								<TableHead>Modalidad actual</TableHead>
 								<TableHead className="text-right">Pagado</TableHead>
 								<TableHead className="text-right">Reinvertido</TableHead>
 								<TableHead className="text-right">Flujo liquidado</TableHead>
@@ -197,7 +205,9 @@ export function ReinvestmentReport({
 							{model.rows.map((row) => (
 								<TableRow
 									key={row.type}
-									data-state={selectedModeRow?.type === row.type ? "selected" : undefined}
+									data-state={
+										selectedModeRow?.type === row.type ? "selected" : undefined
+									}
 								>
 									<TableCell className="font-medium">{row.label}</TableCell>
 									<TableCell className="text-right">
@@ -245,41 +255,42 @@ export function ReinvestmentReport({
 					</Table>
 				</TableOverflow>
 				{selectedModeRow ? (
-					<ModeReconciliation
-						row={selectedModeRow}
-						currency={currency}
-					/>
+					<ModeReconciliation row={selectedModeRow} currency={currency} />
 				) : null}
 				{showInvestors ? (
 					<div className="mt-4">
 						<TableOverflow label="Detalle por inversionista">
 							<Table className="min-w-[720px]">
-							<TableHeader>
-								<TableRow>
-									<TableHead>Inversionista</TableHead>
-									<TableHead>Modalidad</TableHead>
-									<TableHead className="text-right">Pagado</TableHead>
-									<TableHead className="text-right">Reinvertido</TableHead>
-									<TableHead className="text-right">Capital activo</TableHead>
-								</TableRow>
-							</TableHeader>
-							<TableBody>
-								{safeData.porInversionista.map((item) => (
-									<TableRow key={item.inversionista_id}>
-										<TableCell className="font-medium">{item.nombre}</TableCell>
-										<TableCell>{item.tipo_reinversion}</TableCell>
-										<TableCell className="text-right">
-											{currency(item.a_recibir)}
-										</TableCell>
-										<TableCell className="text-right">
-											{currency(item.reinversion)}
-										</TableCell>
-										<TableCell className="text-right">
-											{currency(item.capital_activo)}
-										</TableCell>
+								<TableHeader>
+									<TableRow>
+										<TableHead>Inversionista</TableHead>
+										<TableHead>Modalidad actual</TableHead>
+										<TableHead className="text-right">Pagado</TableHead>
+										<TableHead className="text-right">Reinvertido</TableHead>
+										<TableHead className="text-right">
+											Capital activo actual
+										</TableHead>
 									</TableRow>
-								))}
-							</TableBody>
+								</TableHeader>
+								<TableBody>
+									{safeData.porInversionista.map((item) => (
+										<TableRow key={item.inversionista_id}>
+											<TableCell className="font-medium">
+												{item.nombre}
+											</TableCell>
+											<TableCell>{item.tipo_reinversion}</TableCell>
+											<TableCell className="text-right">
+												{currency(item.a_recibir)}
+											</TableCell>
+											<TableCell className="text-right">
+												{currency(item.reinversion)}
+											</TableCell>
+											<TableCell className="text-right">
+												{currency(item.capital_activo)}
+											</TableCell>
+										</TableRow>
+									))}
+								</TableBody>
 							</Table>
 						</TableOverflow>
 					</div>
@@ -291,12 +302,9 @@ export function ReinvestmentReport({
 					Rendimiento y movimientos del mes
 				</h3>
 				{!showSecondaryDetails ? (
-					<p
-						className="rounded-md border border-amber-300 bg-amber-50 p-3 text-amber-900 text-sm"
-						role="status"
-					>
+					<output className="rounded-md border border-amber-300 bg-amber-50 p-3 text-amber-900 text-sm">
 						{getPublicPartialDetailMessage()}
-					</p>
+					</output>
 				) : (
 					<>
 						<div className="grid gap-3 lg:grid-cols-3">
@@ -463,29 +471,36 @@ function ModeReconciliation({
 				</div>
 				<div>
 					<h5 className="font-semibold">Composición contable del flujo</h5>
-					<dl className="mt-3 divide-y rounded-md border bg-background">
-						<LedgerRow
-							label="Capital liquidado"
-							value={currency(row.composition.capital)}
-						/>
-						<LedgerRow
-							label="+ Interés bruto"
-							value={currency(row.composition.interest)}
-						/>
-						<LedgerRow
-							label="+ IVA facturado"
-							value={currency(row.composition.billedVat)}
-						/>
-						<LedgerRow
-							label="− ISR retenido"
-							value={currency(row.composition.withheldIsr)}
-						/>
-						<LedgerRow
-							label="= Flujo liquidado"
-							value={currency(row.composition.distributed)}
-							total
-						/>
-					</dl>
+					{row.compositionStatus === "unavailable" ? (
+						<p className="mt-3 rounded-md border border-amber-300 bg-amber-50 p-3 text-amber-900 text-sm">
+							La composición fiscal no está disponible: IVA e ISR registrados no
+							tienen tratamiento inmutable.
+						</p>
+					) : (
+						<dl className="mt-3 divide-y rounded-md border bg-background">
+							<LedgerRow
+								label="Capital liquidado"
+								value={currency(row.composition.capital)}
+							/>
+							<LedgerRow
+								label="+ Interés bruto"
+								value={currency(row.composition.interest)}
+							/>
+							<LedgerRow
+								label="+ IVA facturado"
+								value={currency(row.composition.billedVat)}
+							/>
+							<LedgerRow
+								label="− ISR retenido"
+								value={currency(row.composition.withheldIsr)}
+							/>
+							<LedgerRow
+								label="= Flujo liquidado"
+								value={currency(row.composition.distributed)}
+								total
+							/>
+						</dl>
+					)}
 					<p className="mt-3 text-muted-foreground text-sm">
 						Esta composición explica el flujo distribuido entre efectivo y
 						reinversión. No representa montos adicionales.
@@ -515,11 +530,7 @@ function Destination({
 			<strong className="mt-1 block text-2xl">{value}</strong>
 			<p className="mt-1 text-muted-foreground text-sm">{description}</p>
 			{formula ? (
-				<div
-					className="mt-4 border-t pt-3"
-					role="group"
-					aria-label={formula.sentence}
-				>
+				<fieldset className="mt-4 border-t pt-3" aria-label={formula.sentence}>
 					<div
 						className="flex flex-wrap items-stretch gap-1.5"
 						aria-hidden="true"
@@ -545,7 +556,7 @@ function Destination({
 						/>
 					</div>
 					<p className="sr-only">{formula.sentence}</p>
-				</div>
+				</fieldset>
 			) : null}
 		</div>
 	);
@@ -571,7 +582,7 @@ function FormulaPart({
 			<span className="block break-words text-muted-foreground text-xs">
 				{label}
 			</span>
-			<strong className="block tabular-nums text-sm">{value}</strong>
+			<strong className="block text-sm tabular-nums">{value}</strong>
 		</div>
 	);
 }
@@ -670,7 +681,7 @@ function DetailTable({
 	if (detail === "interest") {
 		if (data.detalleInteresNeto.length === 0) return <NoDetail />;
 		return (
-			<TableOverflow label="Detalle de interés neto">
+			<TableOverflow label="Detalle de interés registrado">
 				<Table className="min-w-[760px]">
 					<TableHeader>
 						<TableRow>
@@ -679,7 +690,7 @@ function DetailTable({
 							<TableHead className="text-right">Interés</TableHead>
 							<TableHead className="text-right">IVA</TableHead>
 							<TableHead className="text-right">ISR</TableHead>
-							<TableHead className="text-right">Neto</TableHead>
+							<TableHead className="text-right">Neto derivado</TableHead>
 						</TableRow>
 					</TableHeader>
 					<TableBody>
@@ -704,7 +715,7 @@ function DetailTable({
 									{currency(row.isr)}
 								</TableCell>
 								<TableCell className="text-right font-medium">
-									{currency(row.neto)}
+									{row.tratamiento_fiscal === "cube" ? currency(row.neto) : "—"}
 								</TableCell>
 							</TableRow>
 						))}
@@ -779,14 +790,12 @@ function TableOverflow({
 	label: string;
 }) {
 	return (
-		<div
+		<section
 			className="w-full overflow-x-auto rounded-md border"
-			role="region"
 			aria-label={label}
-			tabIndex={0}
 		>
 			{children}
-		</div>
+		</section>
 	);
 }
 

--- a/apps/crm/apps/web/src/lib/reports/monto-a-cobrar.test.ts
+++ b/apps/crm/apps/web/src/lib/reports/monto-a-cobrar.test.ts
@@ -70,6 +70,7 @@ test("totaliza el split sin modificar el total original", () => {
 				interes_iva_inv_participacion_actual: "5",
 				interes_iva_cube_participacion_actual: "7",
 				creditos_participacion_invalida: 1,
+				creditos_participacion_invalida_rango: 1,
 				cuotas_participacion_invalida: 2,
 			},
 		],
@@ -83,6 +84,93 @@ test("totaliza el split sin modificar el total original", () => {
 		interesIvaCube: 7,
 		creditosInvalidos: 1,
 		cuotasInvalidas: 2,
+	});
+});
+
+test("usa el conteo distinct del rango y conserva las cuotas entre buckets", () => {
+	const rows = [
+		{
+			capital_inv_participacion_actual: "0",
+			capital_cube_participacion_actual: "0",
+			interes_iva_inv_participacion_actual: "0",
+			interes_iva_cube_participacion_actual: "0",
+			creditos_participacion_invalida: 1,
+			creditos_participacion_invalida_rango: 1,
+			cuotas_participacion_invalida: 1,
+		},
+		{
+			capital_inv_participacion_actual: "0",
+			capital_cube_participacion_actual: "0",
+			interes_iva_inv_participacion_actual: "0",
+			interes_iva_cube_participacion_actual: "0",
+			creditos_participacion_invalida: 1,
+			creditos_participacion_invalida_rango: 1,
+			cuotas_participacion_invalida: 2,
+		},
+		{
+			capital_inv_participacion_actual: "0",
+			capital_cube_participacion_actual: "0",
+			interes_iva_inv_participacion_actual: "0",
+			interes_iva_cube_participacion_actual: "0",
+			creditos_participacion_invalida: 1,
+			creditos_participacion_invalida_rango: 1,
+			cuotas_participacion_invalida: 3,
+		},
+	];
+
+	for (const acumulado of [false, true]) {
+		expect(getMontoACobrarParticipacionTotals(rows, acumulado)).toMatchObject({
+			creditosInvalidos: 1,
+			cuotasInvalidas: 6,
+		});
+	}
+});
+
+test("usa dos créditos distintos del conteo escalar del rango", () => {
+	const rows = [
+		{
+			capital_inv_participacion_actual: "0",
+			capital_cube_participacion_actual: "0",
+			interes_iva_inv_participacion_actual: "0",
+			interes_iva_cube_participacion_actual: "0",
+			creditos_participacion_invalida: 1,
+			creditos_participacion_invalida_rango: 2,
+			cuotas_participacion_invalida: 1,
+		},
+	];
+
+	expect(getMontoACobrarParticipacionTotals(rows, false)).toMatchObject({
+		creditosInvalidos: 2,
+	});
+});
+
+test("conserva el fallback legacy cuando el conteo del rango no existe", () => {
+	const rows = [
+		{
+			capital_inv_participacion_actual: "0",
+			capital_cube_participacion_actual: "0",
+			interes_iva_inv_participacion_actual: "0",
+			interes_iva_cube_participacion_actual: "0",
+			creditos_participacion_invalida: 1,
+			cuotas_participacion_invalida: 1,
+		},
+		{
+			capital_inv_participacion_actual: "0",
+			capital_cube_participacion_actual: "0",
+			interes_iva_inv_participacion_actual: "0",
+			interes_iva_cube_participacion_actual: "0",
+			creditos_participacion_invalida: 1,
+			cuotas_participacion_invalida: 2,
+		},
+	];
+
+	expect(getMontoACobrarParticipacionTotals(rows, false)).toMatchObject({
+		creditosInvalidos: 2,
+		cuotasInvalidas: 3,
+	});
+	expect(getMontoACobrarParticipacionTotals(rows, true)).toMatchObject({
+		creditosInvalidos: 1,
+		cuotasInvalidas: 3,
 	});
 });
 

--- a/apps/crm/apps/web/src/lib/reports/monto-a-cobrar.test.ts
+++ b/apps/crm/apps/web/src/lib/reports/monto-a-cobrar.test.ts
@@ -65,6 +65,7 @@ test("totaliza el split sin modificar el total original", () => {
 	const totals = getMontoACobrarParticipacionTotals(
 		[
 			{
+				cuotas_count: 1,
 				capital_inv_participacion_actual: "10",
 				capital_cube_participacion_actual: "90",
 				interes_iva_inv_participacion_actual: "5",
@@ -90,6 +91,7 @@ test("totaliza el split sin modificar el total original", () => {
 test("usa el conteo distinct del rango y conserva las cuotas entre buckets", () => {
 	const rows = [
 		{
+			cuotas_count: 1,
 			capital_inv_participacion_actual: "0",
 			capital_cube_participacion_actual: "0",
 			interes_iva_inv_participacion_actual: "0",
@@ -99,6 +101,7 @@ test("usa el conteo distinct del rango y conserva las cuotas entre buckets", () 
 			cuotas_participacion_invalida: 1,
 		},
 		{
+			cuotas_count: 2,
 			capital_inv_participacion_actual: "0",
 			capital_cube_participacion_actual: "0",
 			interes_iva_inv_participacion_actual: "0",
@@ -108,6 +111,7 @@ test("usa el conteo distinct del rango y conserva las cuotas entre buckets", () 
 			cuotas_participacion_invalida: 2,
 		},
 		{
+			cuotas_count: 3,
 			capital_inv_participacion_actual: "0",
 			capital_cube_participacion_actual: "0",
 			interes_iva_inv_participacion_actual: "0",
@@ -129,6 +133,7 @@ test("usa el conteo distinct del rango y conserva las cuotas entre buckets", () 
 test("usa dos créditos distintos del conteo escalar del rango", () => {
 	const rows = [
 		{
+			cuotas_count: 1,
 			capital_inv_participacion_actual: "0",
 			capital_cube_participacion_actual: "0",
 			interes_iva_inv_participacion_actual: "0",
@@ -147,6 +152,7 @@ test("usa dos créditos distintos del conteo escalar del rango", () => {
 test("conserva el fallback legacy cuando el conteo del rango no existe", () => {
 	const rows = [
 		{
+			cuotas_count: 1,
 			capital_inv_participacion_actual: "0",
 			capital_cube_participacion_actual: "0",
 			interes_iva_inv_participacion_actual: "0",
@@ -155,6 +161,7 @@ test("conserva el fallback legacy cuando el conteo del rango no existe", () => {
 			cuotas_participacion_invalida: 1,
 		},
 		{
+			cuotas_count: 2,
 			capital_inv_participacion_actual: "0",
 			capital_cube_participacion_actual: "0",
 			interes_iva_inv_participacion_actual: "0",
@@ -177,6 +184,7 @@ test("conserva el fallback legacy cuando el conteo del rango no existe", () => {
 test("el acumulado usa el último período y no suma valores ya acumulados", () => {
 	const rows = [
 		{
+			cuotas_count: 1,
 			capital_inv_participacion_actual: "10",
 			capital_cube_participacion_actual: "90",
 			interes_iva_inv_participacion_actual: "5",
@@ -185,6 +193,7 @@ test("el acumulado usa el último período y no suma valores ya acumulados", () 
 			cuotas_participacion_invalida: 1,
 		},
 		{
+			cuotas_count: 2,
 			capital_inv_participacion_actual: "20",
 			capital_cube_participacion_actual: "180",
 			interes_iva_inv_participacion_actual: "10",
@@ -201,5 +210,37 @@ test("el acumulado usa el último período y no suma valores ya acumulados", () 
 	expect(getMontoACobrarParticipacionTotals(rows, true)).toMatchObject({
 		capitalInv: 20,
 		capitalCube: 180,
+	});
+});
+
+test("el acumulado conserva el split ante un último bucket solo de pagos", () => {
+	const rows = [
+		{
+			cuotas_count: 1,
+			capital_inv_participacion_actual: "20",
+			capital_cube_participacion_actual: "180",
+			interes_iva_inv_participacion_actual: "10",
+			interes_iva_cube_participacion_actual: "90",
+			creditos_participacion_invalida: 0,
+			creditos_participacion_invalida_rango: 0,
+			cuotas_participacion_invalida: 0,
+		},
+		{
+			cuotas_count: 0,
+			capital_inv_participacion_actual: "0",
+			capital_cube_participacion_actual: "0",
+			interes_iva_inv_participacion_actual: "0",
+			interes_iva_cube_participacion_actual: "0",
+			creditos_participacion_invalida: 0,
+			creditos_participacion_invalida_rango: 0,
+			cuotas_participacion_invalida: 0,
+		},
+	];
+
+	expect(getMontoACobrarParticipacionTotals(rows, true)).toMatchObject({
+		capitalInv: 20,
+		capitalCube: 180,
+		interesIvaInv: 10,
+		interesIvaCube: 90,
 	});
 });

--- a/apps/crm/apps/web/src/lib/reports/monto-a-cobrar.test.ts
+++ b/apps/crm/apps/web/src/lib/reports/monto-a-cobrar.test.ts
@@ -1,0 +1,117 @@
+import { describe, expect, test } from "bun:test";
+import {
+	fillMissingMontoACobrarPeriods,
+	getMontoACobrarParticipacionTotals,
+} from "./monto-a-cobrar";
+
+describe("fillMissingMontoACobrarPeriods", () => {
+	test("rellena buckets diarios faltantes incluyendo el split y metadata", () => {
+		const rows = fillMissingMontoACobrarPeriods(
+			[
+				{
+					bucket: "2026-07-01",
+					cuotas_count: 1,
+					total_cuota: "100",
+					total_interes: "10",
+					total_iva: "1.2",
+					total_seguro: "0",
+					total_gps: "0",
+					total_membresias: "0",
+					total_mora: "0",
+					mora_count: 0,
+					total_credits: 1,
+					credits_con_mora: 0,
+					acum_total_cuota: "100",
+					acum_total_interes: "10",
+					acum_total_iva: "1.2",
+					acum_total_seguro: "0",
+					acum_total_gps: "0",
+					acum_total_membresias: "0",
+					total_interes_inversionista: "0",
+					acum_total_interes_inversionista: "0",
+					capital_inv_participacion_actual: "50",
+					capital_cube_participacion_actual: "50",
+					interes_iva_inv_participacion_actual: "5.6",
+					interes_iva_cube_participacion_actual: "5.6",
+					acum_capital_inv_participacion_actual: "50",
+					acum_capital_cube_participacion_actual: "50",
+					acum_interes_iva_inv_participacion_actual: "5.6",
+					acum_interes_iva_cube_participacion_actual: "5.6",
+					creditos_participacion_invalida: 0,
+					cuotas_participacion_invalida: 0,
+					participacion_actual: true,
+				},
+			],
+			"dia",
+			"2026-07-01",
+			"2026-07-02",
+		);
+
+		expect(rows).toHaveLength(2);
+		expect(rows[1]).toMatchObject({
+			bucket: "2026-07-02",
+			capital_inv_participacion_actual: "0",
+			capital_cube_participacion_actual: "0",
+			interes_iva_inv_participacion_actual: "0",
+			interes_iva_cube_participacion_actual: "0",
+			creditos_participacion_invalida: 0,
+			cuotas_participacion_invalida: 0,
+			participacion_actual: true,
+		});
+	});
+});
+
+test("totaliza el split sin modificar el total original", () => {
+	const totals = getMontoACobrarParticipacionTotals(
+		[
+			{
+				capital_inv_participacion_actual: "10",
+				capital_cube_participacion_actual: "90",
+				interes_iva_inv_participacion_actual: "5",
+				interes_iva_cube_participacion_actual: "7",
+				creditos_participacion_invalida: 1,
+				cuotas_participacion_invalida: 2,
+			},
+		],
+		false,
+	);
+
+	expect(totals).toEqual({
+		capitalInv: 10,
+		capitalCube: 90,
+		interesIvaInv: 5,
+		interesIvaCube: 7,
+		creditosInvalidos: 1,
+		cuotasInvalidas: 2,
+	});
+});
+
+test("el acumulado usa el último período y no suma valores ya acumulados", () => {
+	const rows = [
+		{
+			capital_inv_participacion_actual: "10",
+			capital_cube_participacion_actual: "90",
+			interes_iva_inv_participacion_actual: "5",
+			interes_iva_cube_participacion_actual: "45",
+			creditos_participacion_invalida: 1,
+			cuotas_participacion_invalida: 1,
+		},
+		{
+			capital_inv_participacion_actual: "20",
+			capital_cube_participacion_actual: "180",
+			interes_iva_inv_participacion_actual: "10",
+			interes_iva_cube_participacion_actual: "90",
+			creditos_participacion_invalida: 2,
+			cuotas_participacion_invalida: 2,
+		},
+	];
+
+	expect(getMontoACobrarParticipacionTotals(rows, false)).toMatchObject({
+		capitalInv: 30,
+		capitalCube: 270,
+	});
+	expect(getMontoACobrarParticipacionTotals(rows, true)).toMatchObject({
+		capitalInv: 20,
+		capitalCube: 180,
+	});
+});

--- a/apps/crm/apps/web/src/lib/reports/monto-a-cobrar.ts
+++ b/apps/crm/apps/web/src/lib/reports/monto-a-cobrar.ts
@@ -28,6 +28,7 @@ export type MontoACobrarParticipacionRow = {
 	acum_interes_iva_inv_participacion_actual: string;
 	acum_interes_iva_cube_participacion_actual: string;
 	creditos_participacion_invalida: number;
+	creditos_participacion_invalida_rango?: number;
 	cuotas_participacion_invalida: number;
 	participacion_actual: boolean;
 };
@@ -109,6 +110,7 @@ export function getMontoACobrarParticipacionTotals(
 			| "interes_iva_inv_participacion_actual"
 			| "interes_iva_cube_participacion_actual"
 			| "creditos_participacion_invalida"
+			| "creditos_participacion_invalida_rango"
 			| "cuotas_participacion_invalida"
 		>
 	>,
@@ -116,14 +118,29 @@ export function getMontoACobrarParticipacionTotals(
 ): ParticipacionTotals {
 	const last = rows.at(-1);
 	const numeric = (value: string) => Number.parseFloat(value) || 0;
+	const creditosInvalidosRango = rows.find(
+		(row) => row.creditos_participacion_invalida_rango !== undefined,
+	)?.creditos_participacion_invalida_rango;
+	const creditosInvalidosLegacy = acumulado && last
+		? last.creditos_participacion_invalida
+		: rows.reduce(
+				(total, row) => total + row.creditos_participacion_invalida,
+				0,
+			);
+	const creditosInvalidos =
+		creditosInvalidosRango ?? creditosInvalidosLegacy;
+	const cuotasInvalidas = rows.reduce(
+		(total, row) => total + row.cuotas_participacion_invalida,
+		0,
+	);
 	if (acumulado && last) {
 		return {
 			capitalInv: numeric(last.capital_inv_participacion_actual),
 			capitalCube: numeric(last.capital_cube_participacion_actual),
 			interesIvaInv: numeric(last.interes_iva_inv_participacion_actual),
 			interesIvaCube: numeric(last.interes_iva_cube_participacion_actual),
-			creditosInvalidos: last.creditos_participacion_invalida,
-			cuotasInvalidas: last.cuotas_participacion_invalida,
+			creditosInvalidos,
+			cuotasInvalidas,
 		};
 	}
 	return rows.reduce<ParticipacionTotals>(
@@ -137,10 +154,8 @@ export function getMontoACobrarParticipacionTotals(
 			interesIvaCube:
 				total.interesIvaCube +
 				numeric(row.interes_iva_cube_participacion_actual),
-			creditosInvalidos:
-				total.creditosInvalidos + row.creditos_participacion_invalida,
-			cuotasInvalidas:
-				total.cuotasInvalidas + row.cuotas_participacion_invalida,
+			creditosInvalidos,
+			cuotasInvalidas,
 		}),
 		{
 			capitalInv: 0,

--- a/apps/crm/apps/web/src/lib/reports/monto-a-cobrar.ts
+++ b/apps/crm/apps/web/src/lib/reports/monto-a-cobrar.ts
@@ -1,0 +1,154 @@
+export type MontoACobrarParticipacionRow = {
+	bucket: string;
+	cuotas_count: number;
+	total_cuota: string;
+	total_interes: string;
+	total_iva: string;
+	total_seguro: string;
+	total_gps: string;
+	total_membresias: string;
+	total_mora: string;
+	mora_count: number;
+	total_credits: number;
+	credits_con_mora: number;
+	acum_total_cuota: string;
+	acum_total_interes: string;
+	acum_total_iva: string;
+	acum_total_seguro: string;
+	acum_total_gps: string;
+	acum_total_membresias: string;
+	total_interes_inversionista: string;
+	acum_total_interes_inversionista: string;
+	capital_inv_participacion_actual: string;
+	capital_cube_participacion_actual: string;
+	interes_iva_inv_participacion_actual: string;
+	interes_iva_cube_participacion_actual: string;
+	acum_capital_inv_participacion_actual: string;
+	acum_capital_cube_participacion_actual: string;
+	acum_interes_iva_inv_participacion_actual: string;
+	acum_interes_iva_cube_participacion_actual: string;
+	creditos_participacion_invalida: number;
+	cuotas_participacion_invalida: number;
+	participacion_actual: boolean;
+};
+
+type ParticipacionTotals = {
+	capitalInv: number;
+	capitalCube: number;
+	interesIvaInv: number;
+	interesIvaCube: number;
+	creditosInvalidos: number;
+	cuotasInvalidas: number;
+};
+
+const emptyRow = (bucket: string): MontoACobrarParticipacionRow => ({
+	bucket,
+	cuotas_count: 0,
+	total_cuota: "0",
+	total_interes: "0",
+	total_iva: "0",
+	total_seguro: "0",
+	total_gps: "0",
+	total_membresias: "0",
+	total_mora: "0",
+	mora_count: 0,
+	total_credits: 0,
+	credits_con_mora: 0,
+	acum_total_cuota: "0",
+	acum_total_interes: "0",
+	acum_total_iva: "0",
+	acum_total_seguro: "0",
+	acum_total_gps: "0",
+	acum_total_membresias: "0",
+	total_interes_inversionista: "0",
+	acum_total_interes_inversionista: "0",
+	capital_inv_participacion_actual: "0",
+	capital_cube_participacion_actual: "0",
+	interes_iva_inv_participacion_actual: "0",
+	interes_iva_cube_participacion_actual: "0",
+	acum_capital_inv_participacion_actual: "0",
+	acum_capital_cube_participacion_actual: "0",
+	acum_interes_iva_inv_participacion_actual: "0",
+	acum_interes_iva_cube_participacion_actual: "0",
+	creditos_participacion_invalida: 0,
+	cuotas_participacion_invalida: 0,
+	participacion_actual: true,
+});
+
+export function fillMissingMontoACobrarPeriods(
+	data: MontoACobrarParticipacionRow[],
+	periodo: "anio" | "trimestre" | "mes" | "semana" | "dia",
+	fechaInicio: string,
+	fechaFin: string,
+): MontoACobrarParticipacionRow[] {
+	if (periodo !== "semana" && periodo !== "dia") return data;
+	const toKey = (d: Date) =>
+		`${d.getFullYear()}-${String(d.getMonth() + 1).padStart(2, "0")}-${String(d.getDate()).padStart(2, "0")}`;
+	const rows = new Map(data.map((row) => [row.bucket.slice(0, 10), row]));
+	const start = new Date(`${fechaInicio}T12:00:00`);
+	const end = new Date(`${fechaFin}T12:00:00`);
+	const dates: Date[] = [];
+	const current = new Date(start);
+	if (periodo === "semana") {
+		const day = current.getDay();
+		current.setDate(current.getDate() + (day === 0 ? -6 : 1 - day));
+	}
+	while (current <= end) {
+		dates.push(new Date(current));
+		current.setDate(current.getDate() + (periodo === "dia" ? 1 : 7));
+	}
+	return dates.map((date) => rows.get(toKey(date)) ?? emptyRow(toKey(date)));
+}
+
+export function getMontoACobrarParticipacionTotals(
+	rows: Array<
+		Pick<
+			MontoACobrarParticipacionRow,
+			| "capital_inv_participacion_actual"
+			| "capital_cube_participacion_actual"
+			| "interes_iva_inv_participacion_actual"
+			| "interes_iva_cube_participacion_actual"
+			| "creditos_participacion_invalida"
+			| "cuotas_participacion_invalida"
+		>
+	>,
+	acumulado: boolean,
+): ParticipacionTotals {
+	const last = rows.at(-1);
+	const numeric = (value: string) => Number.parseFloat(value) || 0;
+	if (acumulado && last) {
+		return {
+			capitalInv: numeric(last.capital_inv_participacion_actual),
+			capitalCube: numeric(last.capital_cube_participacion_actual),
+			interesIvaInv: numeric(last.interes_iva_inv_participacion_actual),
+			interesIvaCube: numeric(last.interes_iva_cube_participacion_actual),
+			creditosInvalidos: last.creditos_participacion_invalida,
+			cuotasInvalidas: last.cuotas_participacion_invalida,
+		};
+	}
+	return rows.reduce<ParticipacionTotals>(
+		(total, row) => ({
+			capitalInv:
+				total.capitalInv + numeric(row.capital_inv_participacion_actual),
+			capitalCube:
+				total.capitalCube + numeric(row.capital_cube_participacion_actual),
+			interesIvaInv:
+				total.interesIvaInv + numeric(row.interes_iva_inv_participacion_actual),
+			interesIvaCube:
+				total.interesIvaCube +
+				numeric(row.interes_iva_cube_participacion_actual),
+			creditosInvalidos:
+				total.creditosInvalidos + row.creditos_participacion_invalida,
+			cuotasInvalidas:
+				total.cuotasInvalidas + row.cuotas_participacion_invalida,
+		}),
+		{
+			capitalInv: 0,
+			capitalCube: 0,
+			interesIvaInv: 0,
+			interesIvaCube: 0,
+			creditosInvalidos: 0,
+			cuotasInvalidas: 0,
+		},
+	);
+}

--- a/apps/crm/apps/web/src/lib/reports/monto-a-cobrar.ts
+++ b/apps/crm/apps/web/src/lib/reports/monto-a-cobrar.ts
@@ -105,6 +105,7 @@ export function getMontoACobrarParticipacionTotals(
 	rows: Array<
 		Pick<
 			MontoACobrarParticipacionRow,
+			| "cuotas_count"
 			| "capital_inv_participacion_actual"
 			| "capital_cube_participacion_actual"
 			| "interes_iva_inv_participacion_actual"
@@ -116,7 +117,7 @@ export function getMontoACobrarParticipacionTotals(
 	>,
 	acumulado: boolean,
 ): ParticipacionTotals {
-	const last = rows.at(-1);
+	const last = rows.findLast((row) => row.cuotas_count > 0);
 	const numeric = (value: string) => Number.parseFloat(value) || 0;
 	const creditosInvalidosRango = rows.find(
 		(row) => row.creditos_participacion_invalida_rango !== undefined,

--- a/apps/crm/apps/web/src/lib/reports/reinvestment-report.test.ts
+++ b/apps/crm/apps/web/src/lib/reports/reinvestment-report.test.ts
@@ -27,6 +27,7 @@ const response = (): ReinversionLiquidacionesResponse => ({
 			total_cuota: "111.20",
 			iva_facturado: "1.20",
 			total_distribuido: "111.20",
+			cantidad_liquidaciones: 1,
 		},
 		reinversion_capital: {
 			reinversion_capital: "50.00",
@@ -39,6 +40,7 @@ const response = (): ReinversionLiquidacionesResponse => ({
 			total_cuota: "4.65",
 			iva_facturado: "0.00",
 			total_distribuido: "54.65",
+			cantidad_liquidaciones: 1,
 		},
 	},
 	interesNeto: {
@@ -115,6 +117,24 @@ test("modelo ejecutivo concilia pagado + reinvertido con flujo liquidado", () =>
 		contract: true,
 	});
 	expect(model.rows.map((row) => row.type)).toContain("reinversion_capital");
+});
+
+test("acepta dos centavos de deriva para dos liquidaciones", () => {
+	const data = response();
+	data.porTipo.sin_reinversion.total_capital = "100.02";
+	data.porTipo.sin_reinversion.cantidad_liquidaciones = 2;
+
+	expect(buildReinvestmentReportModel(data).reconciliations.modes).toBe(true);
+	expect(getReportState({ pending: false, error: false, data })).toBe("ready");
+});
+
+test("rechaza la deriva que supera la cantidad de liquidaciones", () => {
+	const data = response();
+	data.porTipo.sin_reinversion.total_capital = "100.03";
+	data.porTipo.sin_reinversion.cantidad_liquidaciones = 2;
+
+	expect(buildReinvestmentReportModel(data).reconciliations.modes).toBe(false);
+	expect(getReportState({ pending: false, error: false, data })).toBe("error");
 });
 
 test("presentación por modalidad conserva destinos, ecuación y composición contable", () => {
@@ -236,6 +256,7 @@ test("variable, excedente y combinada no fabrican fórmulas por destino", () => 
 				total_cuota: "71.20",
 				iva_facturado: "1.20",
 				total_distribuido: "111.20",
+				cantidad_liquidaciones: 1,
 			},
 		};
 		const row = buildReinvestmentReportModel(data).rows[0];
@@ -272,6 +293,11 @@ test("contrato anterior o malformado falla de forma controlada y no concilia", (
 	expect(
 		getReportState({ pending: false, error: false, data: malformed }),
 	).toBe("incompatible");
+
+	const missingModeCount = response() as unknown as Record<string, unknown>;
+	delete (missingModeCount.porTipo as Record<string, Record<string, unknown>>)
+		.sin_reinversion.cantidad_liquidaciones;
+	expect(buildReinvestmentReportModel(missingModeCount).compatible).toBe(false);
 });
 
 test("reemplazo conserva export Excel por inversionista con destinos y capital activo", () => {
@@ -549,6 +575,7 @@ describe("getReportState", () => {
 				total_cuota: "0.00",
 				iva_facturado: "0.00",
 				total_distribuido: "0.00",
+				cantidad_liquidaciones: 1,
 			},
 		};
 		zero.interesNeto = {

--- a/apps/crm/apps/web/src/lib/reports/reinvestment-report.test.ts
+++ b/apps/crm/apps/web/src/lib/reports/reinvestment-report.test.ts
@@ -1,0 +1,587 @@
+import { describe, expect, test } from "bun:test";
+import {
+	buildInvestorExportRows,
+	buildReinvestmentReportModel,
+	buildSecondarySummaryPresentation,
+	canRenderSecondaryDetails,
+	getMonthlyFooterPresentation,
+	getModePresentation,
+	getPublicPartialDetailMessage,
+	getReconciliationPresentation,
+	getReportState,
+	REGISTERED_ZERO_ACTIVITY_COPY,
+} from "./reinvestment-report";
+import type { ReinversionLiquidacionesResponse } from "./scenario";
+
+const response = (): ReinversionLiquidacionesResponse => ({
+	contrato_version: 2,
+	porTipo: {
+		sin_reinversion: {
+			reinversion_capital: "0.00",
+			reinversion_interes: "0.00",
+			reinversion_total: "0.00",
+			total_capital: "100.00",
+			total_interes: "10.00",
+			total_iva: "1.20",
+			total_isr: "0.00",
+			total_cuota: "111.20",
+			iva_facturado: "1.20",
+			total_distribuido: "111.20",
+		},
+		reinversion_capital: {
+			reinversion_capital: "50.00",
+			reinversion_interes: "0.00",
+			reinversion_total: "50.00",
+			total_capital: "50.00",
+			total_interes: "5.00",
+			total_iva: "0.00",
+			total_isr: "0.35",
+			total_cuota: "4.65",
+			iva_facturado: "0.00",
+			total_distribuido: "54.65",
+		},
+	},
+	interesNeto: {
+		conFactura: { interes: "10.00", iva: "1.20", neto: "11.20" },
+		sinFactura: { interes: "5.00", isr: "0.35", neto: "4.65" },
+		cube: { interes: "0.00", iva: "0.00", neto: "0.00" },
+	},
+	pagosExtras: { abonos_capital: "20.00", cancelaciones: "30.00" },
+	porInversionista: [],
+	comprasMes: [{ tipo: "sin_reinversion", cantidad: 1, monto: "80.00" }],
+	detalleInteresNeto: [
+		{
+			inversionista_id: 1,
+			inversionista: "Ana",
+			referencia: "LIQ-1",
+			tratamiento_fiscal: "con_factura",
+			interes: "10.00",
+			iva: "1.20",
+			isr: "0.00",
+			neto: "11.20",
+		},
+		{
+			inversionista_id: 2,
+			inversionista: "Luis",
+			referencia: "LIQ-2",
+			tratamiento_fiscal: "sin_factura",
+			interes: "5.00",
+			iva: "0.00",
+			isr: "0.35",
+			neto: "4.65",
+		},
+	],
+	detallePagosExtras: [
+		{
+			fecha: "2026-07-01",
+			credito: "CR-1",
+			tipo: "abono_capital",
+			monto: "20.00",
+		},
+		{
+			fecha: "2026-07-02",
+			credito: "CR-2",
+			tipo: "cancelacion",
+			monto: "30.00",
+		},
+	],
+	detalleComprasMes: [
+		{
+			fecha: "2026-07-03",
+			inversionista: "Ana",
+			modalidad: "sin_reinversion",
+			monto: "80.00",
+		},
+	],
+	detalle_estado: { disponible: true, error: null },
+	cantidad_liquidaciones: 2,
+});
+
+test("modelo ejecutivo concilia pagado + reinvertido con flujo liquidado", () => {
+	const model = buildReinvestmentReportModel(response());
+	expect(model.totals).toEqual({
+		distributed: 165.85,
+		paid: 115.85,
+		reinvested: 50,
+		active: 0,
+	});
+	expect(model.reconciled).toBe(true);
+	expect(model.reconciliations).toEqual({
+		destinations: true,
+		modes: true,
+		interest: true,
+		extras: true,
+		purchases: true,
+		contract: true,
+	});
+	expect(model.rows.map((row) => row.type)).toContain("reinversion_capital");
+});
+
+test("presentación por modalidad conserva destinos, ecuación y composición contable", () => {
+	const model = buildReinvestmentReportModel(response());
+	const row = model.rows.find((item) => item.type === "reinversion_capital");
+	expect(row).toBeDefined();
+	if (!row) throw new Error("Falta modalidad de reinversión de capital");
+	expect(getModePresentation(row)).toMatchObject({
+		paid: 4.65,
+		reinvested: 50,
+		distributed: 54.65,
+		equation: "Q4.65 pagado + Q50.00 reinvertido = Q54.65 flujo liquidado.",
+		composition: {
+			capital: 50,
+			interest: 5,
+			billedVat: 0,
+			withheldIsr: 0.35,
+			distributed: 54.65,
+		},
+		splitAvailable: true,
+		destinations: {
+			paid: {
+				parts: [{ label: "Rendimiento fiscal neto", value: 4.65 }],
+				result: 4.65,
+				sentence:
+					"Pagado a inversionistas se forma con Q4.65 de rendimiento fiscal neto y da Q4.65.",
+			},
+			reinvested: {
+				parts: [{ label: "Capital", value: 50 }],
+				result: 50,
+				sentence: "Reinvertido se forma con Q50.00 de capital y da Q50.00.",
+			},
+		},
+	});
+});
+
+test("capital, interés y total explican qué forma cada destino", () => {
+	const base = response().porTipo.reinversion_capital;
+	const cases = [
+		{
+			type: "reinversion_capital",
+			paid: 4.65,
+			reinvested: 50,
+			paidParts: ["Rendimiento fiscal neto"],
+			reinvestedParts: ["Capital"],
+		},
+		{
+			type: "reinversion_interes",
+			paid: 50,
+			reinvested: 4.65,
+			paidParts: ["Capital"],
+			reinvestedParts: ["Rendimiento fiscal neto"],
+		},
+		{
+			type: "reinversion_total",
+			paid: 0,
+			reinvested: 54.65,
+			paidParts: [],
+			reinvestedParts: ["Capital", "Rendimiento fiscal neto"],
+		},
+	] as const;
+
+	for (const item of cases) {
+		const data = response();
+		data.porTipo = {
+			[item.type]: {
+				...base,
+				reinversion_capital:
+					item.type === "reinversion_capital" ||
+					item.type === "reinversion_total"
+						? "50.00"
+						: "0.00",
+				reinversion_interes:
+					item.type === "reinversion_interes" ||
+					item.type === "reinversion_total"
+						? "4.65"
+						: "0.00",
+				reinversion_total: item.reinvested.toFixed(2),
+				total_cuota: item.paid.toFixed(2),
+			},
+		};
+		const row = buildReinvestmentReportModel(data).rows[0];
+		expect(row).toBeDefined();
+		if (!row) throw new Error(`Falta modalidad ${item.type}`);
+			const presentation = getModePresentation(row);
+			expect(presentation.destinations?.paid.parts.map((part) => part.label)).toEqual(
+				[...item.paidParts],
+			);
+			expect(
+				presentation.destinations?.reinvested.parts.map((part) => part.label),
+			).toEqual([...item.reinvestedParts]);
+		expect(presentation.destinations?.paid.result).toBe(item.paid);
+		expect(presentation.destinations?.reinvested.result).toBe(item.reinvested);
+		expect(presentation.destinations?.paid.sentence).toContain(
+			"Pagado a inversionistas",
+		);
+		expect(presentation.destinations?.reinvested.sentence).toContain(
+			"Reinvertido",
+		);
+	}
+});
+
+test("variable, excedente y combinada no fabrican fórmulas por destino", () => {
+	for (const type of [
+		"reinversion_variable",
+		"reinversion_excedente",
+		"reinversion_combinada",
+	]) {
+		const data = response();
+		data.porTipo = {
+			[type]: {
+				reinversion_capital: "0.00",
+				reinversion_interes: "0.00",
+				reinversion_total: "40.00",
+				total_capital: "100.00",
+				total_interes: "10.00",
+				total_iva: "1.20",
+				total_isr: "0.00",
+				total_cuota: "71.20",
+				iva_facturado: "1.20",
+				total_distribuido: "111.20",
+			},
+		};
+		const row = buildReinvestmentReportModel(data).rows[0];
+		expect(row).toBeDefined();
+		if (!row) throw new Error(`Falta modalidad ${type}`);
+		const presentation = getModePresentation(row);
+		expect(presentation.destinations).toBeNull();
+		expect(presentation.splitAvailable).toBe(false);
+		expect(presentation.splitNote).toContain(
+			"no está disponible en la fuente actual",
+		);
+	}
+});
+
+test("contrato anterior o malformado falla de forma controlada y no concilia", () => {
+	const legacy = { ...response() } as Record<string, unknown>;
+	delete legacy.contrato_version;
+	expect(() => buildReinvestmentReportModel(legacy)).not.toThrow();
+	expect(buildReinvestmentReportModel(legacy)).toMatchObject({
+		compatible: false,
+		reconciled: false,
+		rows: [],
+	});
+	expect(getReportState({ pending: false, error: false, data: legacy })).toBe(
+		"incompatible",
+	);
+
+	const malformed = {
+		...response(),
+		contrato_version: 2,
+		detalleInteresNeto: null,
+	};
+	expect(() => buildReinvestmentReportModel(malformed)).not.toThrow();
+	expect(
+		getReportState({ pending: false, error: false, data: malformed }),
+	).toBe("incompatible");
+});
+
+test("reemplazo conserva export Excel por inversionista con destinos y capital activo", () => {
+	const data = response();
+	data.porInversionista = [
+		{
+			inversionista_id: 1,
+			nombre: "Ana",
+			tipo_reinversion: "reinversion_capital",
+			reinversion_capital: "50.00",
+			reinversion_interes: "0.00",
+			reinversion: "50.00",
+			a_recibir: "4.65",
+			monto_aportado: "950.00",
+			capital_activo: "1000.00",
+		},
+	];
+	expect(buildInvestorExportRows(data)).toEqual([
+		{
+			Inversionista: "Ana",
+			Modalidad: "reinversion_capital",
+			Pagado: "4.65",
+			Reinvertido: "50.00",
+			"Capital activo": "1000.00",
+		},
+	]);
+	expect(buildInvestorExportRows({})).toEqual([]);
+});
+
+test("presentación restaura los tres subresúmenes canónicos y sus fórmulas", () => {
+	expect(buildSecondarySummaryPresentation(response())).toEqual([
+		{
+			key: "interest",
+			label: "Interés neto",
+			total: 15.85,
+			items: [
+				{
+					label: "Con factura",
+					value: 11.2,
+					formula: "Q10.00 + Q1.20 IVA = Q11.20",
+				},
+				{
+					label: "Sin factura",
+					value: 4.65,
+					formula: "Q5.00 − Q0.35 ISR = Q4.65",
+				},
+				{
+					label: "CUBE",
+					value: 0,
+					formula: "Q0.00 + Q0.00 IVA = Q0.00",
+				},
+			],
+		},
+		{
+			key: "extras",
+			label: "Pagos extras",
+			total: 50,
+			items: [
+				{ label: "Abonos a capital", value: 20 },
+				{ label: "Cancelaciones", value: 30 },
+			],
+		},
+		{
+			key: "purchases",
+			label: "Compras del mes",
+			total: 80,
+			items: [
+				{
+					label: "Tradicional",
+					value: 80,
+					meta: "1 compra",
+				},
+			],
+		},
+	]);
+});
+
+test("footer mensual presenta la misma conciliación que el modelo", () => {
+	const model = buildReinvestmentReportModel(response());
+	expect(getMonthlyFooterPresentation(model)).toEqual({
+		paid: 115.85,
+		reinvested: 50,
+		distributed: 165.85,
+		equation:
+			"Q115.85 pagado + Q50.00 reinvertido = Q165.85 flujo liquidado.",
+	});
+});
+
+test("modelo fail-closed marca no reconciliado cualquier detalle descuadrado, incluido CUBE", () => {
+	const interestMismatch = response();
+	interestMismatch.detalleInteresNeto[0].neto = "10.20";
+	expect(buildReinvestmentReportModel(interestMismatch).reconciled).toBe(false);
+
+	const cubeMismatch = response();
+	cubeMismatch.interesNeto.cube.neto = "22.40";
+	cubeMismatch.detalleInteresNeto.push(
+		{
+			inversionista_id: 0,
+			inversionista: "CUBE",
+			referencia: "CUBE",
+			tratamiento_fiscal: "cube",
+			interes: "22.40",
+			iva: "0.00",
+			isr: "0.00",
+			neto: "22.40",
+		},
+		{
+			inversionista_id: 0,
+			inversionista: "CUBE",
+			referencia: "CUBE-duplicado",
+			tratamiento_fiscal: "cube",
+			interes: "22.40",
+			iva: "0.00",
+			isr: "0.00",
+			neto: "22.40",
+		},
+	);
+	expect(buildReinvestmentReportModel(cubeMismatch).reconciled).toBe(false);
+
+	const extrasMismatch = response();
+	extrasMismatch.detallePagosExtras[0].monto = "19.99";
+	expect(buildReinvestmentReportModel(extrasMismatch).reconciled).toBe(false);
+
+	const purchasesMismatch = response();
+	purchasesMismatch.detalleComprasMes[0].monto = "79.99";
+	expect(buildReinvestmentReportModel(purchasesMismatch).reconciled).toBe(
+		false,
+	);
+});
+
+test("dos compras del mismo inversionista, fecha y modalidad concilian como dos operaciones", () => {
+	const purchases = response();
+	purchases.comprasMes = [
+		{ tipo: "sin_reinversion", cantidad: 2, monto: "80.00" },
+	];
+	purchases.detalleComprasMes = [
+		{
+			fecha: "2026-07-03",
+			inversionista: "Ana",
+			modalidad: "sin_reinversion",
+			monto: "40.00",
+		},
+		{
+			fecha: "2026-07-03",
+			inversionista: "Ana",
+			modalidad: "sin_reinversion",
+			monto: "40.00",
+		},
+	];
+
+	const model = buildReinvestmentReportModel(purchases);
+	expect(model.reconciliations.purchases).toBe(true);
+	expect(getReportState({ pending: false, error: false, data: purchases })).toBe(
+		"ready",
+	);
+});
+
+test("ruta Admin reportes entrega query real, estados y respuesta íntegra al componente productivo", async () => {
+	const routeSource = await Bun.file(
+		new URL("../../routes/admin/reports/index.tsx", import.meta.url),
+	).text();
+	const queryStart = routeSource.indexOf(
+		"const reinversionLiquidacionesQuery = useQuery",
+	);
+	const queryEnd = routeSource.indexOf(
+		"const investorsCarteraQuery",
+		queryStart,
+	);
+	const renderStart = routeSource.indexOf("<ReinvestmentReport");
+	const renderEnd = routeSource.indexOf("/>", renderStart);
+	const queryWiring = routeSource.slice(queryStart, queryEnd);
+	const renderWiring = routeSource.slice(renderStart, renderEnd);
+
+	expect(queryWiring).toContain(
+		"orpc.getReinversionLiquidaciones.queryOptions",
+	);
+	expect(queryWiring).toContain("input: { mes: flujoMesNum, anio: flujoAnioNum }");
+	expect(renderWiring).toContain("data={reinversionData}");
+	expect(renderWiring).toContain(
+		"isPending={reinversionLiquidacionesQuery.isPending}",
+	);
+	expect(renderWiring).toContain(
+		"isError={reinversionLiquidacionesQuery.isError}",
+	);
+	expect(renderWiring).toContain(
+		"onRetry={() => reinversionLiquidacionesQuery.refetch()}",
+	);
+	expect(renderWiring).not.toContain("detalleInteresNeto:");
+	expect(renderWiring).not.toContain("detalleComprasMes:");
+});
+
+test("el modelo no permite descuadres compensados entre subcategorías", () => {
+	const interest = response();
+	interest.detalleInteresNeto[0].neto = "10.20";
+	interest.detalleInteresNeto[1].neto = "5.65";
+	expect(buildReinvestmentReportModel(interest).reconciliations.interest).toBe(
+		false,
+	);
+
+	const extras = response();
+	extras.detallePagosExtras[0].monto = "19.00";
+	extras.detallePagosExtras[1].monto = "31.00";
+	expect(buildReinvestmentReportModel(extras).reconciliations.extras).toBe(false);
+});
+
+describe("presentación fail-closed", () => {
+	test("solo presenta conciliación verificada para ready + reconciled", () => {
+		expect(getReconciliationPresentation("ready", true)).toBe("verified");
+		expect(getReconciliationPresentation("ready", false)).toBe("failed");
+	});
+
+	test("partial nunca presenta confianza ni totales secundarios", () => {
+		expect(getReconciliationPresentation("partial", true)).toBe("unavailable");
+		expect(getReconciliationPresentation("partial", false)).toBe("unavailable");
+		expect(canRenderSecondaryDetails("partial")).toBe(false);
+		expect(canRenderSecondaryDetails("ready")).toBe(true);
+		expect(canRenderSecondaryDetails("error")).toBe(false);
+	});
+});
+
+describe("getReportState", () => {
+	test("distingue carga, error, vacío, parcial y listo", () => {
+		expect(getReportState({ pending: true, error: false })).toBe("loading");
+		expect(getReportState({ pending: false, error: true })).toBe("error");
+		expect(getReportState({ pending: false, error: false })).toBe("empty");
+		expect(
+			getReportState({
+				pending: false,
+				error: false,
+				data: {
+					...response(),
+					detalle_estado: {
+						disponible: false,
+						error: "No fue posible recuperar el detalle.",
+					},
+				},
+			}),
+		).toBe("partial");
+		expect(
+			getReportState({ pending: false, error: false, data: response() }),
+		).toBe("ready");
+	});
+
+	test("una respuesta completa descuadrada fuerza error", () => {
+		const mismatch = response();
+		mismatch.detalleInteresNeto[0].neto = "10.20";
+		expect(
+			getReportState({ pending: false, error: false, data: mismatch }),
+		).toBe("error");
+	});
+
+	test("una respuesta parcial con modalidades descuadradas fuerza error", () => {
+		const mismatch = response();
+		mismatch.detalle_estado = {
+			disponible: false,
+			error: "No fue posible recuperar el detalle.",
+		};
+		mismatch.porTipo.sin_reinversion.total_distribuido = "999.99";
+		expect(
+			getReportState({ pending: false, error: false, data: mismatch }),
+		).toBe("error");
+	});
+
+	test("distingue liquidaciones registradas sin flujo ni posición", () => {
+		const zero = response();
+		zero.porTipo = {
+			sin_reinversion: {
+				reinversion_capital: "0.00",
+				reinversion_interes: "0.00",
+				reinversion_total: "0.00",
+				total_capital: "0.00",
+				total_interes: "0.00",
+				total_iva: "0.00",
+				total_isr: "0.00",
+				total_cuota: "0.00",
+				iva_facturado: "0.00",
+				total_distribuido: "0.00",
+			},
+		};
+		zero.interesNeto = {
+			conFactura: { interes: "0.00", iva: "0.00", neto: "0.00" },
+			sinFactura: { interes: "0.00", isr: "0.00", neto: "0.00" },
+			cube: { interes: "0.00", iva: "0.00", neto: "0.00" },
+		};
+		zero.pagosExtras = { abonos_capital: "0.00", cancelaciones: "0.00" };
+		zero.comprasMes = [];
+		zero.detalleInteresNeto = [];
+		zero.detallePagosExtras = [];
+		zero.detalleComprasMes = [];
+		zero.cantidad_liquidaciones = 1;
+
+		expect(getReportState({ pending: false, error: false, data: zero })).toBe(
+			"registered-zero",
+		);
+		expect(REGISTERED_ZERO_ACTIVITY_COPY).toContain(
+			"Hay liquidaciones registradas",
+		);
+		expect(REGISTERED_ZERO_ACTIVITY_COPY).toContain(
+			"no generan efectivo ni reinversión",
+		);
+	});
+});
+
+test("el copy parcial nunca expone el error técnico recibido", () => {
+	const secret =
+		'relation "cartera.liquidaciones" does not exist at 10.0.0.8:5432';
+	const copy = getPublicPartialDetailMessage(secret);
+	expect(copy).toBe(
+		"Los detalles no están disponibles para este período. No se muestran totales secundarios.",
+	);
+	expect(copy).not.toContain("cartera.liquidaciones");
+	expect(copy).not.toContain("10.0.0.8");
+});

--- a/apps/crm/apps/web/src/lib/reports/reinvestment-report.test.ts
+++ b/apps/crm/apps/web/src/lib/reports/reinvestment-report.test.ts
@@ -613,6 +613,22 @@ describe("presentación fail-closed", () => {
 });
 
 describe("getReportState", () => {
+	const purchaseOnlyResponse = () => {
+		const data = response();
+		data.porTipo = {};
+		data.interesNeto = {
+			conFactura: { interes: "0.00", iva: "0.00", neto: "0.00" },
+			sinFactura: { interes: "0.00", isr: "0.00", neto: "0.00" },
+			cube: { interes: "0.00", iva: "0.00", neto: "0.00" },
+		};
+		data.pagosExtras = { abonos_capital: "0.00", cancelaciones: "0.00" };
+		data.porInversionista = [];
+		data.detalleInteresNeto = [];
+		data.detallePagosExtras = [];
+		data.cantidad_liquidaciones = 0;
+		return data;
+	};
+
 	test("distingue carga, error, vacío, parcial y listo", () => {
 		expect(getReportState({ pending: true, error: false })).toBe("loading");
 		expect(getReportState({ pending: false, error: true })).toBe("error");
@@ -653,6 +669,31 @@ describe("getReportState", () => {
 		expect(
 			getReportState({ pending: false, error: false, data: mismatch }),
 		).toBe("error");
+	});
+
+	test("conserva compras conciliadas aunque no existan liquidaciones", () => {
+		const purchases = purchaseOnlyResponse();
+
+		expect(buildReinvestmentReportModel(purchases).reconciled).toBe(true);
+		expect(
+			getReportState({ pending: false, error: false, data: purchases }),
+		).toBe("ready");
+		expect(
+			buildSecondarySummaryPresentation(purchases).find(
+				(summary) => summary.key === "purchases",
+			)?.total,
+		).toBe(80);
+	});
+
+	test("mantiene vacío un mes compatible sin liquidaciones ni compras", () => {
+		const empty = purchaseOnlyResponse();
+		empty.comprasMes = [];
+		empty.detalleComprasMes = [];
+
+		expect(buildReinvestmentReportModel(empty).reconciled).toBe(true);
+		expect(
+			getReportState({ pending: false, error: false, data: empty }),
+		).toBe("empty");
 	});
 
 	test("distingue liquidaciones registradas sin flujo ni posición", () => {

--- a/apps/crm/apps/web/src/lib/reports/reinvestment-report.test.ts
+++ b/apps/crm/apps/web/src/lib/reports/reinvestment-report.test.ts
@@ -327,6 +327,100 @@ test("reemplazo conserva export Excel por inversionista con destinos y capital a
 	expect(buildInvestorExportRows({})).toEqual([]);
 });
 
+test("rechaza inversionistas con campos monetarios no numéricos", () => {
+	const nan = response();
+	nan.porInversionista = [
+		{
+			inversionista_id: 1,
+			nombre: "Ana",
+			tipo_reinversion: "reinversion_capital",
+			reinversion_capital: "NaN",
+			reinversion_interes: "0.00",
+			reinversion: "0.00",
+			a_recibir: "0.00",
+			monto_aportado: "0.00",
+			capital_activo: "0.00",
+		},
+	];
+	expect(buildReinvestmentReportModel(nan).compatible).toBe(false);
+	expect(getReportState({ pending: false, error: false, data: nan })).toBe(
+		"incompatible",
+	);
+
+	const nonnumeric = response();
+	nonnumeric.porInversionista = [
+		{
+			inversionista_id: 1,
+			nombre: "Ana",
+			tipo_reinversion: "reinversion_capital",
+			reinversion_capital: "0.00",
+			reinversion_interes: "0.00",
+			reinversion: "0.00",
+			a_recibir: "no-numérico",
+			monto_aportado: "0.00",
+			capital_activo: "0.00",
+		},
+	];
+	expect(buildReinvestmentReportModel(nonnumeric).compatible).toBe(false);
+	expect(
+		getReportState({ pending: false, error: false, data: nonnumeric }),
+	).toBe("incompatible");
+});
+
+test("acepta campos monetarios válidos y conserva capital activo sin flujo", () => {
+	const zero = response();
+	zero.porTipo = {
+		sin_reinversion: {
+			reinversion_capital: "0.00",
+			reinversion_interes: "0.00",
+			reinversion_total: "0.00",
+			total_capital: "0.00",
+			total_interes: "0.00",
+			total_iva: "0.00",
+			total_isr: "0.00",
+			total_cuota: "0.00",
+			iva_facturado: "0.00",
+			total_distribuido: "0.00",
+			cantidad_liquidaciones: 1,
+		},
+	};
+	zero.interesNeto = {
+		conFactura: { interes: "0.00", iva: "0.00", neto: "0.00" },
+		sinFactura: { interes: "0.00", isr: "0.00", neto: "0.00" },
+		cube: { interes: "0.00", iva: "0.00", neto: "0.00" },
+	};
+	zero.pagosExtras = { abonos_capital: "0.00", cancelaciones: "0.00" };
+	zero.porInversionista = [
+		{
+			inversionista_id: 1,
+			nombre: "Ana",
+			tipo_reinversion: "sin_reinversion",
+			reinversion_capital: "0.00",
+			reinversion_interes: "0.00",
+			reinversion: "0.00",
+			a_recibir: "0.00",
+			monto_aportado: "0.00",
+			capital_activo: "1250.00",
+		},
+	];
+	zero.comprasMes = [];
+	zero.detalleInteresNeto = [];
+	zero.detallePagosExtras = [];
+	zero.detalleComprasMes = [];
+
+	const model = buildReinvestmentReportModel(zero);
+	expect(model.compatible).toBe(true);
+	expect(model.totals).toEqual({
+		distributed: 0,
+		paid: 0,
+		reinvested: 0,
+		active: 1250,
+	});
+	expect(getReportState({ pending: false, error: false, data: zero })).toBe(
+		"ready",
+	);
+});
+
 test("presentación restaura los tres subresúmenes canónicos y sus fórmulas", () => {
 	expect(buildSecondarySummaryPresentation(response())).toEqual([
 		{

--- a/apps/crm/apps/web/src/lib/reports/reinvestment-report.test.ts
+++ b/apps/crm/apps/web/src/lib/reports/reinvestment-report.test.ts
@@ -4,8 +4,8 @@ import {
 	buildReinvestmentReportModel,
 	buildSecondarySummaryPresentation,
 	canRenderSecondaryDetails,
-	getMonthlyFooterPresentation,
 	getModePresentation,
+	getMonthlyFooterPresentation,
 	getPublicPartialDetailMessage,
 	getReconciliationPresentation,
 	getReportState,
@@ -44,8 +44,7 @@ const response = (): ReinversionLiquidacionesResponse => ({
 		},
 	},
 	interesNeto: {
-		conFactura: { interes: "10.00", iva: "1.20", neto: "11.20" },
-		sinFactura: { interes: "5.00", isr: "0.35", neto: "4.65" },
+		noVerificado: { interes: "15.00" },
 		cube: { interes: "0.00", iva: "0.00", neto: "0.00" },
 	},
 	pagosExtras: { abonos_capital: "20.00", cancelaciones: "30.00" },
@@ -56,21 +55,19 @@ const response = (): ReinversionLiquidacionesResponse => ({
 			inversionista_id: 1,
 			inversionista: "Ana",
 			referencia: "LIQ-1",
-			tratamiento_fiscal: "con_factura",
+			tratamiento_fiscal: "no_verificado",
 			interes: "10.00",
-			iva: "1.20",
+			iva: "0.00",
 			isr: "0.00",
-			neto: "11.20",
 		},
 		{
 			inversionista_id: 2,
 			inversionista: "Luis",
 			referencia: "LIQ-2",
-			tratamiento_fiscal: "sin_factura",
+			tratamiento_fiscal: "no_verificado",
 			interes: "5.00",
 			iva: "0.00",
-			isr: "0.35",
-			neto: "4.65",
+			isr: "0.00",
 		},
 	],
 	detallePagosExtras: [
@@ -115,11 +112,12 @@ test("modelo ejecutivo concilia pagado + reinvertido con flujo liquidado", () =>
 		extras: true,
 		purchases: true,
 		contract: true,
+		composition: "unavailable",
 	});
 	expect(model.rows.map((row) => row.type)).toContain("reinversion_capital");
 });
 
-test("acepta dos centavos de deriva para dos liquidaciones", () => {
+test("conserva la conciliación canónica aunque la metadata fiscal tenga deriva", () => {
 	const data = response();
 	data.porTipo.sin_reinversion.total_capital = "100.02";
 	data.porTipo.sin_reinversion.cantidad_liquidaciones = 2;
@@ -128,16 +126,97 @@ test("acepta dos centavos de deriva para dos liquidaciones", () => {
 	expect(getReportState({ pending: false, error: false, data })).toBe("ready");
 });
 
-test("rechaza la deriva que supera la cantidad de liquidaciones", () => {
+test("IVA e ISR registrados sin asignación fiscal dejan la composición no disponible", () => {
 	const data = response();
-	data.porTipo.sin_reinversion.total_capital = "100.03";
-	data.porTipo.sin_reinversion.cantidad_liquidaciones = 2;
+	data.porTipo.sin_reinversion.iva_facturado = "0.00";
+	data.porTipo.sin_reinversion.total_iva = "1.20";
+	data.porTipo.sin_reinversion.total_isr = "0.35";
+	data.porTipo.sin_reinversion.total_cuota = "110.85";
+	data.porTipo.sin_reinversion.total_distribuido = "110.85";
+	const model = buildReinvestmentReportModel(data);
+
+	expect(getReportState({ pending: false, error: false, data })).toBe("ready");
+	expect(model.rows[0]?.compositionStatus).toBe("unavailable");
+	expect(model.reconciliations.composition).toBe("unavailable");
+	expect(getReconciliationPresentation("ready", model.reconciled, model)).toBe(
+		"unavailable",
+	);
+});
+
+test("distingue una conciliación exacta de una dentro de tolerancia", () => {
+	const exactData = response();
+	exactData.porTipo.sin_reinversion = {
+		reinversion_capital: "0.00",
+		reinversion_interes: "0.00",
+		reinversion_total: "0.00",
+		total_capital: "100.00",
+		total_interes: "0.00",
+		total_iva: "0.00",
+		total_isr: "0.00",
+		total_cuota: "100.00",
+		iva_facturado: "0.00",
+		total_distribuido: "100.00",
+		cantidad_liquidaciones: 1,
+	};
+	exactData.porTipo.reinversion_capital = {
+		reinversion_capital: "50.00",
+		reinversion_interes: "0.00",
+		reinversion_total: "50.00",
+		total_capital: "100.00",
+		total_interes: "0.00",
+		total_iva: "0.00",
+		total_isr: "0.00",
+		total_cuota: "50.00",
+		iva_facturado: "0.00",
+		total_distribuido: "100.00",
+		cantidad_liquidaciones: 1,
+	};
+	const exact = buildReinvestmentReportModel(exactData);
+	expect(getReconciliationPresentation("ready", exact.reconciled, exact)).toBe(
+		"verified",
+	);
+
+	const tolerated = structuredClone(exactData);
+	tolerated.porTipo.sin_reinversion = {
+		reinversion_capital: "0.00",
+		reinversion_interes: "0.00",
+		reinversion_total: "0.00",
+		total_capital: "100.01",
+		total_interes: "0.00",
+		total_iva: "0.00",
+		total_isr: "0.00",
+		total_cuota: "100.00",
+		iva_facturado: "0.00",
+		total_distribuido: "100.00",
+		cantidad_liquidaciones: 1,
+	};
+	const model = buildReinvestmentReportModel(tolerated);
+	expect(model.reconciled).toBe(true);
+	expect(getReconciliationPresentation("ready", model.reconciled, model)).toBe(
+		"tolerance",
+	);
+
+	const beyondTolerance = structuredClone(exactData);
+	beyondTolerance.porTipo.sin_reinversion = {
+		...tolerated.porTipo.sin_reinversion,
+		total_capital: "100.02",
+	};
+	const failed = buildReinvestmentReportModel(beyondTolerance);
+	expect(failed.reconciled).toBe(false);
+	expect(
+		getReconciliationPresentation("ready", failed.reconciled, failed),
+	).toBe("failed");
+});
+
+test("rechaza un destino que no concilia", () => {
+	const data = response();
+	data.porTipo.sin_reinversion.total_distribuido = "100.03";
 
 	expect(buildReinvestmentReportModel(data).reconciliations.modes).toBe(false);
 	expect(getReportState({ pending: false, error: false, data })).toBe("error");
 });
 
-test("presentación por modalidad conserva destinos, ecuación y composición contable", () => {
+test("modalidad actual no presenta fórmulas históricas sin snapshot", () => {
 	const model = buildReinvestmentReportModel(response());
 	const row = model.rows.find((item) => item.type === "reinversion_capital");
 	expect(row).toBeDefined();
@@ -146,102 +225,18 @@ test("presentación por modalidad conserva destinos, ecuación y composición co
 		paid: 4.65,
 		reinvested: 50,
 		distributed: 54.65,
-		equation: "Q4.65 pagado + Q50.00 reinvertido = Q54.65 flujo liquidado.",
-		composition: {
-			capital: 50,
-			interest: 5,
-			billedVat: 0,
-			withheldIsr: 0.35,
-			distributed: 54.65,
-		},
-		splitAvailable: true,
-		destinations: {
-			paid: {
-				parts: [{ label: "Rendimiento fiscal neto", value: 4.65 }],
-				result: 4.65,
-				sentence:
-					"Pagado a inversionistas se forma con Q4.65 de rendimiento fiscal neto y da Q4.65.",
-			},
-			reinvested: {
-				parts: [{ label: "Capital", value: 50 }],
-				result: 50,
-				sentence: "Reinvertido se forma con Q50.00 de capital y da Q50.00.",
-			},
-		},
+		splitAvailable: false,
+		destinations: null,
 	});
 });
 
-test("capital, interés y total explican qué forma cada destino", () => {
-	const base = response().porTipo.reinversion_capital;
-	const cases = [
-		{
-			type: "sin_reinversion",
-			paid: 54.65,
-			reinvested: 0,
-			paidParts: ["Capital", "Rendimiento fiscal neto"],
-			reinvestedParts: [],
-		},
-		{
-			type: "reinversion_capital",
-			paid: 4.65,
-			reinvested: 50,
-			paidParts: ["Rendimiento fiscal neto"],
-			reinvestedParts: ["Capital"],
-		},
-		{
-			type: "reinversion_interes",
-			paid: 50,
-			reinvested: 4.65,
-			paidParts: ["Capital"],
-			reinvestedParts: ["Rendimiento fiscal neto"],
-		},
-		{
-			type: "reinversion_total",
-			paid: 0,
-			reinvested: 54.65,
-			paidParts: [],
-			reinvestedParts: ["Capital", "Rendimiento fiscal neto"],
-		},
-	] as const;
-
-	for (const item of cases) {
-		const data = response();
-		data.porTipo = {
-			[item.type]: {
-				...base,
-				reinversion_capital:
-					item.type === "reinversion_capital" ||
-					item.type === "reinversion_total"
-						? "50.00"
-						: "0.00",
-				reinversion_interes:
-					item.type === "reinversion_interes" ||
-					item.type === "reinversion_total"
-						? "4.65"
-						: "0.00",
-				reinversion_total: item.reinvested.toFixed(2),
-				total_cuota: item.paid.toFixed(2),
-			},
-		};
-		const row = buildReinvestmentReportModel(data).rows[0];
-		expect(row).toBeDefined();
-		if (!row) throw new Error(`Falta modalidad ${item.type}`);
-			const presentation = getModePresentation(row);
-			expect(presentation.destinations?.paid.parts.map((part) => part.label)).toEqual(
-				[...item.paidParts],
-			);
-			expect(
-				presentation.destinations?.reinvested.parts.map((part) => part.label),
-			).toEqual([...item.reinvestedParts]);
-		expect(presentation.destinations?.paid.result).toBe(item.paid);
-		expect(presentation.destinations?.reinvested.result).toBe(item.reinvested);
-		expect(presentation.destinations?.paid.sentence).toContain(
-			"Pagado a inversionistas",
-		);
-		expect(presentation.destinations?.reinvested.sentence).toContain(
-			"Reinvertido",
-		);
-	}
+test("cambio de modalidad actual no reclasifica ni verifica el flujo histórico", () => {
+	const data = response();
+	data.porTipo = { reinversion_total: data.porTipo.reinversion_capital };
+	const row = buildReinvestmentReportModel(data).rows[0];
+	expect(row?.label).toBe("Interés compuesto");
+	if (!row) throw new Error("Se esperaba una modalidad");
+	expect(getModePresentation(row).destinations).toBeNull();
 });
 
 test("suprime fórmulas de una modalidad actual que no concilia con destinos históricos", () => {
@@ -332,6 +327,57 @@ test("contrato anterior o malformado falla de forma controlada y no concilia", (
 	expect(buildReinvestmentReportModel(missingModeCount).compatible).toBe(false);
 });
 
+test("contrato web rechaza categorías, ids y conteos fuera del contrato", () => {
+	const invalidCategory = response() as unknown as Record<string, unknown>;
+	(
+		invalidCategory.detalleInteresNeto as Record<string, unknown>[]
+	)[0].tratamiento_fiscal = "inventado";
+	expect(buildReinvestmentReportModel(invalidCategory).compatible).toBe(false);
+
+	const invalidCount = response() as unknown as Record<string, unknown>;
+	(invalidCount.comprasMes as Record<string, unknown>[])[0].cantidad = 1.5;
+	expect(buildReinvestmentReportModel(invalidCount).compatible).toBe(false);
+
+	const invalidId = response() as unknown as Record<string, unknown>;
+	invalidId.porInversionista = [
+		{
+			inversionista_id: -1,
+			nombre: "Ana",
+			tipo_reinversion: "sin_reinversion",
+			reinversion_capital: "0.00",
+			reinversion_interes: "0.00",
+			reinversion: "0.00",
+			a_recibir: "0.00",
+			capital_activo: "0.00",
+		},
+	];
+	expect(buildReinvestmentReportModel(invalidId).compatible).toBe(false);
+
+	const invalidMoney = response() as unknown as Record<string, unknown>;
+	(invalidMoney.pagosExtras as Record<string, unknown>).abonos_capital =
+		"-0.01";
+	expect(buildReinvestmentReportModel(invalidMoney).compatible).toBe(false);
+	for (const value of ["1e2", "0x10"]) {
+		const invalidDecimal = response() as unknown as Record<string, unknown>;
+		(invalidDecimal.pagosExtras as Record<string, unknown>).abonos_capital =
+			value;
+		expect(buildReinvestmentReportModel(invalidDecimal).compatible).toBe(false);
+	}
+
+	const invalidMode = response() as unknown as Record<string, unknown>;
+	invalidMode.porTipo = { inventado: response().porTipo.sin_reinversion };
+	expect(buildReinvestmentReportModel(invalidMode).compatible).toBe(false);
+
+	for (const detalle_estado of [
+		{ disponible: true, error: "contradictorio" },
+		{ disponible: false, error: " " },
+	]) {
+		const contradictory = response() as unknown as Record<string, unknown>;
+		contradictory.detalle_estado = detalle_estado;
+		expect(buildReinvestmentReportModel(contradictory).compatible).toBe(false);
+	}
+});
+
 test("reemplazo conserva export Excel por inversionista con destinos y capital activo", () => {
 	const data = response();
 	data.porInversionista = [
@@ -343,17 +389,16 @@ test("reemplazo conserva export Excel por inversionista con destinos y capital a
 			reinversion_interes: "0.00",
 			reinversion: "50.00",
 			a_recibir: "4.65",
-			monto_aportado: "950.00",
 			capital_activo: "1000.00",
 		},
 	];
 	expect(buildInvestorExportRows(data)).toEqual([
 		{
 			Inversionista: "Ana",
-			Modalidad: "reinversion_capital",
+			"Modalidad actual": "reinversion_capital",
 			Pagado: "4.65",
 			Reinvertido: "50.00",
-			"Capital activo": "1000.00",
+			"Capital activo actual": "1000.00",
 		},
 	]);
 	expect(buildInvestorExportRows({})).toEqual([]);
@@ -370,7 +415,6 @@ test("rechaza inversionistas con campos monetarios no numéricos", () => {
 			reinversion_interes: "0.00",
 			reinversion: "0.00",
 			a_recibir: "0.00",
-			monto_aportado: "0.00",
 			capital_activo: "0.00",
 		},
 	];
@@ -389,7 +433,6 @@ test("rechaza inversionistas con campos monetarios no numéricos", () => {
 			reinversion_interes: "0.00",
 			reinversion: "0.00",
 			a_recibir: "no-numérico",
-			monto_aportado: "0.00",
 			capital_activo: "0.00",
 		},
 	];
@@ -429,8 +472,7 @@ test("acepta campos monetarios válidos y conserva capital activo sin flujo", ()
 		},
 	};
 	zero.interesNeto = {
-		conFactura: { interes: "0.00", iva: "0.00", neto: "0.00" },
-		sinFactura: { interes: "0.00", isr: "0.00", neto: "0.00" },
+		noVerificado: { interes: "0.00" },
 		cube: { interes: "0.00", iva: "0.00", neto: "0.00" },
 	};
 	zero.pagosExtras = { abonos_capital: "0.00", cancelaciones: "0.00" };
@@ -443,7 +485,6 @@ test("acepta campos monetarios válidos y conserva capital activo sin flujo", ()
 			reinversion_interes: "0.00",
 			reinversion: "0.00",
 			a_recibir: "0.00",
-			monto_aportado: "0.00",
 			capital_activo: "1250.00",
 		},
 	];
@@ -469,18 +510,13 @@ test("presentación restaura los tres subresúmenes canónicos y sus fórmulas",
 	expect(buildSecondarySummaryPresentation(response())).toEqual([
 		{
 			key: "interest",
-			label: "Interés neto",
-			total: 15.85,
+			label: "Interés registrado",
+			total: 15,
 			items: [
 				{
-					label: "Con factura",
-					value: 11.2,
-					formula: "Q10.00 + Q1.20 IVA = Q11.20",
-				},
-				{
-					label: "Sin factura",
-					value: 4.65,
-					formula: "Q5.00 − Q0.35 ISR = Q4.65",
+					label: "Sin asignación fiscal",
+					value: 15,
+					formula: "Q15.00 interés registrado sin asignación fiscal",
 				},
 				{
 					label: "CUBE",
@@ -519,14 +555,13 @@ test("footer mensual presenta la misma conciliación que el modelo", () => {
 		paid: 115.85,
 		reinvested: 50,
 		distributed: 165.85,
-		equation:
-			"Q115.85 pagado + Q50.00 reinvertido = Q165.85 flujo liquidado.",
+		equation: "Q115.85 pagado + Q50.00 reinvertido = Q165.85 flujo liquidado.",
 	});
 });
 
 test("modelo fail-closed marca no reconciliado cualquier detalle descuadrado, incluido CUBE", () => {
 	const interestMismatch = response();
-	interestMismatch.detalleInteresNeto[0].neto = "10.20";
+	interestMismatch.detalleInteresNeto[0].interes = "10.20";
 	expect(buildReinvestmentReportModel(interestMismatch).reconciled).toBe(false);
 
 	const cubeMismatch = response();
@@ -588,9 +623,9 @@ test("dos compras del mismo inversionista, fecha y modalidad concilian como dos 
 
 	const model = buildReinvestmentReportModel(purchases);
 	expect(model.reconciliations.purchases).toBe(true);
-	expect(getReportState({ pending: false, error: false, data: purchases })).toBe(
-		"ready",
-	);
+	expect(
+		getReportState({ pending: false, error: false, data: purchases }),
+	).toBe("ready");
 });
 
 test("ruta Admin reportes entrega query real, estados y respuesta íntegra al componente productivo", async () => {
@@ -612,7 +647,9 @@ test("ruta Admin reportes entrega query real, estados y respuesta íntegra al co
 	expect(queryWiring).toContain(
 		"orpc.getReinversionLiquidaciones.queryOptions",
 	);
-	expect(queryWiring).toContain("input: { mes: flujoMesNum, anio: flujoAnioNum }");
+	expect(queryWiring).toContain(
+		"input: { mes: flujoMesNum, anio: flujoAnioNum }",
+	);
 	expect(renderWiring).toContain("data={reinversionData}");
 	expect(renderWiring).toContain(
 		"isPending={reinversionLiquidacionesQuery.isPending}",
@@ -627,10 +664,27 @@ test("ruta Admin reportes entrega query real, estados y respuesta íntegra al co
 	expect(renderWiring).not.toContain("detalleComprasMes:");
 });
 
+test("UI y export nombran el capital como posición actual", async () => {
+	const component = await Bun.file(
+		new URL(
+			"../../components/reports/reinvestment-report.tsx",
+			import.meta.url,
+		),
+	).text();
+	expect(component).toContain("Capital activo actual");
+	expect(component).toMatch(
+		/getReconciliationPresentation\(\s*state,\s*model\.reconciled,\s*model,?\s*\)/,
+	);
+	const report = await Bun.file(
+		new URL("./reinvestment-report.ts", import.meta.url),
+	).text();
+	expect(report).toContain('"Capital activo actual": row.capital_activo');
+});
+
 test("el modelo no permite descuadres compensados entre subcategorías", () => {
 	const interest = response();
-	interest.detalleInteresNeto[0].neto = "10.20";
-	interest.detalleInteresNeto[1].neto = "5.65";
+	interest.detalleInteresNeto[0].interes = "10.20";
+	interest.detalleInteresNeto[1].interes = "5.00";
 	expect(buildReinvestmentReportModel(interest).reconciliations.interest).toBe(
 		false,
 	);
@@ -638,7 +692,9 @@ test("el modelo no permite descuadres compensados entre subcategorías", () => {
 	const extras = response();
 	extras.detallePagosExtras[0].monto = "19.00";
 	extras.detallePagosExtras[1].monto = "31.00";
-	expect(buildReinvestmentReportModel(extras).reconciliations.extras).toBe(false);
+	expect(buildReinvestmentReportModel(extras).reconciliations.extras).toBe(
+		false,
+	);
 });
 
 describe("presentación fail-closed", () => {
@@ -661,8 +717,7 @@ describe("getReportState", () => {
 		const data = response();
 		data.porTipo = {};
 		data.interesNeto = {
-			conFactura: { interes: "0.00", iva: "0.00", neto: "0.00" },
-			sinFactura: { interes: "0.00", isr: "0.00", neto: "0.00" },
+			noVerificado: { interes: "0.00" },
 			cube: { interes: "0.00", iva: "0.00", neto: "0.00" },
 		};
 		data.pagosExtras = { abonos_capital: "0.00", cancelaciones: "0.00" };
@@ -697,7 +752,7 @@ describe("getReportState", () => {
 
 	test("una respuesta completa descuadrada fuerza error", () => {
 		const mismatch = response();
-		mismatch.detalleInteresNeto[0].neto = "10.20";
+		mismatch.detalleInteresNeto[0].interes = "10.20";
 		expect(
 			getReportState({ pending: false, error: false, data: mismatch }),
 		).toBe("error");
@@ -713,6 +768,100 @@ describe("getReportState", () => {
 		expect(
 			getReportState({ pending: false, error: false, data: mismatch }),
 		).toBe("error");
+	});
+
+	test("detalle parcial precede a registered-zero", () => {
+		const zero = response();
+		zero.porTipo = Object.fromEntries(
+			Object.keys(zero.porTipo).map((type) => [
+				type,
+				{
+					reinversion_capital: "0.00",
+					reinversion_interes: "0.00",
+					reinversion_total: "0.00",
+					total_capital: "0.00",
+					total_interes: "0.00",
+					total_iva: "0.00",
+					total_isr: "0.00",
+					total_cuota: "0.00",
+					iva_facturado: "0.00",
+					total_distribuido: "0.00",
+					cantidad_liquidaciones: 1,
+				},
+			]),
+		);
+		zero.comprasMes = [];
+		zero.detalleComprasMes = [];
+		zero.detalleInteresNeto = [];
+		zero.detallePagosExtras = [];
+		zero.interesNeto = {
+			noVerificado: { interes: "0.00" },
+			cube: { interes: "0.00", iva: "0.00", neto: "0.00" },
+		};
+		zero.pagosExtras = { abonos_capital: "0.00", cancelaciones: "0.00" };
+		zero.porInversionista = [];
+		zero.detalle_estado = { disponible: false, error: "No disponible" };
+		expect(getReportState({ pending: false, error: false, data: zero })).toBe(
+			"partial",
+		);
+	});
+
+	test("liquidaciones en cero con compra completada se mantienen como actividad", () => {
+		const data = response();
+		data.porTipo = {
+			sin_reinversion: {
+				reinversion_capital: "0.00",
+				reinversion_interes: "0.00",
+				reinversion_total: "0.00",
+				total_capital: "0.00",
+				total_interes: "0.00",
+				total_iva: "0.00",
+				total_isr: "0.00",
+				total_cuota: "0.00",
+				iva_facturado: "0.00",
+				total_distribuido: "0.00",
+				cantidad_liquidaciones: 1,
+			},
+		};
+		data.interesNeto = {
+			noVerificado: { interes: "0.00" },
+			cube: { interes: "0.00", iva: "0.00", neto: "0.00" },
+		};
+		data.pagosExtras = { abonos_capital: "0.00", cancelaciones: "0.00" };
+		data.porInversionista = [];
+		data.comprasMes = [{ tipo: "sin_reinversion", cantidad: 1, monto: "0.00" }];
+		data.detalleInteresNeto = [];
+		data.detallePagosExtras = [];
+		data.detalleComprasMes = [
+			{
+				fecha: "2026-07-03",
+				inversionista: "Ana",
+				modalidad: "sin_reinversion",
+				monto: "0.00",
+			},
+		];
+		data.cantidad_liquidaciones = 1;
+		expect(getReportState({ pending: false, error: false, data })).toBe(
+			"ready",
+		);
+	});
+
+	test("compra completada de valor cero no se presenta como registered-zero", () => {
+		const purchases = purchaseOnlyResponse();
+		purchases.comprasMes = [
+			{ tipo: "sin_reinversion", cantidad: 1, monto: "0.00" },
+		];
+		purchases.detalleComprasMes = [
+			{
+				fecha: "2026-07-03",
+				inversionista: "Ana",
+				modalidad: "sin_reinversion",
+				monto: "0.00",
+			},
+		];
+		expect(
+			getReportState({ pending: false, error: false, data: purchases }),
+		).toBe("ready");
 	});
 
 	test("conserva compras conciliadas aunque no existan liquidaciones", () => {
@@ -735,9 +884,9 @@ describe("getReportState", () => {
 		empty.detalleComprasMes = [];
 
 		expect(buildReinvestmentReportModel(empty).reconciled).toBe(true);
-		expect(
-			getReportState({ pending: false, error: false, data: empty }),
-		).toBe("empty");
+		expect(getReportState({ pending: false, error: false, data: empty })).toBe(
+			"empty",
+		);
 	});
 
 	test("distingue liquidaciones registradas sin flujo ni posición", () => {
@@ -758,8 +907,7 @@ describe("getReportState", () => {
 			},
 		};
 		zero.interesNeto = {
-			conFactura: { interes: "0.00", iva: "0.00", neto: "0.00" },
-			sinFactura: { interes: "0.00", isr: "0.00", neto: "0.00" },
+			noVerificado: { interes: "0.00" },
 			cube: { interes: "0.00", iva: "0.00", neto: "0.00" },
 		};
 		zero.pagosExtras = { abonos_capital: "0.00", cancelaciones: "0.00" };

--- a/apps/crm/apps/web/src/lib/reports/reinvestment-report.test.ts
+++ b/apps/crm/apps/web/src/lib/reports/reinvestment-report.test.ts
@@ -175,6 +175,13 @@ test("capital, interés y total explican qué forma cada destino", () => {
 	const base = response().porTipo.reinversion_capital;
 	const cases = [
 		{
+			type: "sin_reinversion",
+			paid: 54.65,
+			reinvested: 0,
+			paidParts: ["Capital", "Rendimiento fiscal neto"],
+			reinvestedParts: [],
+		},
+		{
 			type: "reinversion_capital",
 			paid: 4.65,
 			reinvested: 50,
@@ -235,6 +242,31 @@ test("capital, interés y total explican qué forma cada destino", () => {
 			"Reinvertido",
 		);
 	}
+});
+
+test("suprime fórmulas de una modalidad actual que no concilia con destinos históricos", () => {
+	const data = response();
+	data.porTipo = {
+		reinversion_total: {
+			...data.porTipo.reinversion_capital,
+			reinversion_capital: "0.00",
+			reinversion_interes: "0.00",
+			reinversion_total: "0.00",
+			total_cuota: "54.65",
+		},
+	};
+
+	const model = buildReinvestmentReportModel(data);
+	const row = model.rows[0];
+	expect(row).toBeDefined();
+	if (!row) throw new Error("Falta modalidad histórica reclasificada");
+
+	expect(model.reconciliations.destinations).toBe(true);
+	expect(row).toMatchObject({ paid: 54.65, reinvested: 0, distributed: 54.65 });
+	expect(getModePresentation(row)).toMatchObject({
+		destinations: null,
+		splitAvailable: false,
+	});
 });
 
 test("variable, excedente y combinada no fabrican fórmulas por destino", () => {
@@ -365,6 +397,18 @@ test("rechaza inversionistas con campos monetarios no numéricos", () => {
 	expect(
 		getReportState({ pending: false, error: false, data: nonnumeric }),
 	).toBe("incompatible");
+});
+
+test("rechaza campos monetarios vacíos o con solo whitespace", () => {
+	for (const value of ["", "   "]) {
+		const data = response();
+		data.porTipo.sin_reinversion.total_cuota = value;
+
+		expect(buildReinvestmentReportModel(data).compatible).toBe(false);
+		expect(getReportState({ pending: false, error: false, data })).toBe(
+			"incompatible",
+		);
+	}
 });
 
 test("acepta campos monetarios válidos y conserva capital activo sin flujo", () => {

--- a/apps/crm/apps/web/src/lib/reports/reinvestment-report.ts
+++ b/apps/crm/apps/web/src/lib/reports/reinvestment-report.ts
@@ -6,7 +6,9 @@ const sumCents = (values: (number | string)[]) =>
 const isRecord = (value: unknown): value is Record<string, unknown> =>
 	typeof value === "object" && value !== null && !Array.isArray(value);
 const isMoney = (value: unknown): value is string =>
-	typeof value === "string" && Number.isFinite(Number(value));
+	typeof value === "string" &&
+	value.trim().length > 0 &&
+	Number.isFinite(Number(value));
 const hasMoneyFields = (value: unknown, fields: string[]) =>
 	isRecord(value) && fields.every((field) => isMoney(value[field]));
 const hasStringFields = (value: unknown, fields: string[]) =>
@@ -443,6 +445,12 @@ function getDestinationFormulas(
 	>;
 	const parts = partsByType[row.type as keyof typeof partsByType];
 	if (!parts) return null;
+	if (
+		sumCents(parts.paid.map((part) => part.value)) !== cents(row.paid) ||
+		sumCents(parts.reinvested.map((part) => part.value)) !==
+			cents(row.reinvested)
+	)
+		return null;
 	return {
 		paid: destinationFormula("Pagado a inversionistas", parts.paid, row.paid),
 		reinvested: destinationFormula(
@@ -454,14 +462,15 @@ function getDestinationFormulas(
 }
 
 export function getModePresentation(row: ReinvestmentModeRow) {
-	const splitAvailable = !NO_SPLIT_TYPES.has(row.type);
+	const destinations = getDestinationFormulas(row);
+	const splitAvailable = destinations !== null;
 	return {
 		paid: row.paid,
 		reinvested: row.reinvested,
 		distributed: row.distributed,
 		equation: `${q(row.paid)} pagado + ${q(row.reinvested)} reinvertido = ${q(row.distributed)} flujo liquidado.`,
 		composition: row.composition,
-		destinations: getDestinationFormulas(row),
+		destinations,
 		splitAvailable,
 		splitNote: splitAvailable
 			? null

--- a/apps/crm/apps/web/src/lib/reports/reinvestment-report.ts
+++ b/apps/crm/apps/web/src/lib/reports/reinvestment-report.ts
@@ -343,11 +343,17 @@ export function getReportState(input: {
 	if (input.error) return "error";
 	const model = buildReinvestmentReportModel(input.data);
 	if (!model.compatible) return input.data ? "incompatible" : "empty";
-	if (model.data.cantidad_liquidaciones === 0) return "empty";
+	const hasReportActivity =
+		model.data.cantidad_liquidaciones > 0 ||
+		model.data.comprasMes.some((purchase) => purchase.cantidad > 0);
+	if (!hasReportActivity) return "empty";
 	if (!model.reconciliations.destinations || !model.reconciliations.modes) {
 		return "error";
 	}
-	if (Object.values(model.totals).every((value) => cents(value) === 0)) {
+	if (
+		model.data.cantidad_liquidaciones > 0 &&
+		Object.values(model.totals).every((value) => cents(value) === 0)
+	) {
 		return "registered-zero";
 	}
 	if (!model.data.detalle_estado.disponible) return "partial";

--- a/apps/crm/apps/web/src/lib/reports/reinvestment-report.ts
+++ b/apps/crm/apps/web/src/lib/reports/reinvestment-report.ts
@@ -1,0 +1,557 @@
+import type { ReinversionLiquidacionesResponse } from "./scenario";
+
+const cents = (value: number | string) => Math.round(Number(value) * 100);
+const sumCents = (values: (number | string)[]) =>
+	values.reduce<number>((total, value) => total + cents(value), 0);
+const isRecord = (value: unknown): value is Record<string, unknown> =>
+	typeof value === "object" && value !== null && !Array.isArray(value);
+const isMoney = (value: unknown): value is string =>
+	typeof value === "string" && Number.isFinite(Number(value));
+const hasMoneyFields = (value: unknown, fields: string[]) =>
+	isRecord(value) && fields.every((field) => isMoney(value[field]));
+const hasStringFields = (value: unknown, fields: string[]) =>
+	isRecord(value) && fields.every((field) => typeof value[field] === "string");
+
+const MODE_MONEY_FIELDS = [
+	"reinversion_capital",
+	"reinversion_interes",
+	"reinversion_total",
+	"total_capital",
+	"total_interes",
+	"total_iva",
+	"iva_facturado",
+	"total_isr",
+	"total_cuota",
+	"total_distribuido",
+];
+
+export function getCompatibleReportData(
+	input: unknown,
+): ReinversionLiquidacionesResponse | undefined {
+	if (!isRecord(input) || input.contrato_version !== 2) return undefined;
+	if (!isRecord(input.porTipo)) return undefined;
+	if (
+		!Object.values(input.porTipo).every((row) =>
+			hasMoneyFields(row, MODE_MONEY_FIELDS),
+		)
+	)
+		return undefined;
+	if (
+		!Array.isArray(input.porInversionista) ||
+		!input.porInversionista.every(
+			(row) =>
+				isRecord(row) &&
+				typeof row.inversionista_id === "number" &&
+				hasStringFields(row, [
+					"nombre",
+					"tipo_reinversion",
+					"reinversion_capital",
+					"reinversion_interes",
+					"reinversion",
+					"a_recibir",
+					"monto_aportado",
+					"capital_activo",
+				]),
+		)
+	)
+		return undefined;
+	if (
+		!isRecord(input.interesNeto) ||
+		!hasMoneyFields(input.interesNeto.conFactura, ["interes", "iva", "neto"]) ||
+		!hasMoneyFields(input.interesNeto.sinFactura, ["interes", "isr", "neto"]) ||
+		!hasMoneyFields(input.interesNeto.cube, ["interes", "iva", "neto"])
+	)
+		return undefined;
+	if (
+		!hasMoneyFields(input.pagosExtras, ["abonos_capital", "cancelaciones"]) ||
+		!Array.isArray(input.comprasMes) ||
+		!input.comprasMes.every(
+			(row) =>
+				isRecord(row) &&
+				typeof row.tipo === "string" &&
+				typeof row.cantidad === "number" &&
+				isMoney(row.monto),
+		)
+	)
+		return undefined;
+	if (
+		!Array.isArray(input.detalleInteresNeto) ||
+		!input.detalleInteresNeto.every(
+			(row) =>
+				isRecord(row) &&
+				typeof row.inversionista_id === "number" &&
+				hasStringFields(row, [
+					"inversionista",
+					"referencia",
+					"tratamiento_fiscal",
+				]) &&
+				hasMoneyFields(row, ["interes", "iva", "isr", "neto"]),
+		)
+	)
+		return undefined;
+	if (
+		!Array.isArray(input.detallePagosExtras) ||
+		!input.detallePagosExtras.every(
+			(row) =>
+				hasStringFields(row, ["fecha", "credito", "tipo"]) &&
+				isRecord(row) &&
+				isMoney(row.monto),
+		) ||
+		!Array.isArray(input.detalleComprasMes) ||
+		!input.detalleComprasMes.every(
+			(row) =>
+				hasStringFields(row, ["fecha", "inversionista", "modalidad"]) &&
+				isRecord(row) &&
+				isMoney(row.monto),
+		)
+	)
+		return undefined;
+	if (
+		!isRecord(input.detalle_estado) ||
+		typeof input.detalle_estado.disponible !== "boolean" ||
+		!(
+			input.detalle_estado.error === null ||
+			typeof input.detalle_estado.error === "string"
+		) ||
+		typeof input.cantidad_liquidaciones !== "number"
+	)
+		return undefined;
+	return input as ReinversionLiquidacionesResponse;
+}
+
+const labels: Record<string, string> = {
+	sin_reinversion: "Tradicional",
+	reinversion_capital: "Reinversión de capital",
+	reinversion_interes: "Reinversión de interés",
+	reinversion_total: "Interés compuesto",
+	reinversion_variable: "Reinversión variable",
+	reinversion_excedente: "Reinversión excedente",
+	reinversion_combinada: "Reinversión combinada",
+};
+
+export type ReinvestmentModeRow = {
+	type: string;
+	label: string;
+	paid: number;
+	reinvested: number;
+	distributed: number;
+	active: number;
+	composition: {
+		capital: number;
+		interest: number;
+		billedVat: number;
+		withheldIsr: number;
+		distributed: number;
+	};
+	reinvestmentComposition: {
+		capital: number;
+		interest: number;
+	};
+	reconciled: boolean;
+};
+
+const incompatibleModel = {
+	compatible: false as const,
+	data: undefined,
+	rows: [] as ReinvestmentModeRow[],
+	totals: { distributed: 0, paid: 0, reinvested: 0, active: 0 },
+	reconciliations: {
+		destinations: false,
+		modes: false,
+		interest: false,
+		extras: false,
+		purchases: false,
+		contract: false,
+	},
+	reconciled: false,
+};
+
+export function buildReinvestmentReportModel(input: unknown) {
+	const data = getCompatibleReportData(input);
+	if (!data) return incompatibleModel;
+	const rows = Object.entries(data.porTipo)
+		.map(([type, value]): ReinvestmentModeRow => {
+			const paid = Number(value.total_cuota);
+			const reinvested = Number(value.reinversion_total);
+			const distributed = Number(value.total_distribuido);
+			const composition = {
+				capital: Number(value.total_capital),
+				interest: Number(value.total_interes),
+				billedVat: Number(value.iva_facturado),
+				withheldIsr: Number(value.total_isr),
+				distributed,
+			};
+			return {
+				type,
+				label: labels[type] ?? type,
+				paid,
+				reinvested,
+				distributed,
+				active: data.porInversionista
+					.filter((investor) => investor.tipo_reinversion === type)
+					.reduce(
+						(total, investor) => total + Number(investor.capital_activo),
+						0,
+					),
+				composition,
+				reinvestmentComposition: {
+					capital: Number(value.reinversion_capital),
+					interest: Number(value.reinversion_interes),
+				},
+				reconciled:
+					sumCents([paid, reinvested]) === cents(distributed) &&
+					sumCents([
+						composition.capital,
+						composition.interest,
+						composition.billedVat,
+						-composition.withheldIsr,
+					]) === cents(distributed),
+			};
+		})
+		.filter((row) => row.distributed !== 0 || row.active !== 0);
+	const totals = rows.reduce(
+		(total, row) => ({
+			distributed: total.distributed + row.distributed,
+			paid: total.paid + row.paid,
+			reinvested: total.reinvested + row.reinvested,
+			active: total.active + row.active,
+		}),
+		{ distributed: 0, paid: 0, reinvested: 0, active: 0 },
+	);
+	const roundedTotals = Object.fromEntries(
+		Object.entries(totals).map(([key, value]) => [
+			key,
+			Math.round(value * 100) / 100,
+		]),
+	) as typeof totals;
+	const cubeRows = data.detalleInteresNeto.filter(
+		(row) => row.tratamiento_fiscal === "cube",
+	);
+	const interestCategories = [
+		["con_factura", data.interesNeto.conFactura.neto],
+		["sin_factura", data.interesNeto.sinFactura.neto],
+		["cube", data.interesNeto.cube.neto],
+	] as const;
+	const interestByCategory = interestCategories.every(
+		([category, summary]) =>
+			sumCents(
+				data.detalleInteresNeto
+					.filter((row) => row.tratamiento_fiscal === category)
+					.map((row) => row.neto),
+			) === cents(summary),
+	);
+	const extrasByCategory =
+		sumCents(
+			data.detallePagosExtras
+				.filter((row) => row.tipo === "abono_capital")
+				.map((row) => row.monto),
+		) === cents(data.pagosExtras.abonos_capital) &&
+		sumCents(
+			data.detallePagosExtras
+				.filter((row) => row.tipo === "cancelacion")
+				.map((row) => row.monto),
+		) === cents(data.pagosExtras.cancelaciones);
+	const purchasesByMode = data.comprasMes.every(
+		(summary) =>
+			data.detalleComprasMes.filter(
+				(row) => row.modalidad === summary.tipo,
+			).length === summary.cantidad &&
+			sumCents(
+				data.detalleComprasMes
+					.filter((row) => row.modalidad === summary.tipo)
+					.map((row) => row.monto),
+			) === cents(summary.monto),
+	);
+	const reconciliations = {
+		destinations:
+			cents(roundedTotals.paid + roundedTotals.reinvested) ===
+			cents(roundedTotals.distributed),
+		modes: rows.every((row) => row.reconciled),
+		interest:
+			sumCents(data.detalleInteresNeto.map((row) => row.neto)) ===
+				sumCents([
+					data.interesNeto.conFactura.neto,
+					data.interesNeto.sinFactura.neto,
+					data.interesNeto.cube.neto,
+				]) &&
+			interestByCategory &&
+			cubeRows.length <= 1 &&
+			data.detalleInteresNeto.every((row) =>
+				interestCategories.some(
+					([category]) => category === row.tratamiento_fiscal,
+				),
+			),
+		extras:
+			sumCents(data.detallePagosExtras.map((row) => row.monto)) ===
+				sumCents([
+					data.pagosExtras.abonos_capital,
+					data.pagosExtras.cancelaciones,
+				]) &&
+			extrasByCategory &&
+			data.detallePagosExtras.every(
+				(row) => row.tipo === "abono_capital" || row.tipo === "cancelacion",
+			),
+		purchases:
+			sumCents(data.detalleComprasMes.map((row) => row.monto)) ===
+				sumCents(data.comprasMes.map((row) => row.monto)) &&
+			purchasesByMode &&
+			data.detalleComprasMes.every((row) =>
+				data.comprasMes.some((summary) => summary.tipo === row.modalidad),
+			),
+		contract: data.detalle_estado.disponible,
+	};
+	return {
+		compatible: true as const,
+		data,
+		rows,
+		totals: roundedTotals,
+		reconciliations,
+		reconciled: Object.values(reconciliations).every(Boolean),
+	};
+}
+
+export type ReportState =
+	| "loading"
+	| "error"
+	| "empty"
+	| "registered-zero"
+	| "partial"
+	| "incompatible"
+	| "ready";
+
+export const REGISTERED_ZERO_ACTIVITY_COPY =
+	"Hay liquidaciones registradas, pero no generan efectivo ni reinversión en este período.";
+
+const PUBLIC_PARTIAL_DETAIL_MESSAGE =
+	"Los detalles no están disponibles para este período. No se muestran totales secundarios.";
+
+export function getPublicPartialDetailMessage(_backendMessage?: unknown) {
+	return PUBLIC_PARTIAL_DETAIL_MESSAGE;
+}
+
+export function getReportState(input: {
+	pending: boolean;
+	error: boolean;
+	data?: unknown;
+}): ReportState {
+	if (input.pending) return "loading";
+	if (input.error) return "error";
+	const model = buildReinvestmentReportModel(input.data);
+	if (!model.compatible) return input.data ? "incompatible" : "empty";
+	if (model.data.cantidad_liquidaciones === 0) return "empty";
+	if (!model.reconciliations.destinations || !model.reconciliations.modes) {
+		return "error";
+	}
+	if (Object.values(model.totals).every((value) => cents(value) === 0)) {
+		return "registered-zero";
+	}
+	if (!model.data.detalle_estado.disponible) return "partial";
+	if (!model.reconciled) return "error";
+	return "ready";
+}
+
+export function getReconciliationPresentation(
+	state: ReportState,
+	reconciled: boolean,
+): "verified" | "unavailable" | "failed" {
+	if (state === "partial") return "unavailable";
+	return state === "ready" && reconciled ? "verified" : "failed";
+}
+
+export function canRenderSecondaryDetails(state: ReportState) {
+	return state === "ready";
+}
+
+const q = (value: number) => `Q${value.toFixed(2)}`;
+const amount = (values: (number | string)[]) => sumCents(values) / 100;
+const NO_SPLIT_TYPES = new Set([
+	"reinversion_variable",
+	"reinversion_excedente",
+	"reinversion_combinada",
+]);
+
+export type DestinationFormula = {
+	parts: { label: "Capital" | "Rendimiento fiscal neto"; value: number }[];
+	result: number;
+	sentence: string;
+};
+
+function destinationFormula(
+	destination: "Pagado a inversionistas" | "Reinvertido",
+	parts: DestinationFormula["parts"],
+	result: number,
+): DestinationFormula {
+	const composition =
+		parts.length === 0
+			? "no recibe capital ni rendimiento fiscal neto"
+			: `se forma con ${parts
+					.map(
+						(part) =>
+							`${q(part.value)} de ${part.label.toLocaleLowerCase("es")}`,
+					)
+					.join(" más ")}`;
+	return {
+		parts,
+		result,
+		sentence: `${destination} ${composition} y da ${q(result)}.`,
+	};
+}
+
+function getDestinationFormulas(
+	row: ReinvestmentModeRow,
+): {
+	paid: DestinationFormula;
+	reinvested: DestinationFormula;
+} | null {
+	if (NO_SPLIT_TYPES.has(row.type)) return null;
+	const capital = {
+		label: "Capital" as const,
+		value: row.composition.capital,
+	};
+	const netYield = {
+		label: "Rendimiento fiscal neto" as const,
+		value:
+			Math.round(
+				(row.composition.interest +
+					row.composition.billedVat -
+					row.composition.withheldIsr) *
+					100,
+			) / 100,
+	};
+	const partsByType = {
+		sin_reinversion: { paid: [capital, netYield], reinvested: [] },
+		reinversion_capital: { paid: [netYield], reinvested: [capital] },
+		reinversion_interes: { paid: [capital], reinvested: [netYield] },
+		reinversion_total: { paid: [], reinvested: [capital, netYield] },
+	} satisfies Record<
+		string,
+		{
+			paid: DestinationFormula["parts"];
+			reinvested: DestinationFormula["parts"];
+		}
+	>;
+	const parts = partsByType[row.type as keyof typeof partsByType];
+	if (!parts) return null;
+	return {
+		paid: destinationFormula("Pagado a inversionistas", parts.paid, row.paid),
+		reinvested: destinationFormula(
+			"Reinvertido",
+			parts.reinvested,
+			row.reinvested,
+		),
+	};
+}
+
+export function getModePresentation(row: ReinvestmentModeRow) {
+	const splitAvailable = !NO_SPLIT_TYPES.has(row.type);
+	return {
+		paid: row.paid,
+		reinvested: row.reinvested,
+		distributed: row.distributed,
+		equation: `${q(row.paid)} pagado + ${q(row.reinvested)} reinvertido = ${q(row.distributed)} flujo liquidado.`,
+		composition: row.composition,
+		destinations: getDestinationFormulas(row),
+		splitAvailable,
+		splitNote: splitAvailable
+			? null
+			: "El desglose de la reinversión entre capital e interés no está disponible en la fuente actual.",
+	};
+}
+
+export function getMonthlyFooterPresentation(model: {
+	totals: { paid: number; reinvested: number; distributed: number };
+}) {
+	const { paid, reinvested, distributed } = model.totals;
+	return {
+		paid,
+		reinvested,
+		distributed,
+		equation: `${q(paid)} pagado + ${q(reinvested)} reinvertido = ${q(distributed)} flujo liquidado.`,
+	};
+}
+
+export type SecondarySummaryPresentation = {
+	key: "interest" | "extras" | "purchases";
+	label: string;
+	total: number;
+	items: {
+		label: string;
+		value: number;
+		formula?: string;
+		meta?: string;
+	}[];
+};
+
+export function buildSecondarySummaryPresentation(
+	input: unknown,
+): SecondarySummaryPresentation[] {
+	const data = getCompatibleReportData(input);
+	if (!data) return [];
+	const conFactura = data.interesNeto.conFactura;
+	const sinFactura = data.interesNeto.sinFactura;
+	const cube = data.interesNeto.cube;
+	return [
+		{
+			key: "interest",
+			label: "Interés neto",
+			total: amount([conFactura.neto, sinFactura.neto, cube.neto]),
+			items: [
+				{
+					label: "Con factura",
+					value: Number(conFactura.neto),
+					formula: `${q(Number(conFactura.interes))} + ${q(Number(conFactura.iva))} IVA = ${q(Number(conFactura.neto))}`,
+				},
+				{
+					label: "Sin factura",
+					value: Number(sinFactura.neto),
+					formula: `${q(Number(sinFactura.interes))} − ${q(Number(sinFactura.isr))} ISR = ${q(Number(sinFactura.neto))}`,
+				},
+				{
+					label: "CUBE",
+					value: Number(cube.neto),
+					formula: `${q(Number(cube.interes))} + ${q(Number(cube.iva))} IVA = ${q(Number(cube.neto))}`,
+				},
+			],
+		},
+		{
+			key: "extras",
+			label: "Pagos extras",
+			total: amount([
+				data.pagosExtras.abonos_capital,
+				data.pagosExtras.cancelaciones,
+			]),
+			items: [
+				{
+					label: "Abonos a capital",
+					value: Number(data.pagosExtras.abonos_capital),
+				},
+				{
+					label: "Cancelaciones",
+					value: Number(data.pagosExtras.cancelaciones),
+				},
+			],
+		},
+		{
+			key: "purchases",
+			label: "Compras del mes",
+			total: amount(data.comprasMes.map((item) => item.monto)),
+			items: data.comprasMes.map((item) => ({
+				label: labels[item.tipo] ?? item.tipo,
+				value: Number(item.monto),
+				meta: `${item.cantidad} ${item.cantidad === 1 ? "compra" : "compras"}`,
+			})),
+		},
+	];
+}
+
+export function buildInvestorExportRows(input: unknown) {
+	const data = getCompatibleReportData(input);
+	if (!data) return [];
+	return data.porInversionista.map((row) => ({
+		Inversionista: row.nombre,
+		Modalidad: row.tipo_reinversion,
+		Pagado: row.a_recibir,
+		Reinvertido: row.reinversion,
+		"Capital activo": row.capital_activo,
+	}));
+}

--- a/apps/crm/apps/web/src/lib/reports/reinvestment-report.ts
+++ b/apps/crm/apps/web/src/lib/reports/reinvestment-report.ts
@@ -31,8 +31,12 @@ export function getCompatibleReportData(
 	if (!isRecord(input) || input.contrato_version !== 2) return undefined;
 	if (!isRecord(input.porTipo)) return undefined;
 	if (
-		!Object.values(input.porTipo).every((row) =>
-			hasMoneyFields(row, MODE_MONEY_FIELDS),
+		!Object.values(input.porTipo).every(
+			(row) =>
+				isRecord(row) &&
+				hasMoneyFields(row, MODE_MONEY_FIELDS) &&
+				Number.isInteger(row.cantidad_liquidaciones) &&
+				Number(row.cantidad_liquidaciones) >= 0,
 		)
 	)
 		return undefined;
@@ -200,12 +204,14 @@ export function buildReinvestmentReportModel(input: unknown) {
 				},
 				reconciled:
 					sumCents([paid, reinvested]) === cents(distributed) &&
-					sumCents([
-						composition.capital,
-						composition.interest,
-						composition.billedVat,
-						-composition.withheldIsr,
-					]) === cents(distributed),
+					Math.abs(
+						sumCents([
+							composition.capital,
+							composition.interest,
+							composition.billedVat,
+							-composition.withheldIsr,
+						]) - cents(distributed),
+					) <= value.cantidad_liquidaciones,
 			};
 		})
 		.filter((row) => row.distributed !== 0 || row.active !== 0);

--- a/apps/crm/apps/web/src/lib/reports/reinvestment-report.ts
+++ b/apps/crm/apps/web/src/lib/reports/reinvestment-report.ts
@@ -6,13 +6,22 @@ const sumCents = (values: (number | string)[]) =>
 const isRecord = (value: unknown): value is Record<string, unknown> =>
 	typeof value === "object" && value !== null && !Array.isArray(value);
 const isMoney = (value: unknown): value is string =>
-	typeof value === "string" &&
-	value.trim().length > 0 &&
-	Number.isFinite(Number(value));
+	typeof value === "string" && /^\d+(?:\.\d+)?$/.test(value);
 const hasMoneyFields = (value: unknown, fields: string[]) =>
 	isRecord(value) && fields.every((field) => isMoney(value[field]));
 const hasStringFields = (value: unknown, fields: string[]) =>
 	isRecord(value) && fields.every((field) => typeof value[field] === "string");
+const isNonnegativeInteger = (value: unknown) =>
+	typeof value === "number" && Number.isInteger(value) && value >= 0;
+const MODES = new Set([
+	"sin_reinversion",
+	"reinversion_capital",
+	"reinversion_interes",
+	"reinversion_total",
+	"reinversion_variable",
+	"reinversion_excedente",
+	"reinversion_combinada",
+]);
 
 const MODE_MONEY_FIELDS = [
 	"reinversion_capital",
@@ -33,12 +42,12 @@ export function getCompatibleReportData(
 	if (!isRecord(input) || input.contrato_version !== 2) return undefined;
 	if (!isRecord(input.porTipo)) return undefined;
 	if (
+		!Object.keys(input.porTipo).every((key) => MODES.has(key)) ||
 		!Object.values(input.porTipo).every(
 			(row) =>
 				isRecord(row) &&
 				hasMoneyFields(row, MODE_MONEY_FIELDS) &&
-				Number.isInteger(row.cantidad_liquidaciones) &&
-				Number(row.cantidad_liquidaciones) >= 0,
+				isNonnegativeInteger(row.cantidad_liquidaciones),
 		)
 	)
 		return undefined;
@@ -47,14 +56,16 @@ export function getCompatibleReportData(
 		!input.porInversionista.every(
 			(row) =>
 				isRecord(row) &&
-				typeof row.inversionista_id === "number" &&
+				isNonnegativeInteger(row.inversionista_id) &&
+				typeof row.nombre === "string" &&
+				row.nombre.trim().length > 0 &&
+				MODES.has(String(row.tipo_reinversion)) &&
 				hasStringFields(row, ["nombre", "tipo_reinversion"]) &&
 				hasMoneyFields(row, [
 					"reinversion_capital",
 					"reinversion_interes",
 					"reinversion",
 					"a_recibir",
-					"monto_aportado",
 					"capital_activo",
 				]),
 		)
@@ -62,8 +73,7 @@ export function getCompatibleReportData(
 		return undefined;
 	if (
 		!isRecord(input.interesNeto) ||
-		!hasMoneyFields(input.interesNeto.conFactura, ["interes", "iva", "neto"]) ||
-		!hasMoneyFields(input.interesNeto.sinFactura, ["interes", "isr", "neto"]) ||
+		!hasMoneyFields(input.interesNeto.noVerificado, ["interes"]) ||
 		!hasMoneyFields(input.interesNeto.cube, ["interes", "iva", "neto"])
 	)
 		return undefined;
@@ -73,8 +83,8 @@ export function getCompatibleReportData(
 		!input.comprasMes.every(
 			(row) =>
 				isRecord(row) &&
-				typeof row.tipo === "string" &&
-				typeof row.cantidad === "number" &&
+				MODES.has(String(row.tipo)) &&
+				isNonnegativeInteger(row.cantidad) &&
 				isMoney(row.monto),
 		)
 	)
@@ -84,13 +94,17 @@ export function getCompatibleReportData(
 		!input.detalleInteresNeto.every(
 			(row) =>
 				isRecord(row) &&
-				typeof row.inversionista_id === "number" &&
+				isNonnegativeInteger(row.inversionista_id) &&
 				hasStringFields(row, [
 					"inversionista",
 					"referencia",
 					"tratamiento_fiscal",
 				]) &&
-				hasMoneyFields(row, ["interes", "iva", "isr", "neto"]),
+				((row.tratamiento_fiscal === "no_verificado" &&
+					hasMoneyFields(row, ["interes", "iva", "isr"]) &&
+					!("neto" in row)) ||
+					(row.tratamiento_fiscal === "cube" &&
+						hasMoneyFields(row, ["interes", "iva", "isr", "neto"]))),
 		)
 	)
 		return undefined;
@@ -98,15 +112,17 @@ export function getCompatibleReportData(
 		!Array.isArray(input.detallePagosExtras) ||
 		!input.detallePagosExtras.every(
 			(row) =>
-				hasStringFields(row, ["fecha", "credito", "tipo"]) &&
+				hasStringFields(row, ["fecha", "credito"]) &&
 				isRecord(row) &&
+				(row.tipo === "abono_capital" || row.tipo === "cancelacion") &&
 				isMoney(row.monto),
 		) ||
 		!Array.isArray(input.detalleComprasMes) ||
 		!input.detalleComprasMes.every(
 			(row) =>
-				hasStringFields(row, ["fecha", "inversionista", "modalidad"]) &&
+				hasStringFields(row, ["fecha", "inversionista"]) &&
 				isRecord(row) &&
+				MODES.has(String(row.modalidad)) &&
 				isMoney(row.monto),
 		)
 	)
@@ -115,10 +131,13 @@ export function getCompatibleReportData(
 		!isRecord(input.detalle_estado) ||
 		typeof input.detalle_estado.disponible !== "boolean" ||
 		!(
-			input.detalle_estado.error === null ||
-			typeof input.detalle_estado.error === "string"
+			(input.detalle_estado.disponible === true &&
+				input.detalle_estado.error === null) ||
+			(input.detalle_estado.disponible === false &&
+				typeof input.detalle_estado.error === "string" &&
+				input.detalle_estado.error.trim().length > 0)
 		) ||
-		typeof input.cantidad_liquidaciones !== "number"
+		!isNonnegativeInteger(input.cantidad_liquidaciones)
 	)
 		return undefined;
 	return input as ReinversionLiquidacionesResponse;
@@ -153,6 +172,9 @@ export type ReinvestmentModeRow = {
 		interest: number;
 	};
 	reconciled: boolean;
+	roundingResidual: number | null;
+	compositionStatus: "exact" | "tolerance" | "failed" | "unavailable";
+	historicalModeVerified: false;
 };
 
 const incompatibleModel = {
@@ -167,6 +189,7 @@ const incompatibleModel = {
 		extras: false,
 		purchases: false,
 		contract: false,
+		composition: "failed" as const,
 	},
 	reconciled: false,
 };
@@ -186,6 +209,16 @@ export function buildReinvestmentReportModel(input: unknown) {
 				withheldIsr: Number(value.total_isr),
 				distributed,
 			};
+			const hasAmbiguousFiscal =
+				Number(value.total_iva) !== 0 || Number(value.total_isr) !== 0;
+			const roundingResidual = Math.abs(
+				sumCents([
+					composition.capital,
+					composition.interest,
+					composition.billedVat,
+					-composition.withheldIsr,
+				]) - cents(distributed),
+			);
 			return {
 				type,
 				label: labels[type] ?? type,
@@ -205,14 +238,17 @@ export function buildReinvestmentReportModel(input: unknown) {
 				},
 				reconciled:
 					sumCents([paid, reinvested]) === cents(distributed) &&
-					Math.abs(
-						sumCents([
-							composition.capital,
-							composition.interest,
-							composition.billedVat,
-							-composition.withheldIsr,
-						]) - cents(distributed),
-					) <= value.cantidad_liquidaciones,
+					(hasAmbiguousFiscal ||
+						roundingResidual <= value.cantidad_liquidaciones),
+				roundingResidual: hasAmbiguousFiscal ? null : roundingResidual / 100,
+				compositionStatus: hasAmbiguousFiscal
+					? "unavailable"
+					: roundingResidual === 0
+						? "exact"
+						: roundingResidual <= value.cantidad_liquidaciones
+							? "tolerance"
+							: "failed",
+				historicalModeVerified: false,
 			};
 		})
 		.filter((row) => row.distributed !== 0 || row.active !== 0);
@@ -234,19 +270,12 @@ export function buildReinvestmentReportModel(input: unknown) {
 	const cubeRows = data.detalleInteresNeto.filter(
 		(row) => row.tratamiento_fiscal === "cube",
 	);
-	const interestCategories = [
-		["con_factura", data.interesNeto.conFactura.neto],
-		["sin_factura", data.interesNeto.sinFactura.neto],
-		["cube", data.interesNeto.cube.neto],
-	] as const;
-	const interestByCategory = interestCategories.every(
-		([category, summary]) =>
-			sumCents(
-				data.detalleInteresNeto
-					.filter((row) => row.tratamiento_fiscal === category)
-					.map((row) => row.neto),
-			) === cents(summary),
+	const noVerificadoRows = data.detalleInteresNeto.filter(
+		(row) => row.tratamiento_fiscal === "no_verificado",
 	);
+	const noVerificadoMatches =
+		sumCents(noVerificadoRows.map((row) => row.interes)) ===
+		cents(data.interesNeto.noVerificado.interes);
 	const extrasByCategory =
 		sumCents(
 			data.detallePagosExtras
@@ -260,9 +289,8 @@ export function buildReinvestmentReportModel(input: unknown) {
 		) === cents(data.pagosExtras.cancelaciones);
 	const purchasesByMode = data.comprasMes.every(
 		(summary) =>
-			data.detalleComprasMes.filter(
-				(row) => row.modalidad === summary.tipo,
-			).length === summary.cantidad &&
+			data.detalleComprasMes.filter((row) => row.modalidad === summary.tipo)
+				.length === summary.cantidad &&
 			sumCents(
 				data.detalleComprasMes
 					.filter((row) => row.modalidad === summary.tipo)
@@ -275,18 +303,14 @@ export function buildReinvestmentReportModel(input: unknown) {
 			cents(roundedTotals.distributed),
 		modes: rows.every((row) => row.reconciled),
 		interest:
-			sumCents(data.detalleInteresNeto.map((row) => row.neto)) ===
-				sumCents([
-					data.interesNeto.conFactura.neto,
-					data.interesNeto.sinFactura.neto,
-					data.interesNeto.cube.neto,
-				]) &&
-			interestByCategory &&
+			noVerificadoMatches &&
+			sumCents(cubeRows.map((row) => row.neto)) ===
+				cents(data.interesNeto.cube.neto) &&
 			cubeRows.length <= 1 &&
-			data.detalleInteresNeto.every((row) =>
-				interestCategories.some(
-					([category]) => category === row.tratamiento_fiscal,
-				),
+			data.detalleInteresNeto.every(
+				(row) =>
+					row.tratamiento_fiscal === "no_verificado" ||
+					row.tratamiento_fiscal === "cube",
 			),
 		extras:
 			sumCents(data.detallePagosExtras.map((row) => row.monto)) ===
@@ -306,6 +330,13 @@ export function buildReinvestmentReportModel(input: unknown) {
 				data.comprasMes.some((summary) => summary.tipo === row.modalidad),
 			),
 		contract: data.detalle_estado.disponible,
+		composition: rows.some((row) => row.compositionStatus === "unavailable")
+			? "unavailable"
+			: rows.some((row) => row.compositionStatus === "failed")
+				? "failed"
+				: rows.some((row) => row.compositionStatus === "tolerance")
+					? "tolerance"
+					: "exact",
 	};
 	return {
 		compatible: true as const,
@@ -352,13 +383,14 @@ export function getReportState(input: {
 	if (!model.reconciliations.destinations || !model.reconciliations.modes) {
 		return "error";
 	}
+	if (!model.data.detalle_estado.disponible) return "partial";
 	if (
 		model.data.cantidad_liquidaciones > 0 &&
+		!model.data.comprasMes.some((purchase) => purchase.cantidad > 0) &&
 		Object.values(model.totals).every((value) => cents(value) === 0)
 	) {
 		return "registered-zero";
 	}
-	if (!model.data.detalle_estado.disponible) return "partial";
 	if (!model.reconciled) return "error";
 	return "ready";
 }
@@ -366,8 +398,22 @@ export function getReportState(input: {
 export function getReconciliationPresentation(
 	state: ReportState,
 	reconciled: boolean,
-): "verified" | "unavailable" | "failed" {
+	model?: ReturnType<typeof buildReinvestmentReportModel>,
+): "verified" | "tolerance" | "unavailable" | "failed" {
 	if (state === "partial") return "unavailable";
+	if (
+		state === "ready" &&
+		model?.rows.some((row) => row.compositionStatus === "unavailable")
+	)
+		return "unavailable";
+	if (
+		state === "ready" &&
+		reconciled &&
+		model?.rows.some(
+			(row) => row.roundingResidual !== null && row.roundingResidual !== 0,
+		)
+	)
+		return "tolerance";
 	return state === "ready" && reconciled ? "verified" : "failed";
 }
 
@@ -410,13 +456,12 @@ function destinationFormula(
 	};
 }
 
-function getDestinationFormulas(
-	row: ReinvestmentModeRow,
-): {
+function getDestinationFormulas(row: ReinvestmentModeRow): {
 	paid: DestinationFormula;
 	reinvested: DestinationFormula;
 } | null {
-	if (NO_SPLIT_TYPES.has(row.type)) return null;
+	// La modalidad procede del perfil actual, no de un snapshot histórico.
+	if (NO_SPLIT_TYPES.has(row.type) || !row.historicalModeVerified) return null;
 	const capital = {
 		label: "Capital" as const,
 		value: row.composition.capital,
@@ -507,28 +552,22 @@ export function buildSecondarySummaryPresentation(
 ): SecondarySummaryPresentation[] {
 	const data = getCompatibleReportData(input);
 	if (!data) return [];
-	const conFactura = data.interesNeto.conFactura;
-	const sinFactura = data.interesNeto.sinFactura;
+	const noVerificado = data.interesNeto.noVerificado;
 	const cube = data.interesNeto.cube;
 	return [
 		{
 			key: "interest",
-			label: "Interés neto",
-			total: amount([conFactura.neto, sinFactura.neto, cube.neto]),
+			label: "Interés registrado",
+			total: amount([noVerificado.interes, cube.interes]),
 			items: [
 				{
-					label: "Con factura",
-					value: Number(conFactura.neto),
-					formula: `${q(Number(conFactura.interes))} + ${q(Number(conFactura.iva))} IVA = ${q(Number(conFactura.neto))}`,
-				},
-				{
-					label: "Sin factura",
-					value: Number(sinFactura.neto),
-					formula: `${q(Number(sinFactura.interes))} − ${q(Number(sinFactura.isr))} ISR = ${q(Number(sinFactura.neto))}`,
+					label: "Sin asignación fiscal",
+					value: Number(noVerificado.interes),
+					formula: `${q(Number(noVerificado.interes))} interés registrado sin asignación fiscal`,
 				},
 				{
 					label: "CUBE",
-					value: Number(cube.neto),
+					value: Number(cube.interes),
 					formula: `${q(Number(cube.interes))} + ${q(Number(cube.iva))} IVA = ${q(Number(cube.neto))}`,
 				},
 			],
@@ -569,9 +608,9 @@ export function buildInvestorExportRows(input: unknown) {
 	if (!data) return [];
 	return data.porInversionista.map((row) => ({
 		Inversionista: row.nombre,
-		Modalidad: row.tipo_reinversion,
+		"Modalidad actual": row.tipo_reinversion,
 		Pagado: row.a_recibir,
 		Reinvertido: row.reinversion,
-		"Capital activo": row.capital_activo,
+		"Capital activo actual": row.capital_activo,
 	}));
 }

--- a/apps/crm/apps/web/src/lib/reports/reinvestment-report.ts
+++ b/apps/crm/apps/web/src/lib/reports/reinvestment-report.ts
@@ -46,9 +46,8 @@ export function getCompatibleReportData(
 			(row) =>
 				isRecord(row) &&
 				typeof row.inversionista_id === "number" &&
-				hasStringFields(row, [
-					"nombre",
-					"tipo_reinversion",
+				hasStringFields(row, ["nombre", "tipo_reinversion"]) &&
+				hasMoneyFields(row, [
 					"reinversion_capital",
 					"reinversion_interes",
 					"reinversion",

--- a/apps/crm/apps/web/src/lib/reports/scenario.ts
+++ b/apps/crm/apps/web/src/lib/reports/scenario.ts
@@ -105,6 +105,17 @@ export type MontoACobrarPeriodoRow = {
 	acum_total_membresias: string;
 	total_interes_inversionista: string;
 	acum_total_interes_inversionista: string;
+	capital_inv_participacion_actual: string;
+	capital_cube_participacion_actual: string;
+	interes_iva_inv_participacion_actual: string;
+	interes_iva_cube_participacion_actual: string;
+	acum_capital_inv_participacion_actual: string;
+	acum_capital_cube_participacion_actual: string;
+	acum_interes_iva_inv_participacion_actual: string;
+	acum_interes_iva_cube_participacion_actual: string;
+	creditos_participacion_invalida: number;
+	cuotas_participacion_invalida: number;
+	participacion_actual: boolean;
 };
 
 export type FacturacionMesRubro = {

--- a/apps/crm/apps/web/src/lib/reports/scenario.ts
+++ b/apps/crm/apps/web/src/lib/reports/scenario.ts
@@ -158,11 +158,11 @@ export type FlujoCuotasInversionesResponse = {
 };
 
 export type ReinversionLiquidacionesResponse = {
+	contrato_version: 2;
 	/**
-	 * Por modalidad (`tipo_reinversion`), campos crudos de la liquidación:
-	 * - `reinversion_total` → sección "Cuotas → Reinversión".
-	 * - `total_capital` / `total_interes` / `total_iva` / `total_isr` / `total_cuota`
-	 *   → sección "Cuotas → A Recibir".
+	 * Distribución mensual por modalidad. `total_cuota` es el pago neto y
+	 * `reinversion_total` el flujo que permanece colocado; juntos forman el
+	 * flujo liquidado presentado por la UI.
 	 */
 	porTipo: Record<
 		string,
@@ -175,6 +175,8 @@ export type ReinversionLiquidacionesResponse = {
 			total_iva: string;
 			total_isr: string;
 			total_cuota: string;
+			iva_facturado: string;
+			total_distribuido: string;
 		}
 	>;
 	/**
@@ -199,9 +201,36 @@ export type ReinversionLiquidacionesResponse = {
 		reinversion: string;
 		a_recibir: string;
 		monto_aportado: string;
+		capital_activo: string;
 	}[];
 	/** Compras del mes (operación de compra) agrupadas por modalidad de reinversión. */
 	comprasMes: { tipo: string; cantidad: number; monto: string }[];
+	detalleInteresNeto: {
+		inversionista_id: number;
+		inversionista: string;
+		referencia: string;
+		tratamiento_fiscal: "con_factura" | "sin_factura" | "cube";
+		interes: string;
+		iva: string;
+		isr: string;
+		neto: string;
+	}[];
+	detallePagosExtras: {
+		fecha: string;
+		credito: string;
+		tipo: "abono_capital" | "cancelacion";
+		monto: string;
+	}[];
+	detalleComprasMes: {
+		fecha: string;
+		inversionista: string;
+		modalidad: string;
+		monto: string;
+	}[];
+	detalle_estado: {
+		disponible: boolean;
+		error: string | null;
+	};
 	cantidad_liquidaciones: number;
 };
 

--- a/apps/crm/apps/web/src/lib/reports/scenario.ts
+++ b/apps/crm/apps/web/src/lib/reports/scenario.ts
@@ -180,14 +180,8 @@ export type ReinversionLiquidacionesResponse = {
 			cantidad_liquidaciones: number;
 		}
 	>;
-	/**
-	 * Interés neto agrupado por si el inversionista emite factura:
-	 * - `conFactura`: neto = interés + IVA.
-	 * - `sinFactura`: neto = interés − ISR.
-	 */
 	interesNeto: {
-		conFactura: { interes: string; iva: string; neto: string };
-		sinFactura: { interes: string; isr: string; neto: string };
+		noVerificado: { interes: string };
 		cube: { interes: string; iva: string; neto: string };
 	};
 	/** Pagos extras recibidos del mes (vía liquidación → pago espejo → abono). */
@@ -201,21 +195,31 @@ export type ReinversionLiquidacionesResponse = {
 		reinversion_interes: string;
 		reinversion: string;
 		a_recibir: string;
-		monto_aportado: string;
 		capital_activo: string;
 	}[];
 	/** Compras del mes (operación de compra) agrupadas por modalidad de reinversión. */
 	comprasMes: { tipo: string; cantidad: number; monto: string }[];
-	detalleInteresNeto: {
-		inversionista_id: number;
-		inversionista: string;
-		referencia: string;
-		tratamiento_fiscal: "con_factura" | "sin_factura" | "cube";
-		interes: string;
-		iva: string;
-		isr: string;
-		neto: string;
-	}[];
+	detalleInteresNeto: (
+		| {
+				inversionista_id: number;
+				inversionista: string;
+				referencia: string;
+				interes: string;
+				iva: string;
+				isr: string;
+				tratamiento_fiscal: "no_verificado";
+		  }
+		| {
+				inversionista_id: number;
+				inversionista: string;
+				referencia: string;
+				tratamiento_fiscal: "cube";
+				interes: string;
+				iva: string;
+				isr: string;
+				neto: string;
+		  }
+	)[];
 	detallePagosExtras: {
 		fecha: string;
 		credito: string;

--- a/apps/crm/apps/web/src/lib/reports/scenario.ts
+++ b/apps/crm/apps/web/src/lib/reports/scenario.ts
@@ -114,6 +114,7 @@ export type MontoACobrarPeriodoRow = {
 	acum_interes_iva_inv_participacion_actual: string;
 	acum_interes_iva_cube_participacion_actual: string;
 	creditos_participacion_invalida: number;
+	creditos_participacion_invalida_rango?: number;
 	cuotas_participacion_invalida: number;
 	participacion_actual: boolean;
 };

--- a/apps/crm/apps/web/src/lib/reports/scenario.ts
+++ b/apps/crm/apps/web/src/lib/reports/scenario.ts
@@ -177,6 +177,7 @@ export type ReinversionLiquidacionesResponse = {
 			total_cuota: string;
 			iva_facturado: string;
 			total_distribuido: string;
+			cantidad_liquidaciones: number;
 		}
 	>;
 	/**

--- a/apps/crm/apps/web/src/routes/admin/reports/-index.participacion.test.ts
+++ b/apps/crm/apps/web/src/routes/admin/reports/-index.participacion.test.ts
@@ -1,0 +1,10 @@
+import { expect, test } from "bun:test";
+
+test("el pie pasa acumulado al helper del split", async () => {
+	const source = await Bun.file(new URL("./index.tsx", import.meta.url)).text();
+	const footer = source.slice(source.indexOf("const splitTotals"));
+
+	expect(footer).toMatch(
+		/getMontoACobrarParticipacionTotals\([\s\S]*?\),\s*a,\s*\)/,
+	);
+});

--- a/apps/crm/apps/web/src/routes/admin/reports/-scenario-modal-access.test.ts
+++ b/apps/crm/apps/web/src/routes/admin/reports/-scenario-modal-access.test.ts
@@ -1,0 +1,31 @@
+import { expect, test } from "bun:test";
+
+const source = await Bun.file(new URL("./index.tsx", import.meta.url)).text();
+const cobranzaModals = (source.match(
+	/\{canAccessCobranzaReport && \(\n\s*<>\n([\s\S]*?)\n\s*<\/>\n\s*\)\}/,
+))?.[1];
+
+test("admin renders the monto simulation modal", () => {
+	expect(cobranzaModals).toContain('open={scenarioOpen === "monto"}');
+});
+
+test("admin renders the facturacion simulation modal", () => {
+	expect(cobranzaModals).toContain('open={scenarioOpen === "facturacion"}');
+});
+
+test("cobros supervisor renders the monto simulation modal", () => {
+	expect(cobranzaModals).toContain("config={montoACobrarConfig}");
+});
+
+test("cobros supervisor renders the facturacion simulation modal", () => {
+	expect(cobranzaModals).toContain("config={facturacionConfig}");
+});
+
+test("roles without cobranza access do not render the monto modal", () => {
+	expect(source).toContain("{canAccessCobranzaReport && (");
+});
+
+test("administrative simulation modals remain admin-only", () => {
+	const adminSection = source.slice(source.indexOf("{isAdmin && ("));
+	expect(adminSection).toMatch(/config=\{coberturaConfig\}[\s\S]*config=\{comparativoConfig\}/);
+});

--- a/apps/crm/apps/web/src/routes/admin/reports/-tabs.test.ts
+++ b/apps/crm/apps/web/src/routes/admin/reports/-tabs.test.ts
@@ -1,0 +1,33 @@
+import { describe, expect, test } from "bun:test";
+import { getReportTabs } from "./-tabs";
+
+describe("getReportTabs", () => {
+	test("keeps the supervisor on authorized reports only", () => {
+		expect(
+			getReportTabs({
+				canAccessClosedCreditsReport: true,
+				canAccessCobranzaReport: true,
+				isAdmin: false,
+			}),
+		).toEqual({ tabs: ["creditos", "cobranza"], defaultTab: "creditos" });
+	});
+
+	test("keeps every existing report tab for admin", () => {
+		expect(
+			getReportTabs({
+				canAccessClosedCreditsReport: true,
+				canAccessCobranzaReport: true,
+				isAdmin: true,
+			}),
+		).toEqual({
+			tabs: [
+				"creditos",
+				"cobranza",
+				"inversiones",
+				"colocacion",
+				"proyeccion-liquidaciones",
+			],
+			defaultTab: "creditos",
+		});
+	});
+});

--- a/apps/crm/apps/web/src/routes/admin/reports/-tabs.ts
+++ b/apps/crm/apps/web/src/routes/admin/reports/-tabs.ts
@@ -1,0 +1,24 @@
+export type ReportTab =
+	| "creditos"
+	| "cobranza"
+	| "inversiones"
+	| "colocacion"
+	| "proyeccion-liquidaciones";
+
+export function getReportTabs({
+	canAccessClosedCreditsReport,
+	canAccessCobranzaReport,
+	isAdmin,
+}: {
+	canAccessClosedCreditsReport: boolean;
+	canAccessCobranzaReport: boolean;
+	isAdmin: boolean;
+}): { tabs: ReportTab[]; defaultTab: ReportTab } {
+	const tabs: ReportTab[] = [];
+	if (canAccessClosedCreditsReport) tabs.push("creditos");
+	if (canAccessCobranzaReport) tabs.push("cobranza");
+	if (isAdmin) {
+		tabs.push("inversiones", "colocacion", "proyeccion-liquidaciones");
+	}
+	return { tabs, defaultTab: tabs[0] ?? "cobranza" };
+}

--- a/apps/crm/apps/web/src/routes/admin/reports/index.tsx
+++ b/apps/crm/apps/web/src/routes/admin/reports/index.tsx
@@ -35,6 +35,7 @@ import { toast } from "sonner";
 import * as XLSX from "xlsx";
 import { PeriodDatePicker } from "@/components/reports/period-date-picker";
 import { ReportCard } from "@/components/reports/report-card";
+import { ReinvestmentReport } from "@/components/reports/reinvestment-report";
 import { ScenarioModal } from "@/components/reports/scenario-modal";
 import { Button } from "@/components/ui/button";
 import {
@@ -68,6 +69,7 @@ import {
 } from "@/components/ui/table";
 import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs";
 import { authClient } from "@/lib/auth-client";
+import { buildInvestorExportRows } from "@/lib/reports/reinvestment-report";
 import { shouldRedirectToLogin } from "@/lib/auth-session";
 import { getMontoACobrarParticipacionTotals } from "@/lib/reports/monto-a-cobrar";
 import type {
@@ -133,84 +135,11 @@ const COLORS = {
 	incobrable: "#7f1d1d",
 };
 
-// Modalidades de reinversión a mostrar en "Cuotas → Reinversión".
-// El monto de cada una es la suma de `liquidaciones.reinversion_total`.
-// Se omiten `reinversion_interes` ("solo interés", no se usa) y `sin_reinversion`.
-const REINVERSION_MODALIDADES: { tipo: string; label: string }[] = [
-	{ tipo: "reinversion_capital", label: "Reinversión de Capital" },
-	{ tipo: "reinversion_total", label: "Interés compuesto" },
-	{ tipo: "reinversion_variable", label: "Reinversión Variable" },
-	{
-		tipo: "reinversion_excedente",
-		label: "Reinversión Excedente (monto fijo a recibir)",
-	},
-	{
-		tipo: "reinversion_combinada",
-		label: "Reinversión Combinada (combinaciones de modalidades)",
-	},
-];
-
-// Modalidades a mostrar en "Cuotas → A Recibir" (efectivo neto = total_cuota).
-// Incluye `sin_reinversion`; sigue omitiendo `reinversion_interes`.
-const A_RECIBIR_MODALIDADES: { tipo: string; label: string }[] = [
-	{ tipo: "sin_reinversion", label: "Sin Reinversión" },
-	...REINVERSION_MODALIDADES,
-];
-
-// Etiqueta corta de la modalidad de reinversión, para el chip por inversionista.
-const MODALIDAD_LABEL: Record<string, string> = {
-	sin_reinversion: "Sin reinversión",
-	reinversion_capital: "Capital",
-	reinversion_interes: "Interés",
-	reinversion_total: "Interés compuesto",
-	reinversion_variable: "Variable",
-	reinversion_excedente: "Excedente",
-	reinversion_combinada: "Combinada",
-};
-
-// Borde de color por modalidad (outline, sin relleno) para diferenciarlas.
-const MODALIDAD_CHIP_CLASS: Record<string, string> = {
-	sin_reinversion: "border-muted-foreground/30 text-muted-foreground",
-	reinversion_capital: "border-blue-400 text-blue-600 dark:text-blue-400",
-	reinversion_interes: "border-cyan-400 text-cyan-600 dark:text-cyan-400",
-	reinversion_total:
-		"border-emerald-400 text-emerald-600 dark:text-emerald-400",
-	reinversion_variable: "border-amber-400 text-amber-600 dark:text-amber-400",
-	reinversion_excedente:
-		"border-violet-400 text-violet-600 dark:text-violet-400",
-	reinversion_combinada: "border-pink-400 text-pink-600 dark:text-pink-400",
-};
-
-// Estilo compartido para cada sub-sección del reporte de Flujo de Cuotas:
-// panel enmarcado, título con divisor y encabezados de tabla refinados
-// (mayúsculas, muted, números tabulares para alinear montos).
-const SECCION_REPORTE_CLASS =
-	"rounded-xl border bg-card p-4 shadow-sm " +
-	"[&>p:first-child]:border-b [&>p:first-child]:pb-2.5 [&>p:first-child]:text-foreground " +
-	"[&_thead_th]:h-9 [&_thead_th]:text-[11px] [&_thead_th]:font-semibold [&_thead_th]:uppercase [&_thead_th]:tracking-wider [&_thead_th]:text-muted-foreground " +
-	"[&_table]:tabular-nums";
-
 /** Mes por defecto (actual) en formato "YYYY-MM" para el <input type="month">. */
 function getDefaultFlujoMes(): string {
 	const todayGt = formatDateInput(new Date());
 	const [year, month] = todayGt.split("-");
 	return `${year}-${month}`;
-}
-
-/** Convierte "YYYY-MM" al rango de fechas [primer día, último día] del mes. */
-function mesToRange(mesStr: string): {
-	fechaInicio: string;
-	fechaFin: string;
-} {
-	const [year, month] = mesStr.split("-").map(Number);
-	const fechaInicio = `${year}-${String(month).padStart(2, "0")}-01`;
-	const nextM = month === 12 ? 1 : month + 1;
-	const nextY = month === 12 ? year + 1 : year;
-	const lastDay = new Date(
-		`${nextY}-${String(nextM).padStart(2, "0")}-01T12:00:00`,
-	);
-	lastDay.setDate(lastDay.getDate() - 1);
-	return { fechaInicio, fechaFin: formatDateInput(lastDay) };
 }
 
 const MESES = [
@@ -505,9 +434,6 @@ function RouteComponent() {
 		anio: new Date().getFullYear(),
 	}));
 	const [flujoMes, setFlujoMes] = useState(getDefaultFlujoMes);
-	// Rango derivado (primer/último día del mes) para los reportes que aún
-	// consumen el endpoint por rango de fechas (secciones 2 y 3).
-	const flujoCuotasRange = mesToRange(flujoMes);
 	const [flujoAnioStr, flujoMesStr] = flujoMes.split("-");
 	const flujoMesNum = Number(flujoMesStr);
 	const flujoAnioNum = Number(flujoAnioStr);
@@ -530,8 +456,6 @@ function RouteComponent() {
 			anio === flujoAnioActual && mes > flujoMesActual ? flujoMesActual : mes;
 		setFlujoMes(`${anio}-${String(m).padStart(2, "0")}`);
 	};
-	// Filtro de modalidad (solo front) para el Desglose por Inversionista.
-	const [modalidadFiltro, setModalidadFiltro] = useState<string[]>([]);
 	const [comparativoAnio, setComparativoAnio] = useState(() =>
 		new Date().getFullYear(),
 	);
@@ -631,7 +555,7 @@ function RouteComponent() {
 		| FacturacionMesResponse
 		| undefined;
 
-	// Sección "Cuotas → Reinversión": se calcula desde la tabla de liquidaciones.
+	// Reporte mensual final de inversión y reinversión.
 	const reinversionLiquidacionesQuery = useQuery({
 		...orpc.getReinversionLiquidaciones.queryOptions({
 			input: { mes: flujoMesNum, anio: flujoAnioNum },
@@ -887,6 +811,27 @@ function RouteComponent() {
 		} finally {
 			setIsExportingCerrados(false);
 		}
+	};
+	const exportReinvestmentInvestorsExcel = () => {
+		const rows = buildInvestorExportRows(reinversionData);
+		if (rows.length === 0) {
+			toast.error("No hay detalle compatible para exportar.");
+			return;
+		}
+		const worksheet = XLSX.utils.json_to_sheet(rows);
+		worksheet["!cols"] = [
+			{ wch: 30 },
+			{ wch: 24 },
+			{ wch: 18 },
+			{ wch: 18 },
+			{ wch: 18 },
+		];
+		const workbook = XLSX.utils.book_new();
+		XLSX.utils.book_append_sheet(workbook, worksheet, "Por Inversionista");
+		XLSX.writeFile(
+			workbook,
+			`flujo-inversionistas-${flujoAnioNum}-${String(flujoMesNum).padStart(2, "0")}.xlsx`,
+		);
 	};
 
 	const closedCreditsRows = closedCreditsReport.data?.rows ?? [];
@@ -1961,51 +1906,49 @@ function RouteComponent() {
 						{isAdmin && (
 							<>
 						<TabsContent value="inversiones" className="space-y-6">
-							{/* Reporte: Flujo de Cuotas de Inversiones */}
 							<Card>
 								<CardHeader>
 									<div className="flex flex-col gap-4 sm:flex-row sm:items-center sm:justify-between">
 										<div>
-											<CardTitle className="flex items-center gap-2">
-												<TrendingUp className="h-5 w-5" />
-												Flujo de Cuotas de Inversiones
-											</CardTitle>
+											<CardTitle>Inversión y reinversión</CardTitle>
 											<CardDescription>
-												Cuotas esperadas hacia reinversión y hacia pago en
-												efectivo, por período
+												Capital liquidado, distribución y posición activa.
 											</CardDescription>
 										</div>
 										<div className="flex items-center gap-2">
 											<Select
 												value={String(flujoMesNum)}
-												onValueChange={(v) =>
-													setFlujoMesAnio(flujoAnioNum, Number(v))
+												onValueChange={(value) =>
+													setFlujoMesAnio(flujoAnioNum, Number(value))
 												}
 											>
 												<SelectTrigger className="w-36" aria-label="Mes">
 													<SelectValue />
 												</SelectTrigger>
 												<SelectContent>
-													{mesesDisponibles.map((m) => (
-														<SelectItem key={m.num} value={String(m.num)}>
-															{m.nombre}
+													{mesesDisponibles.map((month) => (
+														<SelectItem
+															key={month.num}
+															value={String(month.num)}
+														>
+															{month.nombre}
 														</SelectItem>
 													))}
 												</SelectContent>
 											</Select>
 											<Select
 												value={String(flujoAnioNum)}
-												onValueChange={(v) =>
-													setFlujoMesAnio(Number(v), flujoMesNum)
+												onValueChange={(value) =>
+													setFlujoMesAnio(Number(value), flujoMesNum)
 												}
 											>
 												<SelectTrigger className="w-24" aria-label="Año">
 													<SelectValue />
 												</SelectTrigger>
 												<SelectContent>
-													{aniosDisponibles.map((a) => (
-														<SelectItem key={a} value={String(a)}>
-															{a}
+													{aniosDisponibles.map((year) => (
+														<SelectItem key={year} value={String(year)}>
+															{year}
 														</SelectItem>
 													))}
 												</SelectContent>
@@ -2013,616 +1956,15 @@ function RouteComponent() {
 										</div>
 									</div>
 								</CardHeader>
-								<CardContent className="space-y-8">
-									{/* Sección 1: Cuotas → Reinversión (desde liquidaciones) */}
-									<div className={SECCION_REPORTE_CLASS}>
-										<p className="mb-2 font-semibold text-sm">
-											Cuotas → Reinversión
-										</p>
-										{reinversionLiquidacionesQuery.isPending ? (
-											<div className="py-4 text-center text-muted-foreground text-sm">
-												Cargando...
-											</div>
-										) : reinversionLiquidacionesQuery.isError ? (
-											<div className="py-4 text-center text-destructive text-sm">
-												Error al cargar datos.
-											</div>
-										) : reinversionData ? (
-											(() => {
-												const filas = REINVERSION_MODALIDADES.map((m) => {
-													const d = reinversionData.porTipo[m.tipo];
-													return {
-														...m,
-														capital: Number(d?.reinversion_capital ?? 0),
-														interes: Number(d?.reinversion_interes ?? 0),
-														total: Number(d?.reinversion_total ?? 0),
-													};
-												}).filter((f) => f.total !== 0);
-												const totales = filas.reduce(
-													(a, f) => ({
-														capital: a.capital + f.capital,
-														interes: a.interes + f.interes,
-														total: a.total + f.total,
-													}),
-													{ capital: 0, interes: 0, total: 0 },
-												);
-												return (
-													<Table>
-														<TableHeader>
-															<TableRow>
-																<TableHead>Modalidad de Reinversión</TableHead>
-																<TableHead className="text-right">
-																	Capital
-																</TableHead>
-																<TableHead className="text-right">
-																	Interés
-																</TableHead>
-																<TableHead className="text-right">
-																	Reinversión Total
-																</TableHead>
-															</TableRow>
-														</TableHeader>
-														<TableBody>
-															{filas.map((f) => (
-																<TableRow key={f.tipo}>
-																	<TableCell>{f.label}</TableCell>
-																	<TableCell className="text-right">
-																		{dash(f.capital)}
-																	</TableCell>
-																	<TableCell className="text-right">
-																		{dash(f.interes)}
-																	</TableCell>
-																	<TableCell className="text-right">
-																		{dash(f.total)}
-																	</TableCell>
-																</TableRow>
-															))}
-															<TableRow className="border-t-2 bg-muted/50 font-bold">
-																<TableCell>Total </TableCell>
-																<TableCell className="text-right">
-																	{dash(totales.capital)}
-																</TableCell>
-																<TableCell className="text-right">
-																	{dash(totales.interes)}
-																</TableCell>
-																<TableCell className="text-right">
-																	{dash(totales.total)}
-																</TableCell>
-															</TableRow>
-														</TableBody>
-													</Table>
-												);
-											})()
-										) : null}
-									</div>
-
-									{/* Sección 2: Cuotas → A Recibir (efectivo neto = total_cuota) */}
-									<div className={SECCION_REPORTE_CLASS}>
-										<p className="mb-2 font-semibold text-sm">
-											Cuotas → A Recibir
-										</p>
-										{reinversionLiquidacionesQuery.isPending ? (
-											<div className="py-4 text-center text-muted-foreground text-sm">
-												Cargando...
-											</div>
-										) : reinversionLiquidacionesQuery.isError ? (
-											<div className="py-4 text-center text-destructive text-sm">
-												Error al cargar datos.
-											</div>
-										) : reinversionData ? (
-											(() => {
-												const filas = A_RECIBIR_MODALIDADES.map((m) => {
-													const d = reinversionData.porTipo[m.tipo];
-													return {
-														...m,
-														capital: Number(d?.total_capital ?? 0),
-														interes: Number(d?.total_interes ?? 0),
-														iva: Number(d?.total_iva ?? 0),
-														isr: Number(d?.total_isr ?? 0),
-														total: Number(d?.total_cuota ?? 0),
-													};
-												}).filter(
-													(f) =>
-														f.capital !== 0 ||
-														f.interes !== 0 ||
-														f.iva !== 0 ||
-														f.isr !== 0 ||
-														f.total !== 0,
-												);
-												const totales = filas.reduce(
-													(a, f) => ({
-														capital: a.capital + f.capital,
-														interes: a.interes + f.interes,
-														iva: a.iva + f.iva,
-														isr: a.isr + f.isr,
-														total: a.total + f.total,
-													}),
-													{ capital: 0, interes: 0, iva: 0, isr: 0, total: 0 },
-												);
-												return (
-													<Table>
-														<TableHeader>
-															<TableRow>
-																<TableHead>Modalidad de Reinversión</TableHead>
-																<TableHead className="text-right">
-																	Capital
-																</TableHead>
-																<TableHead className="text-right">
-																	Interés
-																</TableHead>
-																<TableHead className="text-right">
-																	IVA 12%
-																</TableHead>
-																<TableHead className="text-right">
-																	ISR
-																</TableHead>
-																<TableHead className="text-right">
-																	Total a Recibir
-																</TableHead>
-															</TableRow>
-														</TableHeader>
-														<TableBody>
-															{filas.map((f) => (
-																<TableRow key={f.tipo}>
-																	<TableCell>{f.label}</TableCell>
-																	<TableCell className="text-right">
-																		{dash(f.capital)}
-																	</TableCell>
-																	<TableCell className="text-right">
-																		{dash(f.interes)}
-																	</TableCell>
-																	<TableCell className="text-right">
-																		{dash(f.iva)}
-																	</TableCell>
-																	<TableCell className="text-right">
-																		{dash(f.isr)}
-																	</TableCell>
-																	<TableCell className="text-right">
-																		{dash(f.total)}
-																	</TableCell>
-																</TableRow>
-															))}
-															<TableRow className="border-t-2 bg-muted/50 font-bold">
-																<TableCell>Total a Recibir</TableCell>
-																<TableCell className="text-right">
-																	{dash(totales.capital)}
-																</TableCell>
-																<TableCell className="text-right">
-																	{dash(totales.interes)}
-																</TableCell>
-																<TableCell className="text-right">
-																	{dash(totales.iva)}
-																</TableCell>
-																<TableCell className="text-right">
-																	{dash(totales.isr)}
-																</TableCell>
-																<TableCell className="text-right">
-																	{dash(totales.total)}
-																</TableCell>
-															</TableRow>
-														</TableBody>
-													</Table>
-												);
-											})()
-										) : null}
-									</div>
-
-									{/* Sección: Interés Neto (agrupado por si el inversionista emite factura) */}
-									{reinversionData &&
-										(() => {
-											const cf = reinversionData.interesNeto.conFactura;
-											const sf = reinversionData.interesNeto.sinFactura;
-											const cube = reinversionData.interesNeto.cube;
-											const totalInteres =
-												Number(cf.interes) +
-												Number(sf.interes) +
-												Number(cube.interes);
-											const totalIva = Number(cf.iva) + Number(cube.iva);
-											const totalIsr = Number(sf.isr);
-											const totalNeto =
-												Number(cf.neto) + Number(sf.neto) + Number(cube.neto);
-											return (
-												<div className={SECCION_REPORTE_CLASS}>
-													<p className="mb-2 font-semibold text-sm">
-														Interés Neto
-													</p>
-													<Table>
-														<TableHeader>
-															<TableRow>
-																<TableHead>Tipo</TableHead>
-																<TableHead className="text-right">
-																	Interés
-																</TableHead>
-																<TableHead className="text-right">
-																	IVA 12%
-																</TableHead>
-																<TableHead className="text-right">
-																	ISR
-																</TableHead>
-																<TableHead className="text-right">
-																	Interés Neto
-																</TableHead>
-															</TableRow>
-														</TableHeader>
-														<TableBody>
-															<TableRow>
-																<TableCell>Inversionista Con Factura</TableCell>
-																<TableCell className="text-right">
-																	{dash(cf.interes)}
-																</TableCell>
-																<TableCell className="text-right">
-																	{dash(cf.iva)}
-																</TableCell>
-																<TableCell className="text-right text-muted-foreground">
-																	—
-																</TableCell>
-																<TableCell className="text-right font-semibold">
-																	{dash(cf.neto)}
-																</TableCell>
-															</TableRow>
-															<TableRow>
-																<TableCell>Inversionista Sin Factura</TableCell>
-																<TableCell className="text-right">
-																	{dash(sf.interes)}
-																</TableCell>
-																<TableCell className="text-right text-muted-foreground">
-																	—
-																</TableCell>
-																<TableCell className="text-right">
-																	{dash(sf.isr)}
-																</TableCell>
-																<TableCell className="text-right font-semibold">
-																	{dash(sf.neto)}
-																</TableCell>
-															</TableRow>
-
-															<TableRow>
-																<TableCell>Residuo CUBE</TableCell>
-																<TableCell className="text-right">
-																	{dash(cube.interes)}
-																</TableCell>
-																<TableCell className="text-right">
-																	{dash(cube.iva)}
-																</TableCell>
-																<TableCell className="text-right text-muted-foreground">
-																	—
-																</TableCell>
-																<TableCell className="text-right font-semibold">
-																	{dash(cube.neto)}
-																</TableCell>
-															</TableRow>
-															<TableRow className="border-t-2 bg-muted/50 font-bold">
-																<TableCell>Total</TableCell>
-																<TableCell className="text-right">
-																	{dash(totalInteres)}
-																</TableCell>
-																<TableCell className="text-right">
-																	{dash(totalIva)}
-																</TableCell>
-																<TableCell className="text-right">
-																	{dash(totalIsr)}
-																</TableCell>
-																<TableCell className="text-right">
-																	{dash(totalNeto)}
-																</TableCell>
-															</TableRow>
-														</TableBody>
-													</Table>
-												</div>
-											);
-										})()}
-
-									{/* Sección 3: Pagos Extras Recibidos */}
-									{reinversionData &&
-										(() => {
-											const pe = reinversionData.pagosExtras;
-											const totalExtras =
-												Number(pe.abonos_capital) + Number(pe.cancelaciones);
-											return (
-												<div className={SECCION_REPORTE_CLASS}>
-													<p className="mb-2 font-semibold text-sm">
-														Pagos Extras Recibidos
-													</p>
-													<Table>
-														<TableHeader>
-															<TableRow>
-																<TableHead>Tipo</TableHead>
-																<TableHead className="text-right">
-																	Monto
-																</TableHead>
-															</TableRow>
-														</TableHeader>
-														<TableBody>
-															<TableRow>
-																<TableCell>Abonos Extra a Capital</TableCell>
-																<TableCell className="text-right">
-																	{dash(pe.abonos_capital)}
-																</TableCell>
-															</TableRow>
-															<TableRow>
-																<TableCell>Cancelaciones</TableCell>
-																<TableCell className="text-right">
-																	{dash(pe.cancelaciones)}
-																</TableCell>
-															</TableRow>
-															<TableRow className="border-t-2 bg-muted/50 font-bold">
-																<TableCell>Total</TableCell>
-																<TableCell className="text-right">
-																	{dash(totalExtras)}
-																</TableCell>
-															</TableRow>
-														</TableBody>
-													</Table>
-												</div>
-											);
-										})()}
-
-									{/* Sección: Compras en el Mes (compra_cartera, por fecha_completada) */}
-									<div className={SECCION_REPORTE_CLASS}>
-										<p className="mb-2 font-semibold text-sm">
-											Compras en el Mes
-										</p>
-										{reinversionLiquidacionesQuery.isPending ? (
-											<div className="py-4 text-center text-muted-foreground text-sm">
-												Cargando...
-											</div>
-										) : reinversionLiquidacionesQuery.isError ? (
-											<div className="py-4 text-center text-destructive text-sm">
-												Error al cargar datos
-											</div>
-										) : !reinversionData?.comprasMes?.length ? (
-											<div className="py-4 text-center text-muted-foreground text-sm">
-												Sin compras en el período seleccionado
-											</div>
-										) : (
-											(() => {
-												const filas = reinversionData.comprasMes;
-												const totales = filas.reduce(
-													(a, f) => ({
-														cantidad: a.cantidad + f.cantidad,
-														monto: a.monto + Number(f.monto),
-													}),
-													{ cantidad: 0, monto: 0 },
-												);
-												return (
-													<Table>
-														<TableHeader>
-															<TableRow>
-																<TableHead>Modalidad</TableHead>
-																<TableHead className="text-right">
-																	Cantidad
-																</TableHead>
-																<TableHead className="text-right">
-																	Monto
-																</TableHead>
-															</TableRow>
-														</TableHeader>
-														<TableBody>
-															{filas.map((row) => (
-																<TableRow key={row.tipo}>
-																	<TableCell>
-																		{MODALIDAD_LABEL[row.tipo] ?? row.tipo}
-																	</TableCell>
-																	<TableCell className="text-right">
-																		{row.cantidad}
-																	</TableCell>
-																	<TableCell className="text-right">
-																		{dash(row.monto)}
-																	</TableCell>
-																</TableRow>
-															))}
-															<TableRow className="border-t-2 bg-muted/50 font-bold">
-																<TableCell>Total</TableCell>
-																<TableCell className="text-right">
-																	{totales.cantidad}
-																</TableCell>
-																<TableCell className="text-right">
-																	{dash(totales.monto)}
-																</TableCell>
-															</TableRow>
-														</TableBody>
-													</Table>
-												);
-											})()
-										)}
-									</div>
-
-									{/* Sección 4: Desglose por Inversionista (desde liquidaciones) */}
-									<div className={SECCION_REPORTE_CLASS}>
-										<div className="mb-2 flex items-center justify-between">
-											<p className="font-semibold text-sm">
-												Desglose por Inversionista
-											</p>
-											{(reinversionData?.porInversionista?.length ?? 0) > 0 && (
-												<Button
-													variant="outline"
-													size="sm"
-													onClick={() => {
-														const fuente =
-															reinversionData?.porInversionista ?? [];
-														const data =
-															modalidadFiltro.length === 0
-																? fuente
-																: fuente.filter((r) =>
-																		modalidadFiltro.includes(
-																			r.tipo_reinversion,
-																		),
-																	);
-														const rows = data.map((r) => ({
-															Inversionista: r.nombre,
-															Modalidad:
-																MODALIDAD_LABEL[r.tipo_reinversion] ??
-																r.tipo_reinversion,
-															Reinversión: r.reinversion,
-															"A Recibir": r.a_recibir,
-															"Monto Aportado": r.monto_aportado,
-														}));
-														const ws = XLSX.utils.json_to_sheet(rows);
-														ws["!cols"] = [
-															{ wch: 30 },
-															{ wch: 18 },
-															{ wch: 18 },
-															{ wch: 18 },
-															{ wch: 18 },
-														];
-														const wb = XLSX.utils.book_new();
-														XLSX.utils.book_append_sheet(
-															wb,
-															ws,
-															"Por Inversionista",
-														);
-														XLSX.writeFile(
-															wb,
-															`flujo-inversionistas-${flujoCuotasRange.fechaInicio}-${flujoCuotasRange.fechaFin}.xlsx`,
-														);
-													}}
-												>
-													<Download className="mr-2 h-4 w-4" />
-													Exportar Excel
-												</Button>
-											)}
-										</div>
-										{reinversionLiquidacionesQuery.isPending ? (
-											<div className="py-4 text-center text-muted-foreground text-sm">
-												Cargando...
-											</div>
-										) : reinversionLiquidacionesQuery.isError ? (
-											<div className="py-4 text-center text-destructive text-sm">
-												Error al cargar datos
-											</div>
-										) : !reinversionData?.porInversionista?.length ? (
-											<div className="py-4 text-center text-muted-foreground text-sm">
-												Sin datos para el período seleccionado
-											</div>
-										) : (
-											(() => {
-												const todas = reinversionData.porInversionista;
-												const presentes = new Set(
-													todas.map((f) => f.tipo_reinversion),
-												);
-												const modalidades = Object.keys(MODALIDAD_LABEL).filter(
-													(t) => presentes.has(t),
-												);
-												const filas =
-													modalidadFiltro.length === 0
-														? todas
-														: todas.filter((f) =>
-																modalidadFiltro.includes(f.tipo_reinversion),
-															);
-												const totales = filas.reduce(
-													(a, f) => ({
-														reinversion: a.reinversion + Number(f.reinversion),
-														a_recibir: a.a_recibir + Number(f.a_recibir),
-														monto_aportado:
-															a.monto_aportado + Number(f.monto_aportado),
-													}),
-													{ reinversion: 0, a_recibir: 0, monto_aportado: 0 },
-												);
-												return (
-													<>
-														<div className="mb-3 flex flex-wrap items-center gap-1.5">
-															<span className="text-muted-foreground text-xs">
-																Modalidad:
-															</span>
-															{modalidades.map((tipo) => {
-																const activo = modalidadFiltro.includes(tipo);
-																return (
-																	<button
-																		key={tipo}
-																		type="button"
-																		onClick={() =>
-																			setModalidadFiltro((prev) =>
-																				prev.includes(tipo)
-																					? prev.filter((t) => t !== tipo)
-																					: [...prev, tipo],
-																			)
-																		}
-																		className={`rounded border px-2 py-0.5 text-xs transition-colors ${
-																			activo
-																				? "bg-muted font-medium text-foreground"
-																				: "text-muted-foreground"
-																		}`}
-																	>
-																		{MODALIDAD_LABEL[tipo] ?? tipo}
-																	</button>
-																);
-															})}
-															{modalidadFiltro.length > 0 && (
-																<button
-																	type="button"
-																	onClick={() => setModalidadFiltro([])}
-																	className="text-muted-foreground text-xs underline"
-																>
-																	Limpiar
-																</button>
-															)}
-														</div>
-														<Table>
-															<TableHeader>
-																<TableRow>
-																	<TableHead>Inversionista</TableHead>
-																	<TableHead>Modalidad</TableHead>
-																	<TableHead className="text-right">
-																		Reinversión
-																	</TableHead>
-																	<TableHead className="text-right">
-																		A Recibir
-																	</TableHead>
-																	<TableHead className="text-right">
-																		Monto Aportado
-																	</TableHead>
-																</TableRow>
-															</TableHeader>
-															<TableBody>
-																{filas.map((row) => (
-																	<TableRow key={row.inversionista_id}>
-																		<TableCell className="font-medium">
-																			{row.nombre}
-																		</TableCell>
-																		<TableCell>
-																			<span
-																				className={`inline-block rounded border px-1.5 py-0.5 font-normal text-[10px] ${
-																					MODALIDAD_CHIP_CLASS[
-																						row.tipo_reinversion
-																					] ??
-																					"border-muted-foreground/30 text-muted-foreground"
-																				}`}
-																			>
-																				{MODALIDAD_LABEL[
-																					row.tipo_reinversion
-																				] ?? row.tipo_reinversion}
-																			</span>
-																		</TableCell>
-																		<TableCell className="text-right">
-																			{dash(row.reinversion)}
-																		</TableCell>
-																		<TableCell className="text-right">
-																			{dash(row.a_recibir)}
-																		</TableCell>
-																		<TableCell className="text-right">
-																			{dash(row.monto_aportado)}
-																		</TableCell>
-																	</TableRow>
-																))}
-																<TableRow className="border-t-2 bg-muted/50 font-bold">
-																	<TableCell colSpan={2}>Total</TableCell>
-																	<TableCell className="text-right">
-																		{dash(totales.reinversion)}
-																	</TableCell>
-																	<TableCell className="text-right">
-																		{dash(totales.a_recibir)}
-																	</TableCell>
-																	<TableCell className="text-right">
-																		{dash(totales.monto_aportado)}
-																	</TableCell>
-																</TableRow>
-															</TableBody>
-														</Table>
-													</>
-												);
-											})()
-										)}
-									</div>
+								<CardContent className="pt-6">
+									<ReinvestmentReport
+										data={reinversionData}
+										isPending={reinversionLiquidacionesQuery.isPending}
+										isError={reinversionLiquidacionesQuery.isError}
+										periodLabel={`${MESES[flujoMesNum - 1]} de ${flujoAnioNum}`}
+										onRetry={() => reinversionLiquidacionesQuery.refetch()}
+										onExportInvestors={exportReinvestmentInvestorsExcel}
+									/>
 								</CardContent>
 							</Card>
 						</TabsContent>

--- a/apps/crm/apps/web/src/routes/admin/reports/index.tsx
+++ b/apps/crm/apps/web/src/routes/admin/reports/index.tsx
@@ -1090,6 +1090,22 @@ function RouteComponent() {
 								</>
 							)}
 						</TabsList>
+						{canAccessCobranzaReport && (
+							<>
+								<ScenarioModal
+									open={scenarioOpen === "monto"}
+									onOpenChange={(o) => setScenarioOpen(o ? "monto" : null)}
+									config={montoACobrarConfig}
+									baseData={montoCobrarData?.data}
+								/>
+								<ScenarioModal
+									open={scenarioOpen === "facturacion"}
+									onOpenChange={(o) => setScenarioOpen(o ? "facturacion" : null)}
+									config={facturacionConfig}
+									baseData={facturacionMesData}
+								/>
+							</>
+						)}
 						{canAccessClosedCreditsReport && (
 							<TabsContent value="creditos" className="space-y-6">
 								{creditosCerradosCard}
@@ -2710,18 +2726,6 @@ function RouteComponent() {
 						</Dialog>
 
 						{/* Modales de simulación de escenarios */}
-						<ScenarioModal
-							open={scenarioOpen === "monto"}
-							onOpenChange={(o) => setScenarioOpen(o ? "monto" : null)}
-							config={montoACobrarConfig}
-							baseData={montoCobrarData?.data}
-						/>
-						<ScenarioModal
-							open={scenarioOpen === "facturacion"}
-							onOpenChange={(o) => setScenarioOpen(o ? "facturacion" : null)}
-							config={facturacionConfig}
-							baseData={facturacionMesData}
-						/>
 						<ScenarioModal
 							open={scenarioOpen === "cobertura"}
 							onOpenChange={(o) => setScenarioOpen(o ? "cobertura" : null)}

--- a/apps/crm/apps/web/src/routes/admin/reports/index.tsx
+++ b/apps/crm/apps/web/src/routes/admin/reports/index.tsx
@@ -69,6 +69,7 @@ import {
 import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs";
 import { authClient } from "@/lib/auth-client";
 import { shouldRedirectToLogin } from "@/lib/auth-session";
+import { getMontoACobrarParticipacionTotals } from "@/lib/reports/monto-a-cobrar";
 import type {
 	ComparativoHistoricoRow,
 	FacturacionMesResponse,
@@ -413,6 +414,17 @@ function fillMissingPeriods(
 				acum_total_membresias: "0",
 				total_interes_inversionista: "0",
 				acum_total_interes_inversionista: "0",
+				capital_inv_participacion_actual: "0",
+				capital_cube_participacion_actual: "0",
+				interes_iva_inv_participacion_actual: "0",
+				interes_iva_cube_participacion_actual: "0",
+				acum_capital_inv_participacion_actual: "0",
+				acum_capital_cube_participacion_actual: "0",
+				acum_interes_iva_inv_participacion_actual: "0",
+				acum_interes_iva_cube_participacion_actual: "0",
+				creditos_participacion_invalida: 0,
+				cuotas_participacion_invalida: 0,
+				participacion_actual: true,
 			}
 		);
 	});
@@ -1311,9 +1323,9 @@ function RouteComponent() {
 											<CalendarDays className="h-5 w-5 text-blue-500" />
 											<div>
 												<CardTitle>Monto a Cobrarse por Período</CardTitle>
-												<CardDescription>
-													Cuotas pendientes desglosadas por rubro (capital,
-													interés, seguro, etc.)
+													<CardDescription>
+														Cuotas pendientes desglosadas por rubro (capital,
+														interés, seguro, etc.). Según participación actual.
 												</CardDescription>
 											</div>
 										</div>
@@ -1391,6 +1403,17 @@ function RouteComponent() {
 									)}
 									{!!montoCobrarData?.data.length && (
 										<>
+											{(() => {
+												const totals = getMontoACobrarParticipacionTotals(
+													montoCobrarData.data,
+													false,
+												);
+												return totals.creditosInvalidos > 0 ? (
+													<p className="rounded-md border border-amber-300 bg-amber-50 px-3 py-2 text-amber-900 text-sm dark:bg-amber-950/30 dark:text-amber-200">
+														Participación actual inválida en {totals.creditosInvalidos} crédito(s) y {totals.cuotasInvalidas} cuota(s); sus montos no se incluyen en el desglose Inv./CUBE.
+													</p>
+												) : null;
+											})()}
 											{/* Gráfica de barras apiladas */}
 											<ResponsiveContainer width="100%" height={350}>
 												<BarChart
@@ -1496,9 +1519,13 @@ function RouteComponent() {
 															<TableHead className="text-right">
 																Membresías
 															</TableHead>
-															<TableHead className="text-right">
-																Interés Inv. (referencia)
-															</TableHead>
+																	<TableHead className="text-right">
+																		Interés Inv. pagado (referencia)
+																	</TableHead>
+																	<TableHead className="text-right">Capital Inv.</TableHead>
+																	<TableHead className="text-right">Capital CUBE</TableHead>
+																	<TableHead className="text-right">Interés + IVA Inv.</TableHead>
+																	<TableHead className="text-right">Interés + IVA CUBE</TableHead>
 															<TableHead className="text-right">
 																Total Mora
 															</TableHead>
@@ -1533,9 +1560,13 @@ function RouteComponent() {
 															const membresias = a
 																? row.acum_total_membresias
 																: row.total_membresias;
-															const interesInversionista = a
-																? row.acum_total_interes_inversionista
-																: row.total_interes_inversionista;
+																	const interesInversionista = a
+																		? row.acum_total_interes_inversionista
+																		: row.total_interes_inversionista;
+																	const capitalInv = a ? row.acum_capital_inv_participacion_actual : row.capital_inv_participacion_actual;
+																	const capitalCube = a ? row.acum_capital_cube_participacion_actual : row.capital_cube_participacion_actual;
+																	const interesIvaInv = a ? row.acum_interes_iva_inv_participacion_actual : row.interes_iva_inv_participacion_actual;
+																	const interesIvaCube = a ? row.acum_interes_iva_cube_participacion_actual : row.interes_iva_cube_participacion_actual;
 															const total =
 																Number.parseFloat(cuota) +
 																Number.parseFloat(interes) +
@@ -1575,6 +1606,10 @@ function RouteComponent() {
 																	<TableCell className="text-right">
 																		{formatCurrency(interesInversionista)}
 																	</TableCell>
+																	<TableCell className="text-right">{formatCurrency(capitalInv)}</TableCell>
+																	<TableCell className="text-right">{formatCurrency(capitalCube)}</TableCell>
+																	<TableCell className="text-right">{formatCurrency(interesIvaInv)}</TableCell>
+																	<TableCell className="text-right">{formatCurrency(interesIvaCube)}</TableCell>
 																	<TableCell className="text-right">
 																		<div>{formatCurrency(row.total_mora)}</div>
 																		<div
@@ -1626,13 +1661,24 @@ function RouteComponent() {
 																val("acum_total_seguro") +
 																val("acum_total_gps") +
 																val("acum_total_membresias");
-															const totalCred =
-																a && lastRow
-																	? lastRow.cuotas_count
-																	: rows.reduce(
-																			(acc, r) => acc + r.cuotas_count,
-																			0,
-																		);
+																	const totalCred =
+																		a && lastRow
+																			? lastRow.cuotas_count
+																			: rows.reduce(
+																					(acc, r) => acc + r.cuotas_count,
+																					0,
+																				);
+																	const splitTotals = getMontoACobrarParticipacionTotals(
+																		rows.map((row) => ({
+																			capital_inv_participacion_actual: a ? row.acum_capital_inv_participacion_actual : row.capital_inv_participacion_actual,
+																			capital_cube_participacion_actual: a ? row.acum_capital_cube_participacion_actual : row.capital_cube_participacion_actual,
+																			interes_iva_inv_participacion_actual: a ? row.acum_interes_iva_inv_participacion_actual : row.interes_iva_inv_participacion_actual,
+																			interes_iva_cube_participacion_actual: a ? row.acum_interes_iva_cube_participacion_actual : row.interes_iva_cube_participacion_actual,
+																			creditos_participacion_invalida: row.creditos_participacion_invalida,
+																			cuotas_participacion_invalida: row.cuotas_participacion_invalida,
+																		})),
+																		a,
+																	);
 															return (
 																<TableRow className="border-t-2 bg-muted/50 font-bold">
 																	<TableCell>Total</TableCell>
@@ -1688,10 +1734,14 @@ function RouteComponent() {
 																			val(
 																				a
 																					? "acum_total_interes_inversionista"
-																					: "total_interes_inversionista",
-																			),
-																		)}
-																	</TableCell>
+																							: "total_interes_inversionista",
+																						),
+																					)}
+																				</TableCell>
+																				<TableCell className="text-right">{formatCurrency(splitTotals.capitalInv)}</TableCell>
+																				<TableCell className="text-right">{formatCurrency(splitTotals.capitalCube)}</TableCell>
+																				<TableCell className="text-right">{formatCurrency(splitTotals.interesIvaInv)}</TableCell>
+																				<TableCell className="text-right">{formatCurrency(splitTotals.interesIvaCube)}</TableCell>
 																	<TableCell className="text-right">
 																		{formatCurrency(val("total_mora"))}
 																	</TableCell>

--- a/apps/crm/apps/web/src/routes/admin/reports/index.tsx
+++ b/apps/crm/apps/web/src/routes/admin/reports/index.tsx
@@ -1675,6 +1675,7 @@ function RouteComponent() {
 																			interes_iva_inv_participacion_actual: a ? row.acum_interes_iva_inv_participacion_actual : row.interes_iva_inv_participacion_actual,
 																			interes_iva_cube_participacion_actual: a ? row.acum_interes_iva_cube_participacion_actual : row.interes_iva_cube_participacion_actual,
 																			creditos_participacion_invalida: row.creditos_participacion_invalida,
+																			creditos_participacion_invalida_rango: row.creditos_participacion_invalida_rango,
 																			cuotas_participacion_invalida: row.cuotas_participacion_invalida,
 																		})),
 																		a,

--- a/apps/crm/apps/web/src/routes/admin/reports/index.tsx
+++ b/apps/crm/apps/web/src/routes/admin/reports/index.tsx
@@ -87,6 +87,7 @@ import {
 } from "@/lib/reports/scenario-configs";
 import { PERMISSIONS } from "@/lib/roles";
 import { Combobox } from "@/components/ui/combobox";
+import { getReportTabs } from "./-tabs";
 import { client, orpc, queryClient } from "@/utils/orpc";
 type SimulacionInversionistaResult = {
 	success: boolean;
@@ -565,7 +566,16 @@ function RouteComponent() {
 	const canAccessClosedCreditsReport = userRole
 		? PERMISSIONS.canAccessClosedCreditsReport(userRole)
 		: false;
-	const canAccessReports = isAdmin || canAccessClosedCreditsReport;
+	const canAccessCobranzaReport = userRole
+		? PERMISSIONS.canAccessCobranzaReport(userRole)
+		: false;
+	const canAccessReports =
+		isAdmin || canAccessClosedCreditsReport || canAccessCobranzaReport;
+	const reportTabs = getReportTabs({
+		canAccessClosedCreditsReport,
+		canAccessCobranzaReport,
+		isAdmin,
+	});
 
 	const dashboardData = useQuery({
 		...orpc.getDashboardExecutivo.queryOptions({
@@ -605,7 +615,7 @@ function RouteComponent() {
 				fechaFin: montoCobrarRange.fechaFin,
 			},
 		}),
-		enabled: isAdmin,
+		enabled: canAccessCobranzaReport,
 	});
 	const montoCobrarData = montoCobrarQuery.data as
 		| { data: MontoACobrarPeriodoRow[] }
@@ -615,7 +625,7 @@ function RouteComponent() {
 		...orpc.getFacturacionMes.queryOptions({
 			input: { mes: facturacionMes.mes, anio: facturacionMes.anio },
 		}),
-		enabled: isAdmin,
+		enabled: canAccessCobranzaReport,
 	});
 	const facturacionMesData = facturacionMesQuery.data as
 		| FacturacionMesResponse
@@ -1058,16 +1068,7 @@ function RouteComponent() {
 				</div>
 			</div>
 
-			{!isAdmin && canAccessClosedCreditsReport && creditosCerradosCard}
-
-			{isAdmin && (
-				<>
-					<Tabs
-						defaultValue={
-							canAccessClosedCreditsReport ? "creditos" : "cobranza"
-						}
-						className="space-y-6"
-					>
+			<Tabs defaultValue={reportTabs.defaultTab} className="space-y-6">
 						<TabsList>
 							{canAccessClosedCreditsReport && (
 								<TabsTrigger value="creditos">Créditos cerrados</TabsTrigger>
@@ -1076,18 +1077,26 @@ function RouteComponent() {
 							    secciones (TabsContent value="resumen" / "graficas") se
 							    conservan más abajo por si se quieren reutilizar; para
 							    volver a mostrarlas, reañadir aquí sus TabsTrigger. */}
-							<TabsTrigger value="cobranza">Cobranza</TabsTrigger>
-							<TabsTrigger value="inversiones">Inversiones</TabsTrigger>
-							<TabsTrigger value="colocacion">Colocación</TabsTrigger>
-							<TabsTrigger value="proyeccion-liquidaciones">
-								Proyección Liquidaciones
-							</TabsTrigger>
+							{canAccessCobranzaReport && (
+								<TabsTrigger value="cobranza">Cobranza</TabsTrigger>
+							)}
+							{isAdmin && (
+								<>
+									<TabsTrigger value="inversiones">Inversiones</TabsTrigger>
+									<TabsTrigger value="colocacion">Colocación</TabsTrigger>
+									<TabsTrigger value="proyeccion-liquidaciones">
+										Proyección Liquidaciones
+									</TabsTrigger>
+								</>
+							)}
 						</TabsList>
 						{canAccessClosedCreditsReport && (
 							<TabsContent value="creditos" className="space-y-6">
 								{creditosCerradosCard}
 							</TabsContent>
 						)}
+						{isAdmin && (
+							<>
 						<TabsContent value="resumen" className="space-y-6">
 							{/* Enlaces a otros reportes - TODO: Implementar rutas */}
 							<div className="grid gap-4 md:grid-cols-4">
@@ -1314,6 +1323,9 @@ function RouteComponent() {
 								</CardContent>
 							</Card>
 						</TabsContent>
+							</>
+						)}
+						{canAccessCobranzaReport && (
 						<TabsContent value="cobranza" className="space-y-6">
 							{/* Reporte: Monto a Cobrarse por Período */}
 							<Card>
@@ -1929,6 +1941,9 @@ function RouteComponent() {
 								</CardContent>
 							</Card>
 						</TabsContent>
+						)}
+						{isAdmin && (
+							<>
 						<TabsContent value="inversiones" className="space-y-6">
 							{/* Reporte: Flujo de Cuotas de Inversiones */}
 							<Card>
@@ -3476,9 +3491,9 @@ function RouteComponent() {
 								);
 							})()}
 						</TabsContent>
+							</>
+						)}
 					</Tabs>
-				</>
-			)}
 		</div>
 	);
 }

--- a/apps/crm/apps/web/src/routes/admin/reports/index.tsx
+++ b/apps/crm/apps/web/src/routes/admin/reports/index.tsx
@@ -1670,6 +1670,7 @@ function RouteComponent() {
 																				);
 																	const splitTotals = getMontoACobrarParticipacionTotals(
 																		rows.map((row) => ({
+																			cuotas_count: row.cuotas_count,
 																			capital_inv_participacion_actual: a ? row.acum_capital_inv_participacion_actual : row.capital_inv_participacion_actual,
 																			capital_cube_participacion_actual: a ? row.acum_capital_cube_participacion_actual : row.capital_cube_participacion_actual,
 																			interes_iva_inv_participacion_actual: a ? row.acum_interes_iva_inv_participacion_actual : row.interes_iva_inv_participacion_actual,

--- a/apps/crm/apps/web/src/routes/cobros/-mora-display.test.ts
+++ b/apps/crm/apps/web/src/routes/cobros/-mora-display.test.ts
@@ -1,5 +1,26 @@
 import { describe, expect, test } from "bun:test";
-import { buildMoraDisplayRows } from "./-mora-display";
+import { buildMoraDisplayRows, getMoraSnapshotDate } from "./-mora-display";
+
+describe("getMoraSnapshotDate", () => {
+	test("mantiene Hoy en vivo y usa el cierre del día 5 para meses iniciados", () => {
+		expect(getMoraSnapshotDate("hoy", "2026-06", "2026-06-06")).toBeUndefined();
+		expect(getMoraSnapshotDate("mes", "2026-06", "2026-06-06")).toBe(
+			"2026-06-05",
+		);
+	});
+
+	test("conserva el provisional antes del día 5 y los límites de año", () => {
+		expect(getMoraSnapshotDate("mes", "2026-06", "2026-06-03")).toBe(
+			"2026-06-03",
+		);
+		expect(getMoraSnapshotDate("mes", "2025-12", "2026-01-06")).toBe(
+			"2025-12-05",
+		);
+		expect(getMoraSnapshotDate("mes", "2026-01", "2026-02-06")).toBe(
+			"2026-01-05",
+		);
+	});
+});
 
 describe("buildMoraDisplayRows", () => {
 	test("conserva Sin asignar y mezcla los buckets completos por asesor", () => {

--- a/apps/crm/apps/web/src/routes/cobros/-mora-display.test.ts
+++ b/apps/crm/apps/web/src/routes/cobros/-mora-display.test.ts
@@ -52,4 +52,37 @@ describe("buildMoraDisplayRows", () => {
 			}),
 		]);
 	});
+
+	test("ignora recuperación cacheada en modo hoy", () => {
+		const rows = buildMoraDisplayRows(
+			[
+				{
+					asesorId: 7,
+					nombre: "Ana",
+					totalEnMora: { cantidad: 1, sumaMora: "100.00" },
+				},
+			],
+			[
+				{
+					asesorId: 7,
+					nombre: "Ana",
+					esperado: "999.00",
+					cobradoEnSnapshot: "500.00",
+					cobradoFueraSnapshot: "0.00",
+					excedenteEnSnapshot: "0.00",
+					pendiente: "499.00",
+				},
+			],
+			false,
+		);
+
+		expect(rows).toEqual([
+			expect.objectContaining({
+				asesorId: 7,
+				esperado: "100.00",
+				cobradoEnSnapshot: "0",
+				pendiente: "100.00",
+			}),
+		]);
+	});
 });

--- a/apps/crm/apps/web/src/routes/cobros/-mora-display.test.ts
+++ b/apps/crm/apps/web/src/routes/cobros/-mora-display.test.ts
@@ -1,0 +1,55 @@
+import { describe, expect, test } from "bun:test";
+import { buildMoraDisplayRows } from "./-mora-display";
+
+describe("buildMoraDisplayRows", () => {
+	test("conserva Sin asignar y mezcla los buckets completos por asesor", () => {
+		const rows = buildMoraDisplayRows(
+			[
+				{
+					asesorId: 7,
+					nombre: "Ana",
+					totalEnMora: { cantidad: 2, sumaMora: "100.00" },
+					mora_30: { cantidad: 1, sumaCapital: "10.00", sumaMora: "20.00" },
+					mora_60: { cantidad: 1, sumaCapital: "30.00", sumaMora: "40.00" },
+					mora_90: { cantidad: 0, sumaCapital: "0.00", sumaMora: "0.00" },
+					mora_120_plus: { cantidad: 0, sumaCapital: "0.00", sumaMora: "0.00" },
+				},
+			],
+			[
+				{
+					asesorId: 7,
+					nombre: "Ana",
+					esperado: "100.00",
+					cobradoEnSnapshot: "70.00",
+					cobradoFueraSnapshot: "5.00",
+					excedenteEnSnapshot: "0.00",
+					pendiente: "30.00",
+				},
+				{
+					asesorId: null,
+					nombre: "Sin asignar",
+					esperado: "50.00",
+					cobradoEnSnapshot: "20.00",
+					cobradoFueraSnapshot: "0.00",
+					excedenteEnSnapshot: "0.00",
+					pendiente: "30.00",
+				},
+			],
+		);
+
+		expect(rows).toEqual([
+			expect.objectContaining({
+				asesorId: 7,
+				mora_30: { cantidad: 1, sumaCapital: "10.00", sumaMora: "20.00" },
+				mora_60: { cantidad: 1, sumaCapital: "30.00", sumaMora: "40.00" },
+				pendiente: "30.00",
+			}),
+			expect.objectContaining({
+				asesorId: null,
+				nombre: "Sin asignar",
+				esperado: "50.00",
+				pendiente: "30.00",
+			}),
+		]);
+	});
+});

--- a/apps/crm/apps/web/src/routes/cobros/-mora-display.ts
+++ b/apps/crm/apps/web/src/routes/cobros/-mora-display.ts
@@ -1,0 +1,41 @@
+export type MoraBucket = {
+	cantidad: number;
+	sumaCapital: string;
+	sumaMora: string;
+};
+
+type MoraSnapshotAsesor = {
+	asesorId: number;
+	nombre: string;
+	totalEnMora: { cantidad: number; sumaMora: string };
+} & Partial<
+	Record<"mora_30" | "mora_60" | "mora_90" | "mora_120_plus", MoraBucket>
+>;
+
+type MoraRecoveryAsesor = {
+	asesorId: number | null;
+	nombre: string;
+	esperado: string;
+	cobradoEnSnapshot: string;
+	cobradoFueraSnapshot: string;
+	excedenteEnSnapshot: string;
+	pendiente: string;
+};
+
+export type MoraDisplayAsesor = MoraRecoveryAsesor &
+	Partial<Omit<MoraSnapshotAsesor, "asesorId" | "nombre">>;
+
+export function buildMoraDisplayRows(
+	porAsesor: MoraSnapshotAsesor[],
+	recuperacion: MoraRecoveryAsesor[],
+): MoraDisplayAsesor[] {
+	const snapshotPorAsesor = new Map<number, MoraSnapshotAsesor>(
+		porAsesor.map((asesor) => [asesor.asesorId, asesor]),
+	);
+	return recuperacion.map((asesor) => ({
+		...(asesor.asesorId === null
+			? undefined
+			: snapshotPorAsesor.get(asesor.asesorId)),
+		...asesor,
+	}));
+}

--- a/apps/crm/apps/web/src/routes/cobros/-mora-display.ts
+++ b/apps/crm/apps/web/src/routes/cobros/-mora-display.ts
@@ -25,6 +25,16 @@ type MoraRecoveryAsesor = {
 export type MoraDisplayAsesor = MoraRecoveryAsesor &
 	Partial<Omit<MoraSnapshotAsesor, "asesorId" | "nombre">>;
 
+export function getMoraSnapshotDate(
+	modo: "hoy" | "mes",
+	mesAnio: string,
+	hoy: string,
+) {
+	if (modo === "hoy") return undefined;
+	const apertura = `${mesAnio}-05`;
+	return apertura > hoy ? hoy : apertura;
+}
+
 export function buildMoraDisplayRows(
 	porAsesor: MoraSnapshotAsesor[],
 	recuperacion: MoraRecoveryAsesor[] | undefined,

--- a/apps/crm/apps/web/src/routes/cobros/-mora-display.ts
+++ b/apps/crm/apps/web/src/routes/cobros/-mora-display.ts
@@ -27,8 +27,19 @@ export type MoraDisplayAsesor = MoraRecoveryAsesor &
 
 export function buildMoraDisplayRows(
 	porAsesor: MoraSnapshotAsesor[],
-	recuperacion: MoraRecoveryAsesor[],
+	recuperacion: MoraRecoveryAsesor[] | undefined,
+	verCobrado = true,
 ): MoraDisplayAsesor[] {
+	if (!verCobrado || !recuperacion) {
+		return porAsesor.map((asesor) => ({
+			...asesor,
+			esperado: asesor.totalEnMora.sumaMora,
+			cobradoEnSnapshot: "0",
+			cobradoFueraSnapshot: "0",
+			excedenteEnSnapshot: "0",
+			pendiente: asesor.totalEnMora.sumaMora,
+		}));
+	}
 	const snapshotPorAsesor = new Map<number, MoraSnapshotAsesor>(
 		porAsesor.map((asesor) => [asesor.asesorId, asesor]),
 	);

--- a/apps/crm/apps/web/src/routes/cobros/reportes.tsx
+++ b/apps/crm/apps/web/src/routes/cobros/reportes.tsx
@@ -36,6 +36,11 @@ import { usePersistedState } from "@/hooks/usePersistedState";
 import { authClient } from "@/lib/auth-client";
 import { PERMISSIONS } from "@/lib/roles";
 import { orpc } from "@/utils/orpc";
+import {
+	buildMoraDisplayRows,
+	type MoraBucket,
+	type MoraDisplayAsesor,
+} from "./-mora-display";
 
 export const Route = createFileRoute("/cobros/reportes")({
 	component: RouteComponent,
@@ -80,6 +85,12 @@ const ETAPAS = [
 		color: "bg-red-300 text-red-950",
 	},
 ];
+
+type MoraSnapshotAsesor = {
+	asesorId: number;
+	nombre: string;
+	totalEnMora: { cantidad: number; sumaMora: string };
+} & Partial<Record<(typeof ETAPAS)[number]["key"], MoraBucket>>;
 
 function todayGTISO() {
 	return new Date().toLocaleDateString("sv-SE", {
@@ -155,8 +166,8 @@ function TabMora({
 	});
 
 	// Totales con / sin Gerencia (cliente, sobre porAsesor).
-	// eslint-disable-next-line @typescript-eslint/no-explicit-any
-	const porAsesor: any[] = (data as any)?.porAsesor ?? [];
+	const porAsesor = ((data as { porAsesor?: MoraSnapshotAsesor[] } | undefined)
+		?.porAsesor ?? []) as MoraSnapshotAsesor[];
 	const totalConGerencia = porAsesor.reduce(
 		(s, a) => s + Number(a.totalEnMora?.sumaMora ?? 0),
 		0,
@@ -179,11 +190,11 @@ function TabMora({
 	// eslint-disable-next-line @typescript-eslint/no-explicit-any
 	const alcance = (data as any)?.alcance as "live" | "historico" | undefined;
 
-	// Cobrado (mora cobrada en el período del mes). Solo aplica en modo "mes".
+	// Recuperación de mora para el mismo ciclo [día 6, día 6 siguiente).
 	const anioNum = Number(mesAnio.slice(0, 4));
 	const mesNum = Number(mesAnio.slice(5, 7));
-	const { data: cobradoData, refetch: refetchCobrado } = useQuery({
-		...orpc.getMoraCobradaPorAsesor.queryOptions({
+	const { data: recuperacion, refetch: refetchRecuperacion } = useQuery({
+		...orpc.getMoraRecuperacionPorAsesor.queryOptions({
 			input: {
 				mes: mesNum,
 				anio: anioNum,
@@ -193,32 +204,24 @@ function TabMora({
 		}),
 		enabled: !!session && modo === "mes",
 	});
-	const cobradoMap = useMemo(() => {
-		const m = new Map<number, { cobrado: number; nombre: string }>();
-		// eslint-disable-next-line @typescript-eslint/no-explicit-any
-		for (const a of ((cobradoData as any)?.porAsesor ?? []) as any[]) {
-			m.set(a.asesorId, { cobrado: Number(a.cobrado), nombre: a.nombre });
-		}
-		return m;
-	}, [cobradoData]);
-	// eslint-disable-next-line @typescript-eslint/no-explicit-any
-	const totalCobrado = Number((cobradoData as any)?.totalCobrado ?? 0);
 	const verCobrado = modo === "mes";
+	const esperadoSnapshot = Number(
+		recuperacion?.totales.esperado ?? totalConGerencia,
+	);
 
-	// Filas del desglose = unión de asesores con mora esperada y/o cobrada. El
-	// total cobrado incluye pagos sobre créditos ya saldados / fuera del snapshot
-	// de mora activa, así que sin la unión las filas no sumarían el total.
-	const filasAsesor = useMemo(() => {
-		// eslint-disable-next-line @typescript-eslint/no-explicit-any
-		const map = new Map<number, any>();
-		for (const a of porAsesor) map.set(a.asesorId, a);
-		if (verCobrado) {
-			for (const [id, c] of cobradoMap) {
-				if (!map.has(id)) map.set(id, { asesorId: id, nombre: c.nombre });
-			}
+	const filasAsesor = useMemo<MoraDisplayAsesor[]>(() => {
+		if (!recuperacion) {
+			return porAsesor.map((asesor) => ({
+				...asesor,
+				esperado: asesor.totalEnMora.sumaMora,
+				cobradoEnSnapshot: "0",
+				cobradoFueraSnapshot: "0",
+				excedenteEnSnapshot: "0",
+				pendiente: asesor.totalEnMora.sumaMora,
+			}));
 		}
-		return [...map.values()];
-	}, [porAsesor, cobradoMap, verCobrado]);
+		return buildMoraDisplayRows(porAsesor, recuperacion.porAsesor);
+	}, [porAsesor, recuperacion]);
 
 	const ultimaAct = dataUpdatedAt ? fmtTime(new Date(dataUpdatedAt)) : null;
 
@@ -240,7 +243,7 @@ function TabMora({
 						size="sm"
 						onClick={() => {
 							refetch();
-							if (verCobrado) refetchCobrado();
+							if (verCobrado) refetchRecuperacion();
 						}}
 						disabled={isFetching}
 					>
@@ -332,6 +335,13 @@ function TabMora({
 				</div>
 			)}
 
+			{recuperacion?.metadata.alcance === "historico" && (
+				<div className="rounded-lg border border-blue-200 bg-blue-50 px-4 py-2 text-blue-800 text-sm">
+					La mora corresponde al corte histórico; el asesor mostrado es su
+					asignación actual.
+				</div>
+			)}
+
 			{isLoading ? (
 				<div className="grid grid-cols-2 gap-4 md:grid-cols-4">
 					{ETAPAS.map((e) => (
@@ -380,7 +390,7 @@ function TabMora({
 				</div>
 			)}
 
-			{(porAsesor.length > 0 || (verCobrado && totalCobrado > 0)) && (
+			{(porAsesor.length > 0 || (verCobrado && recuperacion)) && (
 				<div
 					className={`grid grid-cols-1 gap-4 md:grid-cols-2 ${verCobrado ? "lg:grid-cols-3" : ""}`}
 				>
@@ -388,10 +398,12 @@ function TabMora({
 						<Card className="border-red-200 bg-red-50">
 							<CardContent className="pt-4">
 								<p className="font-semibold text-red-700 text-sm">
-									Total en Mora (con Gerencia)
+									{verCobrado
+										? "Mora esperada del snapshot"
+										: "Total en Mora (con Gerencia)"}
 								</p>
 								<p className="font-bold text-3xl text-red-800">
-									{fmtQ(totalConGerencia)}
+									{fmtQ(esperadoSnapshot)}
 								</p>
 								<p className="text-muted-foreground text-xs">
 									{credConGerencia} créditos
@@ -414,19 +426,18 @@ function TabMora({
 							</CardContent>
 						</Card>
 					)}
-					{verCobrado && (
+					{verCobrado && recuperacion && (
 						<Card className="border-green-200 bg-green-50">
 							<CardContent className="pt-4">
 								<p className="font-semibold text-green-700 text-sm">
-									Mora Cobrada (en el mes)
+									Cobrado en créditos del snapshot
 								</p>
 								<p className="font-bold text-3xl text-green-800">
-									{fmtQ(totalCobrado)}
+									{fmtQ(recuperacion.totales.cobradoEnSnapshot)}
 								</p>
 								<p className="text-muted-foreground text-xs">
-									{totalConGerencia > 0
-										? `${((totalCobrado / totalConGerencia) * 100).toFixed(1)}% de lo esperado`
-										: "—"}
+									Pendiente: {fmtQ(recuperacion.totales.pendiente)} · Excedente:{" "}
+									{fmtQ(recuperacion.totales.excedenteEnSnapshot)}
 								</p>
 							</CardContent>
 						</Card>
@@ -463,10 +474,13 @@ function TabMora({
 									{verCobrado && (
 										<>
 											<th className="px-4 py-3 text-right font-semibold">
-												Cobrado
+												Cobrado snapshot
 											</th>
 											<th className="px-4 py-3 text-right font-semibold">
-												% Cobrado
+												Fuera snapshot
+											</th>
+											<th className="px-4 py-3 text-right font-semibold">
+												Excedente
 											</th>
 											<th className="px-4 py-3 text-right font-semibold">
 												Pendiente
@@ -476,8 +490,7 @@ function TabMora({
 								</tr>
 							</thead>
 							<tbody>
-								{/* eslint-disable-next-line @typescript-eslint/no-explicit-any */}
-								{filasAsesor.map((asesor: any) => (
+								{filasAsesor.map((asesor) => (
 									<tr
 										key={asesor.asesorId}
 										className="border-t hover:bg-muted/30"
@@ -487,7 +500,7 @@ function TabMora({
 											const bucket = asesor[etapa.key];
 											return (
 												<td key={etapa.key} className="px-4 py-3 text-right">
-													{bucket?.cantidad > 0 ? (
+													{bucket && bucket.cantidad > 0 ? (
 														<div>
 															<div className="font-medium">
 																{fmtQ(bucket.sumaMora)}
@@ -504,7 +517,11 @@ function TabMora({
 										})}
 										<td className="px-4 py-3 text-right">
 											<div className="font-semibold text-red-700">
-												{fmtQ(asesor.totalEnMora?.sumaMora ?? "0")}
+												{fmtQ(
+													verCobrado
+														? (asesor.esperado ?? "0")
+														: (asesor.totalEnMora?.sumaMora ?? "0"),
+												)}
 											</div>
 											<div className="text-muted-foreground text-xs">
 												{asesor.totalEnMora?.cantidad ?? 0} créd.
@@ -531,14 +548,12 @@ function TabMora({
 										</td>
 										{verCobrado &&
 											(() => {
-												const esperado = Number.parseFloat(
-													asesor.totalEnMora?.sumaMora ?? "0",
+												const cobrado = Number(asesor.cobradoEnSnapshot ?? 0);
+												const fuera = Number(asesor.cobradoFueraSnapshot ?? 0);
+												const excedente = Number(
+													asesor.excedenteEnSnapshot ?? 0,
 												);
-												const cobrado =
-													cobradoMap.get(asesor.asesorId)?.cobrado ?? 0;
-												const pct =
-													esperado > 0 ? (cobrado / esperado) * 100 : 0;
-												const pendiente = Math.max(0, esperado - cobrado);
+												const pendiente = Number(asesor.pendiente ?? 0);
 												return (
 													<>
 														<td className="px-4 py-3 text-right font-medium text-green-700">
@@ -549,7 +564,10 @@ function TabMora({
 															)}
 														</td>
 														<td className="px-4 py-3 text-right text-muted-foreground">
-															{esperado > 0 ? `${pct.toFixed(1)}%` : "—"}
+															{fuera > 0 ? fmtQ(fuera) : "—"}
+														</td>
+														<td className="px-4 py-3 text-right text-amber-700">
+															{excedente > 0 ? fmtQ(excedente) : "—"}
 														</td>
 														<td className="px-4 py-3 text-right">
 															{fmtQ(pendiente)}
@@ -581,7 +599,10 @@ function TabMora({
 											{/* eslint-disable-next-line @typescript-eslint/no-explicit-any */}
 											<div>
 												{fmtQ(
-													(data as any).totales.totalEnMora?.sumaMora ?? "0",
+													verCobrado
+														? (recuperacion?.totales.esperado ?? "0")
+														: ((data as any).totales.totalEnMora?.sumaMora ??
+																"0"),
 												)}
 											</div>
 											{/* eslint-disable-next-line @typescript-eslint/no-explicit-any */}
@@ -591,24 +612,20 @@ function TabMora({
 										</td>
 										{verCobrado &&
 											(() => {
-												// eslint-disable-next-line @typescript-eslint/no-explicit-any
-												const esperadoTot = Number.parseFloat(
-													(data as any).totales.totalEnMora?.sumaMora ?? "0",
-												);
-												const pctTot =
-													esperadoTot > 0
-														? (totalCobrado / esperadoTot) * 100
-														: 0;
+												const totales = recuperacion?.totales;
 												return (
 													<>
 														<td className="px-4 py-3 text-right text-green-700">
-															{fmtQ(totalCobrado)}
+															{fmtQ(totales?.cobradoEnSnapshot ?? "0")}
 														</td>
 														<td className="px-4 py-3 text-right font-normal text-muted-foreground">
-															{esperadoTot > 0 ? `${pctTot.toFixed(1)}%` : "—"}
+															{fmtQ(totales?.cobradoFueraSnapshot ?? "0")}
+														</td>
+														<td className="px-4 py-3 text-right font-normal text-amber-700">
+															{fmtQ(totales?.excedenteEnSnapshot ?? "0")}
 														</td>
 														<td className="px-4 py-3 text-right">
-															{fmtQ(Math.max(0, esperadoTot - totalCobrado))}
+															{fmtQ(totales?.pendiente ?? "0")}
 														</td>
 													</>
 												);

--- a/apps/crm/apps/web/src/routes/cobros/reportes.tsx
+++ b/apps/crm/apps/web/src/routes/cobros/reportes.tsx
@@ -38,6 +38,7 @@ import { PERMISSIONS } from "@/lib/roles";
 import { orpc } from "@/utils/orpc";
 import {
 	buildMoraDisplayRows,
+	getMoraSnapshotDate,
 	type MoraBucket,
 	type MoraDisplayAsesor,
 } from "./-mora-display";
@@ -135,13 +136,8 @@ function TabMora({
 		setMesAnio(next);
 	};
 
-	// Fecha snapshot = día 6 del mes elegido, clamp a hoy (nunca futura).
 	const hoy = todayGTISO();
-	const fechaSnapshot = useMemo(() => {
-		if (modo === "hoy") return undefined;
-		const dia6 = `${mesAnio}-06`;
-		return dia6 > hoy ? hoy : dia6;
-	}, [modo, mesAnio, hoy]);
+	const fechaSnapshot = getMoraSnapshotDate(modo, mesAnio, hoy);
 
 	const { data: asesoresData } = useQuery({
 		...orpc.getAsesores.queryOptions({ input: { perPage: 100 } }),

--- a/apps/crm/apps/web/src/routes/cobros/reportes.tsx
+++ b/apps/crm/apps/web/src/routes/cobros/reportes.tsx
@@ -206,22 +206,15 @@ function TabMora({
 	});
 	const verCobrado = modo === "mes";
 	const esperadoSnapshot = Number(
-		recuperacion?.totales.esperado ?? totalConGerencia,
+		verCobrado
+			? (recuperacion?.totales.esperado ?? totalConGerencia)
+			: totalConGerencia,
 	);
 
-	const filasAsesor = useMemo<MoraDisplayAsesor[]>(() => {
-		if (!recuperacion) {
-			return porAsesor.map((asesor) => ({
-				...asesor,
-				esperado: asesor.totalEnMora.sumaMora,
-				cobradoEnSnapshot: "0",
-				cobradoFueraSnapshot: "0",
-				excedenteEnSnapshot: "0",
-				pendiente: asesor.totalEnMora.sumaMora,
-			}));
-		}
-		return buildMoraDisplayRows(porAsesor, recuperacion.porAsesor);
-	}, [porAsesor, recuperacion]);
+	const filasAsesor = useMemo<MoraDisplayAsesor[]>(
+		() => buildMoraDisplayRows(porAsesor, recuperacion?.porAsesor, verCobrado),
+		[porAsesor, recuperacion, verCobrado],
+	);
 
 	const ultimaAct = dataUpdatedAt ? fmtTime(new Date(dataUpdatedAt)) : null;
 
@@ -335,7 +328,7 @@ function TabMora({
 				</div>
 			)}
 
-			{recuperacion?.metadata.alcance === "historico" && (
+			{verCobrado && recuperacion?.metadata.alcance === "historico" && (
 				<div className="rounded-lg border border-blue-200 bg-blue-50 px-4 py-2 text-blue-800 text-sm">
 					La mora corresponde al corte histórico; el asesor mostrado es su
 					asignación actual.


### PR DESCRIPTION
# 🚀 Pase a Producción — `develop` → `main`

Release de los cambios acumulados en `develop` (25 commits, PRs #1198, #1199, #1200, #1208 y #1211). Resumen general por área:

## 💳 Cartera
- Orden cronológico de pagos por cuota y chip de "último aplicado" en el detalle
- Cobros divididos por participación vigente del inversionista
- Reporte de mora reconciliado con recuperación: límites de período cerrados y modos de recuperación respetados
- Compras de cartera pendientes excluidas del capital activo

## 📊 Reportes de Inversión
- Reconstrucción del reporte de inversión y reinversión (UI nueva + backend)
- Invariantes del detalle consolidadas (falla cerrado ante detalle inválido)
- Redondeos reconciliados: componentes CUBE, montos fraccionarios y deriva acumulada
- Posiciones activas de inversionistas retenidas y períodos de solo-compra preservados

## 👥 CRM
- Cobranza para supervisores: reportes habilitados y modales de escenarios visibles
- Totales de participación acumulada preservados y conteo separado de créditos con participación inválida
- Límite del snapshot de mora por asesor alineado con el reporte

---
ℹ️ Los hotfixes ya mergeados directo a `main` (#1209 facturas fantasma SAT, #1210 tasa en PDF de inversión, entre otros) no forman parte de este pase y quedan intactos.

🤖 Generated with [Claude Code](https://claude.com/claude-code)