### PR TITLE
feat(cartera-back): CB-027 — endpoints de convenios de pago para el CRM

### DIFF
--- a/apps/cartera-back/src/controllers/buckets/bucketActualCredito.ts
+++ b/apps/cartera-back/src/controllers/buckets/bucketActualCredito.ts
@@ -17,6 +17,16 @@ export type BucketActualCredito = {
   /** true = statusCredit en STATUS_BUCKET_FUERA (EN_CONVENIO, CANCELADO...): sin bucket POR DISEÑO. */
   fuera_funnel: boolean;
   /**
+   * CB-027: último bucket registrado en buckets_historial, SIN el filtro de
+   * fuera_funnel que sí aplica a `bucket`. Cuando el crédito sale del funnel
+   * (p.ej. EN_CONVENIO), el motor deja de escribir transiciones para él
+   * (`if (bucketNuevo === null) continue`, latefee.ts) — la última fila queda
+   * congelada en el bucket real previo a la salida. null = sin traza en
+   * historial (crédito nunca procesado por el motor).
+   */
+  bucket_previo: number | null;
+  bucket_previo_prefijo: string | null;
+  /**
    * CB-026: fecha en que el crédito ENTRÓ al bucket actual (ISO), tomada de la
    * última fila de buckets_historial. null cuando el bucket NO vino de esa fila
    * sino de un branch de fallback de bucketActualSql (estado que fuerza bucket
@@ -51,6 +61,8 @@ export async function getBucketActualPorSifco(
     color: string | null;
     estado_mora: string | null;
     fecha_entrada_bucket: string | null;
+    bucket_previo: number | null;
+    bucket_previo_prefijo: string | null;
   }>(sql`
     WITH actual AS (
       SELECT
@@ -101,11 +113,15 @@ export async function getBucketActualPorSifco(
           THEN to_json(ue.fecha AT TIME ZONE 'UTC')#>>'{}'
         ELSE NULL
       END AS fecha_entrada_bucket,
-      b.prefijo, b.nombre, b.color, b.estado_mora
+      b.prefijo, b.nombre, b.color, b.estado_mora,
+      ue.bucket_nuevo AS bucket_previo,
+      bp.prefijo AS bucket_previo_prefijo
     FROM actual a
     LEFT JOIN ultima_entrada ue ON ue.credito_id = a.credito_id
     LEFT JOIN ${SQL_CARTERA_SCHEMA}.buckets b
       ON b.numero = a.bucket AND b.activo = true AND a.fuera = false
+    LEFT JOIN ${SQL_CARTERA_SCHEMA}.buckets bp
+      ON bp.numero = ue.bucket_nuevo AND bp.activo = true
   `);
 
   const row = res.rows?.[0];
@@ -120,5 +136,7 @@ export async function getBucketActualPorSifco(
     estado_mora: row.estado_mora ?? null,
     fuera_funnel: Boolean(row.fuera),
     fecha_entrada_bucket: row.fecha_entrada_bucket ?? null,
+    bucket_previo: row.bucket_previo == null ? null : Number(row.bucket_previo),
+    bucket_previo_prefijo: row.bucket_previo_prefijo ?? null,
   };
 }

--- a/apps/cartera-back/src/controllers/credits.ts
+++ b/apps/cartera-back/src/controllers/credits.ts
@@ -502,6 +502,10 @@ export const getCreditoByNumero = async (numero_credito_sifco: string) => {
           : null,
       cuotasEnConvenio,
       pagosConvenio,
+      // CB-027: plan de pagos del convenio (convenio_cuotas) — numero_cuota,
+      // fecha_vencimiento, fecha_pago. Distinto de cuotasEnConvenio (que son
+      // cuotas_credito reales, sin el calendario propio del convenio).
+      cuotasConvenioMensuales,
     };
   } catch (error) {
     console.error("[getCreditoByNumero] Error:", error);

--- a/apps/cartera-back/src/controllers/credits.ts
+++ b/apps/cartera-back/src/controllers/credits.ts
@@ -498,14 +498,18 @@ export const getCreditoByNumero = async (numero_credito_sifco: string) => {
           ? {
               ...convenioActivo[0],
               cuotaConvenioAPagar,
+              // CB-027: plan de pagos del convenio (convenio_cuotas) —
+              // numero_cuota, fecha_vencimiento, fecha_pago. Distinto de
+              // cuotasEnConvenio (que son cuotas_credito reales, sin el
+              // calendario propio del convenio). Anidado DENTRO de
+              // convenioActivo, no top-level: carteraFront ya lee este campo
+              // así (cardInfo.tsx, registerPayment.ts spread solo
+              // result.convenioActivo) — un top-level sibling nunca le llega.
+              cuotasConvenioMensuales,
             }
           : null,
       cuotasEnConvenio,
       pagosConvenio,
-      // CB-027: plan de pagos del convenio (convenio_cuotas) — numero_cuota,
-      // fecha_vencimiento, fecha_pago. Distinto de cuotasEnConvenio (que son
-      // cuotas_credito reales, sin el calendario propio del convenio).
-      cuotasConvenioMensuales,
     };
   } catch (error) {
     console.error("[getCreditoByNumero] Error:", error);

--- a/apps/cartera-back/src/controllers/paymentAgreement-helpers.test.ts
+++ b/apps/cartera-back/src/controllers/paymentAgreement-helpers.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from "bun:test";
-import { calcularProgresoConvenio } from "./paymentAgreement";
+import { calcularProgresoConvenio } from "./paymentAgreement-helpers";
 
 describe("calcularProgresoConvenio", () => {
   it("calcula el porcentaje de avance con 2 decimales", () => {

--- a/apps/cartera-back/src/controllers/paymentAgreement-helpers.ts
+++ b/apps/cartera-back/src/controllers/paymentAgreement-helpers.ts
@@ -1,0 +1,21 @@
+// Helpers puros de convenios de pago, SIN imports de DB — separado a
+// propósito de paymentAgreement.ts para que se pueda testear sin arrastrar
+// database/index.ts (que lanza en import-time si SUPABASE_DB_URL no está
+// configurado, tronando cualquier test que solo necesite lógica pura).
+
+/**
+ * % de avance de un convenio (monto_pagado / monto_total_convenio * 100),
+ * como string con 2 decimales para consistencia con el resto de campos
+ * numéricos que cartera-back expone como string (evita drift de
+ * precisión flotante en el JSON de la API). "0.00" si el total es 0/negativo
+ * — nunca divide por cero.
+ */
+export function calcularProgresoConvenio(
+  montoTotalConvenio: string | number,
+  montoPagado: string | number
+): string {
+  const total = Number(montoTotalConvenio) || 0;
+  const pagado = Number(montoPagado) || 0;
+  if (total <= 0) return "0.00";
+  return ((pagado / total) * 100).toFixed(2);
+}

--- a/apps/cartera-back/src/controllers/paymentAgreement.test.ts
+++ b/apps/cartera-back/src/controllers/paymentAgreement.test.ts
@@ -1,0 +1,35 @@
+import { describe, expect, it } from "bun:test";
+import { calcularProgresoConvenio } from "./paymentAgreement";
+
+describe("calcularProgresoConvenio", () => {
+  it("calcula el porcentaje de avance con 2 decimales", () => {
+    expect(calcularProgresoConvenio("4318.82", "719.80")).toBe("16.67");
+  });
+
+  it("devuelve 100.00 cuando el convenio está completamente pagado", () => {
+    expect(calcularProgresoConvenio("3840.00", "3840.00")).toBe("100.00");
+  });
+
+  it("devuelve 0.00 cuando no se ha pagado nada", () => {
+    expect(calcularProgresoConvenio("5344.90", "0")).toBe("0.00");
+  });
+
+  it("devuelve 0.00 sin dividir por cero cuando el monto total es 0", () => {
+    expect(calcularProgresoConvenio("0", "100")).toBe("0.00");
+  });
+
+  it("devuelve 0.00 sin dividir por cero cuando el monto total es negativo", () => {
+    expect(calcularProgresoConvenio("-50", "10")).toBe("0.00");
+  });
+
+  it("trata monto_pagado null/undefined como 0 (columna nullable en DB)", () => {
+    // biome-ignore lint/suspicious/noExplicitAny: probando el fallback runtime ante datos nulos de la DB
+    expect(calcularProgresoConvenio("1000", null as any)).toBe("0.00");
+    // biome-ignore lint/suspicious/noExplicitAny: idem
+    expect(calcularProgresoConvenio("1000", undefined as any)).toBe("0.00");
+  });
+
+  it("acepta montos numéricos además de strings", () => {
+    expect(calcularProgresoConvenio(1000, 500)).toBe("50.00");
+  });
+});

--- a/apps/cartera-back/src/controllers/paymentAgreement.ts
+++ b/apps/cartera-back/src/controllers/paymentAgreement.ts
@@ -1,4 +1,4 @@
-import { and, eq, gte, inArray, isNull, lte, sql, sum } from "drizzle-orm";
+import { and, asc, desc, eq, gte, inArray, isNull, lte, or, sql, sum } from "drizzle-orm";
 import { SQL_CARTERA_SCHEMA } from "../database/db/schema";
 import { db } from "../database";
 import {
@@ -13,6 +13,7 @@ import {
   boletas,
   convenio_cuotas,
   moras_credito,
+  asesores,
 } from "../database/db";
 import Big from "big.js";
 import { createMora } from "./latefee";
@@ -1526,5 +1527,258 @@ export const updateConvenioStatus = async (
   } catch (error) {
     console.error("Error updating convenio status:", error);
     return { success: false, message: "Error updating convenio status", error };
+  }
+}
+
+// ─────────────────────────────────────────────────────────────────────────
+// CB-027 — Listado paginado de convenios para el CRM.
+//
+// Distinto de getPaymentAgreements: esa función no pagina, no trae
+// cliente/SIFCO/asesor y hace un N+1 (una query de pagos por convenio) — sirve
+// para el detalle de un crédito puntual, no para una tabla de "todos los
+// convenios". Acá se resuelve con UNA query con joins.
+// ─────────────────────────────────────────────────────────────────────────
+
+export interface ListPaymentAgreementsFilters {
+  estado?: "active" | "completed" | "inactive" | "all";
+  numero_credito_sifco?: string;
+  nombre_usuario?: string;
+  asesor_id?: number;
+  email_asesor?: string;
+  page?: number;
+  perPage?: number;
+}
+
+/**
+ * % de avance de un convenio (monto_pagado / monto_total_convenio * 100),
+ * como string con 2 decimales para consistencia con el resto de campos
+ * numéricos que cartera-back expone como string (evita drift de
+ * precisión flotante en el JSON de la API). "0.00" si el total es 0/negativo
+ * — nunca divide por cero.
+ */
+export function calcularProgresoConvenio(
+  montoTotalConvenio: string | number,
+  montoPagado: string | number
+): string {
+  const total = Number(montoTotalConvenio) || 0;
+  const pagado = Number(montoPagado) || 0;
+  if (total <= 0) return "0.00";
+  return ((pagado / total) * 100).toFixed(2);
+}
+
+export async function listPaymentAgreements(filters: ListPaymentAgreementsFilters = {}) {
+  try {
+    const {
+      estado = "active",
+      numero_credito_sifco,
+      nombre_usuario,
+      asesor_id,
+      email_asesor,
+      page = 1,
+      perPage = 25,
+    } = filters;
+
+    const conditions = [];
+
+    if (estado === "active") {
+      conditions.push(eq(convenios_pago.activo, true));
+      conditions.push(eq(convenios_pago.completado, false));
+    } else if (estado === "completed") {
+      conditions.push(eq(convenios_pago.completado, true));
+    } else if (estado === "inactive") {
+      conditions.push(eq(convenios_pago.activo, false));
+    }
+
+    // Búsqueda libre (SIFCO o cliente): el CRM manda el mismo texto en ambos
+    // campos para "buscar por SIFCO o cliente" — combinarlos con AND (como
+    // antes) exigía que un crédito matcheara AMBOS a la vez, imposible al
+    // buscar por nombre (el SIFCO nunca contiene el nombre del cliente), lo
+    // que rompía la búsqueda por cliente en silencio. Con OR, cualquiera de
+    // los dos que coincida es suficiente — semántica correcta tanto si el
+    // caller manda uno solo como si manda los dos con el mismo texto.
+    if (numero_credito_sifco && nombre_usuario) {
+      conditions.push(
+        or(
+          sql`${creditos.numero_credito_sifco} ILIKE ${`%${numero_credito_sifco}%`}`,
+          sql`${usuarios.nombre} ILIKE ${`%${nombre_usuario}%`}`
+        )
+      );
+    } else if (numero_credito_sifco) {
+      conditions.push(
+        sql`${creditos.numero_credito_sifco} ILIKE ${`%${numero_credito_sifco}%`}`
+      );
+    } else if (nombre_usuario) {
+      conditions.push(sql`${usuarios.nombre} ILIKE ${`%${nombre_usuario}%`}`);
+    }
+    if (asesor_id !== undefined) {
+      conditions.push(eq(creditos.asesor_id, asesor_id));
+    }
+    if (email_asesor) {
+      conditions.push(
+        sql`${platform_users.email} ILIKE ${`%${email_asesor}%`}`
+      );
+    }
+
+    const whereClause = conditions.length > 0 ? and(...conditions) : undefined;
+
+    const baseQuery = db
+      .select({
+        convenio_id: convenios_pago.convenio_id,
+        credito_id: convenios_pago.credito_id,
+        numero_credito_sifco: creditos.numero_credito_sifco,
+        cliente_nombre: usuarios.nombre,
+        asesor_id: creditos.asesor_id,
+        asesor_nombre: asesores.nombre,
+        asesor_email: asesores.emailCashIn,
+        monto_total_convenio: convenios_pago.monto_total_convenio,
+        cuota_mensual: convenios_pago.cuota_mensual,
+        numero_meses: convenios_pago.numero_meses,
+        monto_pagado: convenios_pago.monto_pagado,
+        monto_pendiente: convenios_pago.monto_pendiente,
+        pagos_realizados: convenios_pago.pagos_realizados,
+        pagos_pendientes: convenios_pago.pagos_pendientes,
+        fecha_convenio: convenios_pago.fecha_convenio,
+        activo: convenios_pago.activo,
+        completado: convenios_pago.completado,
+        motivo: convenios_pago.motivo,
+      })
+      .from(convenios_pago)
+      .innerJoin(creditos, eq(creditos.credito_id, convenios_pago.credito_id))
+      .innerJoin(usuarios, eq(usuarios.usuario_id, creditos.usuario_id))
+      .leftJoin(asesores, eq(asesores.asesor_id, creditos.asesor_id))
+      .leftJoin(
+        platform_users,
+        eq(platform_users.asesor_id, asesores.asesor_id)
+      );
+
+    const rows = whereClause
+      ? await baseQuery
+          .where(whereClause)
+          .orderBy(desc(convenios_pago.fecha_convenio))
+          .limit(perPage)
+          .offset((page - 1) * perPage)
+      : await baseQuery
+          .orderBy(desc(convenios_pago.fecha_convenio))
+          .limit(perPage)
+          .offset((page - 1) * perPage);
+
+    const countQuery = db
+      .select({ count: sql<number>`count(*)::int` })
+      .from(convenios_pago)
+      .innerJoin(creditos, eq(creditos.credito_id, convenios_pago.credito_id))
+      .innerJoin(usuarios, eq(usuarios.usuario_id, creditos.usuario_id))
+      .leftJoin(asesores, eq(asesores.asesor_id, creditos.asesor_id))
+      .leftJoin(
+        platform_users,
+        eq(platform_users.asesor_id, asesores.asesor_id)
+      );
+
+    const [{ count: totalCount }] = whereClause
+      ? await countQuery.where(whereClause)
+      : await countQuery;
+
+    // CB-027: último bucket registrado en buckets_historial ANTES de que el
+    // crédito saliera del funnel por el convenio. Misma fuente y mismo
+    // patrón (CTE + DISTINCT ON) que bucketActualCredito.ts — única query
+    // real de "último bucket de un crédito", resuelta UNA vez para todos los
+    // créditos de la página (no una subquery correlacionada por fila). El
+    // motor deja de escribir transiciones para créditos EN_CONVENIO, así que
+    // esta fila queda congelada en el bucket real previo a la salida.
+    // null = sin traza en historial.
+    const creditoIds = [...new Set(rows.map((r) => r.credito_id))];
+    const bucketPrevioPorCredito = new Map<
+      number,
+      { bucket_previo: number | null; bucket_previo_prefijo: string | null }
+    >();
+    if (creditoIds.length > 0) {
+      const bucketRows = await db.execute<{
+        credito_id: number;
+        // NOT NULL en el schema (buckets_historial.bucket_nuevo), pero se
+        // tipa nullable acá porque viene de una columna de SELECT — mismo
+        // criterio defensivo que bucketActualCredito.ts:139 (no confiar en
+        // el constraint vigente frente a datos legacy o migraciones futuras;
+        // Number(null) da 0, que es un bucket B0 real, no "sin dato").
+        bucket_previo: number | null;
+        bucket_previo_prefijo: string | null;
+      }>(sql`
+        WITH ultima_entrada AS (
+          SELECT DISTINCT ON (h.credito_id)
+            h.credito_id, h.bucket_nuevo, h.fecha, h.historial_id
+          FROM ${SQL_CARTERA_SCHEMA}.buckets_historial h
+          WHERE h.credito_id IN (${sql.join(creditoIds, sql`, `)})
+          ORDER BY h.credito_id, h.fecha DESC, h.historial_id DESC
+        )
+        SELECT
+          ue.credito_id,
+          ue.bucket_nuevo AS bucket_previo,
+          b.prefijo AS bucket_previo_prefijo
+        FROM ultima_entrada ue
+        LEFT JOIN ${SQL_CARTERA_SCHEMA}.buckets b
+          ON b.numero = ue.bucket_nuevo AND b.activo = true
+      `);
+      for (const row of bucketRows.rows) {
+        bucketPrevioPorCredito.set(Number(row.credito_id), {
+          bucket_previo:
+            row.bucket_previo == null ? null : Number(row.bucket_previo),
+          bucket_previo_prefijo: row.bucket_previo_prefijo ?? null,
+        });
+      }
+    }
+
+    const data = rows.map((r) => {
+      const progreso = calcularProgresoConvenio(
+        r.monto_total_convenio,
+        r.monto_pagado
+      );
+      const bucketPrevio = bucketPrevioPorCredito.get(r.credito_id);
+      return {
+        ...r,
+        progreso,
+        bucket_previo: bucketPrevio?.bucket_previo ?? null,
+        bucket_previo_prefijo: bucketPrevio?.bucket_previo_prefijo ?? null,
+      };
+    });
+
+    return {
+      success: true,
+      data,
+      page,
+      perPage,
+      totalCount,
+      totalPages: Math.max(1, Math.ceil(totalCount / perPage)),
+    };
+  } catch (error) {
+    console.error("Error listing payment agreements:", error);
+    return {
+      success: false,
+      data: [],
+      page: filters.page ?? 1,
+      perPage: filters.perPage ?? 25,
+      totalCount: 0,
+      totalPages: 1,
+      message: error instanceof Error ? error.message : "Unknown error occurred",
+    };
+  }
+}
+
+// Cuotas del plan de pago de un convenio (tabla convenio_cuotas). No trae
+// monto: cada cuota vale `convenios_pago.cuota_mensual` (la tabla no tiene
+// columna de monto propia — ver schema.ts).
+export async function getConvenioCuotas(convenio_id: number) {
+  try {
+    const cuotas = await db
+      .select()
+      .from(convenio_cuotas)
+      .where(eq(convenio_cuotas.convenio_id, convenio_id))
+      .orderBy(asc(convenio_cuotas.numero_cuota));
+
+    return { success: true, data: cuotas };
+  } catch (error) {
+    console.error("Error getting convenio cuotas:", error);
+    return {
+      success: false,
+      data: [],
+      message: error instanceof Error ? error.message : "Unknown error occurred",
+    };
   }
 }

--- a/apps/cartera-back/src/controllers/paymentAgreement.ts
+++ b/apps/cartera-back/src/controllers/paymentAgreement.ts
@@ -18,6 +18,7 @@ import {
 import Big from "big.js";
 import { createMora } from "./latefee";
 import { getPagosDelMesActual } from "./payments";
+import { calcularProgresoConvenio } from "./paymentAgreement-helpers";
 import { creditRouter } from "../routers";
 
 interface CreatePaymentAgreementInput {
@@ -1549,23 +1550,6 @@ export interface ListPaymentAgreementsFilters {
   perPage?: number;
 }
 
-/**
- * % de avance de un convenio (monto_pagado / monto_total_convenio * 100),
- * como string con 2 decimales para consistencia con el resto de campos
- * numéricos que cartera-back expone como string (evita drift de
- * precisión flotante en el JSON de la API). "0.00" si el total es 0/negativo
- * — nunca divide por cero.
- */
-export function calcularProgresoConvenio(
-  montoTotalConvenio: string | number,
-  montoPagado: string | number
-): string {
-  const total = Number(montoTotalConvenio) || 0;
-  const pagado = Number(montoPagado) || 0;
-  if (total <= 0) return "0.00";
-  return ((pagado / total) * 100).toFixed(2);
-}
-
 export async function listPaymentAgreements(filters: ListPaymentAgreementsFilters = {}) {
   try {
     const {
@@ -1614,8 +1598,15 @@ export async function listPaymentAgreements(filters: ListPaymentAgreementsFilter
       conditions.push(eq(creditos.asesor_id, asesor_id));
     }
     if (email_asesor) {
+      // asesores.emailCashIn, NO platform_users.email: poolPorAsesor.ts ya
+      // documenta que el email de platform_users/advisor está desactualizado
+      // para varios asesores, mientras email_cash_in es el que coincide con
+      // el email real del usuario en el CRM — y es el mismo campo que este
+      // endpoint ya devuelve como `asesor_email`, así que filtrar por otro
+      // campo distinto al mostrado podía ocultar convenios cuyo asesor_email
+      // visible sí matcheaba.
       conditions.push(
-        sql`${platform_users.email} ILIKE ${`%${email_asesor}%`}`
+        sql`${asesores.emailCashIn} ILIKE ${`%${email_asesor}%`}`
       );
     }
 
@@ -1645,11 +1636,7 @@ export async function listPaymentAgreements(filters: ListPaymentAgreementsFilter
       .from(convenios_pago)
       .innerJoin(creditos, eq(creditos.credito_id, convenios_pago.credito_id))
       .innerJoin(usuarios, eq(usuarios.usuario_id, creditos.usuario_id))
-      .leftJoin(asesores, eq(asesores.asesor_id, creditos.asesor_id))
-      .leftJoin(
-        platform_users,
-        eq(platform_users.asesor_id, asesores.asesor_id)
-      );
+      .leftJoin(asesores, eq(asesores.asesor_id, creditos.asesor_id));
 
     const rows = whereClause
       ? await baseQuery
@@ -1667,11 +1654,7 @@ export async function listPaymentAgreements(filters: ListPaymentAgreementsFilter
       .from(convenios_pago)
       .innerJoin(creditos, eq(creditos.credito_id, convenios_pago.credito_id))
       .innerJoin(usuarios, eq(usuarios.usuario_id, creditos.usuario_id))
-      .leftJoin(asesores, eq(asesores.asesor_id, creditos.asesor_id))
-      .leftJoin(
-        platform_users,
-        eq(platform_users.asesor_id, asesores.asesor_id)
-      );
+      .leftJoin(asesores, eq(asesores.asesor_id, creditos.asesor_id));
 
     const [{ count: totalCount }] = whereClause
       ? await countQuery.where(whereClause)

--- a/apps/cartera-back/src/routers/paymentAgree.ts
+++ b/apps/cartera-back/src/routers/paymentAgree.ts
@@ -1,6 +1,6 @@
 // src/routes/paymentAgreements.routes.ts
 import { Elysia, t } from "elysia";
-import { createPaymentAgreement, getPaymentAgreements, updateConvenioStatus } from "../controllers/paymentAgreement";
+import { createPaymentAgreement, getPaymentAgreements, updateConvenioStatus, listPaymentAgreements, getConvenioCuotas } from "../controllers/paymentAgreement";
 import { authMiddleware } from "./midleware";
  
 
@@ -162,6 +162,117 @@ export const paymentAgreementsRouter = new Elysia({ prefix: "/payment-agreements
       detail: {
         summary: "Toggle payment agreement status",
         description: "Activate or deactivate a payment agreement",
+        tags: ["Payment Agreements"],
+      },
+    }
+  )
+
+  // CB-027 — LISTADO paginado con joins (cliente, SIFCO, asesor). Distinto de
+  // GET "/": esa no pagina y no trae estos datos, pensada para el detalle de
+  // un crédito puntual, no para una tabla de todos los convenios.
+  .get(
+    "/listado",
+    async ({ query, set }) => {
+      try {
+        const result = await listPaymentAgreements({
+          estado: query.estado,
+          numero_credito_sifco: query.numero_credito_sifco,
+          nombre_usuario: query.nombre_usuario,
+          asesor_id: query.asesor_id,
+          email_asesor: query.email_asesor,
+          page: query.page,
+          perPage: query.perPage,
+        });
+
+        if (!result.success) {
+          // listPaymentAgreements solo llega a success:false vía su catch
+          // genérico (fallo real de DB/query) — no valida input de negocio
+          // internamente, y query ya viene validado por el schema de abajo
+          // (t.Numeric). Un 400 acá le diría al caller "corregí tu request"
+          // cuando la causa real es un fallo de servidor.
+          set.status = 500;
+          return result;
+        }
+
+        set.status = 200;
+        return result;
+      } catch (error) {
+        set.status = 500;
+        return {
+          success: false,
+          message: "Internal server error",
+          error: error instanceof Error ? error.message : "Unknown error",
+        };
+      }
+    },
+    {
+      query: t.Object({
+        estado: t.Optional(
+          t.Union([
+            t.Literal("active"),
+            t.Literal("completed"),
+            t.Literal("inactive"),
+            t.Literal("all"),
+          ])
+        ),
+        numero_credito_sifco: t.Optional(t.String()),
+        nombre_usuario: t.Optional(t.String()),
+        // t.Numeric() valida/coerciona vía TypeBox: un valor no numérico (o
+        // NaN implícito) falla la validación del schema ANTES del handler,
+        // en vez de llegar como NaN a OFFSET/LIMIT (Postgres lo ignora en
+        // silencio) o negativo (Postgres lo rechaza con error crudo).
+        asesor_id: t.Optional(t.Numeric({ minimum: 1 })),
+        email_asesor: t.Optional(t.String()),
+        page: t.Optional(t.Numeric({ minimum: 1 })),
+        perPage: t.Optional(t.Numeric({ minimum: 1, maximum: 100 })),
+      }),
+      detail: {
+        summary: "List payment agreements (paginated, with client/advisor joins)",
+        description: "CB-027: paginated listing for the CRM convenios table",
+        tags: ["Payment Agreements"],
+      },
+    }
+  )
+
+  // CB-027 — plan de pagos (convenio_cuotas) de un convenio puntual.
+  .get(
+    "/:convenio_id/cuotas",
+    async ({ params, set }) => {
+      try {
+        const convenioId = parseInt(params.convenio_id);
+        if (!Number.isInteger(convenioId) || convenioId < 1) {
+          set.status = 400;
+          return { success: false, message: "convenio_id inválido" };
+        }
+
+        const result = await getConvenioCuotas(convenioId);
+
+        if (!result.success) {
+          // Mismo criterio que /listado: getConvenioCuotas solo llega a
+          // success:false vía su catch genérico (fallo real de DB), no por
+          // input inválido — eso ya se rechazó arriba con 400.
+          set.status = 500;
+          return result;
+        }
+
+        set.status = 200;
+        return result;
+      } catch (error) {
+        set.status = 500;
+        return {
+          success: false,
+          message: "Internal server error",
+          error: error instanceof Error ? error.message : "Unknown error",
+        };
+      }
+    },
+    {
+      params: t.Object({
+        convenio_id: t.String(),
+      }),
+      detail: {
+        summary: "Get convenio cuotas",
+        description: "CB-027: payment plan installments for a payment agreement",
         tags: ["Payment Agreements"],
       },
     }


### PR DESCRIPTION
## Summary
- `GET /payment-agreements/listado`: listado paginado de convenios con joins a cliente/SIFCO/asesor (distinto de `GET /` existente, que no pagina y no trae esos datos — pensado para el detalle de un crédito puntual, no para una tabla).
- `GET /payment-agreements/:convenio_id/cuotas`: plan de pagos de un convenio.
- `bucket_previo` / `bucket_previo_prefijo` en `GET /buckets/credito/:sifco` y en el listado: último bucket registrado en `buckets_historial` ANTES de que el crédito saliera del funnel por el convenio. El motor deja de escribir transiciones para créditos `EN_CONVENIO`, así que la última fila queda congelada en el bucket real previo a la salida — necesario porque con convenio activo `bucket` es siempre `null` (fuera del funnel).

## Notas de la revisión
- El filtro de búsqueda (SIFCO/cliente) combina con `OR`, no `AND` — combinarlos con `AND` exigía que un crédito matcheara ambos campos a la vez, imposible al buscar solo por nombre.
- El join de `bucket_previo` a `buckets` respeta `activo = true`, igual que el join hermano de bucket actual en el mismo archivo.
- `page`/`perPage`/`asesor_id` validados con `t.Numeric()` (TypeBox) en vez de `parseInt` manual — rechaza NaN/negativos antes de tocar SQL.
- Errores internos devuelven 500, no 400 (400 quedaba reservado para input inválido, pero el único camino a `success:false` en estas funciones es un fallo real de DB).

## Test plan
- [x] `bunx tsc --noEmit` limpio
- [x] `bun test` — 231 pass, mismos 39 fails preexistentes (no relacionados)
- [x] Verificado contra DB dev: búsqueda por nombre de cliente, filtro por email de asesor, bucket_previo con bucket desactivado temporalmente (revertido)
- [ ] CRM (server + web) que consume estos endpoints va en PRs separados, después de que este se mergee

🤖 Generated with [Claude Code](https://claude.com/claude-code)