### PR TITLE
feat(crm-server): CB-027 — endpoints de convenios de pago

### DIFF
--- a/apps/crm/apps/server/src/routers/cobros.ts
+++ b/apps/crm/apps/server/src/routers/cobros.ts
@@ -1520,6 +1520,11 @@ export const cobrosRouter = {
 			return contactos;
 		}),
 
+	// LEGACY (tabla CRM `convenios_pago`, no cartera-back): nunca se llama desde
+	// la web (0 usos en apps/web) — el convenio real de negocio vive en
+	// cartera-back y llega vía getDetallesCreditoCarteraBack.convenioActivo y
+	// getConveniosListado (CB-027). Se deja intacto por compatibilidad, no
+	// escribir código nuevo contra esta tabla.
 	// Crear convenio de pago
 	createConvenioPago: cobrosProcedure
 		.input(
@@ -1612,6 +1617,104 @@ export const cobrosRouter = {
 				.orderBy(desc(conveniosPago.createdAt));
 
 			return convenios;
+		}),
+
+	// CB-027: listado paginado de convenios REALES de cartera-back (cliente,
+	// SIFCO, asesor, progreso) para la página /cobros/convenios. Mismo patrón
+	// de "asesor forzado" que getColaDia/getAgendaDia — el rol cobros solo ve
+	// sus propios convenios (match por email contra cartera-back.getAdvisors).
+	getConveniosListado: cobrosProcedure
+		.input(
+			z.object({
+				estado: z.enum(["active", "completed", "inactive", "all"]).optional(),
+				// Búsqueda libre: matchea SIFCO O nombre de cliente (cartera-back
+				// combina ambos con OR — mandar el mismo texto a los dos campos NO
+				// exige que ambos matcheen a la vez, que era el bug original).
+				busqueda: z.string().optional(),
+				asesorId: z.number().int().positive().optional(),
+				page: z.number().int().positive().optional(),
+				perPage: z.number().int().min(1).max(100).optional(),
+			}),
+		)
+		.handler(async ({ input, context }) => {
+			if (!isCarteraBackEnabled()) {
+				return {
+					success: true,
+					sinAsesor: false,
+					asesorForzado: null,
+					items: [],
+					total: 0,
+					page: 1,
+					perPage: input.perPage ?? 25,
+					totalPages: 1,
+				};
+			}
+
+			const puedeVerTodos = PERMISSIONS.canAssignCobros(context.userRole ?? "");
+			const page = input.page ?? 1;
+			const perPage = input.perPage ?? 25;
+
+			let asesorForzado: { asesorId: number; nombre: string } | null = null;
+			let asesorIdFiltro: number | undefined = input.asesorId;
+
+			if (!puedeVerTodos) {
+				const email = context.session?.user?.email?.trim().toLowerCase();
+				const advisors = await carteraBackClient.getAdvisors({
+					page: 1,
+					perPage: 500,
+				});
+				const propio = (advisors.data ?? []).find(
+					(a) => a.email?.trim().toLowerCase() === email,
+				);
+				if (!propio) {
+					return {
+						success: true,
+						sinAsesor: true,
+						asesorForzado: null,
+						items: [],
+						total: 0,
+						page,
+						perPage,
+						totalPages: 1,
+					};
+				}
+				asesorForzado = { asesorId: propio.asesor_id, nombre: propio.nombre };
+				asesorIdFiltro = propio.asesor_id;
+			}
+
+			try {
+				const resultado = await carteraBackClient.getConveniosListado({
+					estado: input.estado,
+					numeroCreditoSifco: input.busqueda,
+					nombreUsuario: input.busqueda,
+					asesorId: asesorIdFiltro,
+					page,
+					perPage,
+				});
+
+				return {
+					success: true,
+					sinAsesor: false,
+					asesorForzado,
+					items: resultado.data,
+					total: resultado.total,
+					page: resultado.page,
+					perPage: resultado.perPage,
+					totalPages: resultado.totalPages,
+				};
+			} catch (error) {
+				// No devolver success:false disfrazado de 200: React Query solo
+				// marca isError ante un fallo real de transporte/oRPC, así que un
+				// {success:false, items:[]} silencioso caía en el mismo branch que
+				// "0 convenios" en la UI — un outage de cartera-back se veía
+				// idéntico a "no hay convenios". Se propaga como error real (mismo
+				// criterio que el resto de procedures de este router, p.ej.
+				// getColaDia, que no atrapan su propia excepción de cartera-back).
+				console.error("[getConveniosListado] Error:", error);
+				throw new ORPCError("INTERNAL_SERVER_ERROR", {
+					message: "No se pudieron cargar los convenios de pago",
+				});
+			}
 		}),
 
 	// Asignar responsable de cobros
@@ -3254,7 +3357,8 @@ export const cobrosRouter = {
 				const montoEnMora = Number(creditoCompleto.moraActual ?? 0);
 
 				const tieneMoraActiva = creditoCompleto.mora != null;
-				const tieneConvenioActivo = creditoCompleto.convenioActivo != null;
+				const convenioActivoData = creditoCompleto.convenioActivo ?? null;
+				const tieneConvenioActivo = convenioActivoData != null;
 				let estadoMora: string | null = "al_dia";
 				if (tieneConvenioActivo) {
 					estadoMora = "en_convenio";
@@ -3295,11 +3399,38 @@ export const cobrosRouter = {
 					montoEnMora: montoEnMora.toFixed(2),
 					diasMoraMaximo: diasMora,
 					cuotasVencidas: cuotasAtrasadas,
-					cuotaConvenio: tieneConvenioActivo
-						? Number(
-								creditoCompleto.convenioActivo!.cuota_mensual ?? 0,
-							).toFixed(2)
+					cuotaConvenio: convenioActivoData
+						? Number(convenioActivoData.cuota_mensual ?? 0).toFixed(2)
 						: null,
+					// CB-027: convenio completo (para la card "Convenios de Pago") + su
+					// plan de pagos. null cuando no hay convenio activo.
+					convenioActivo: convenioActivoData
+						? {
+								convenioId: convenioActivoData.convenio_id,
+								montoTotalConvenio: convenioActivoData.monto_total_convenio,
+								cuotaMensual: convenioActivoData.cuota_mensual,
+								numeroMeses: convenioActivoData.numero_meses,
+								montoPagado: convenioActivoData.monto_pagado ?? "0",
+								montoPendiente: convenioActivoData.monto_pendiente ?? "0",
+								pagosRealizados: convenioActivoData.pagos_realizados ?? 0,
+								pagosPendientes: convenioActivoData.pagos_pendientes ?? 0,
+								activo: convenioActivoData.activo,
+								completado: convenioActivoData.completado,
+								fechaConvenio: convenioActivoData.fecha_convenio,
+								motivo: convenioActivoData.motivo ?? null,
+								observaciones: convenioActivoData.observaciones ?? null,
+							}
+						: null,
+					// CB-027 review fix: cartera-back anida cuotasConvenioMensuales
+					// DENTRO de convenioActivo (no top-level) — carteraFront ya
+					// esperaba ese shape (cardInfo.tsx, registerPayment.ts).
+					convenioCuotas: (
+						convenioActivoData?.cuotasConvenioMensuales ?? []
+					).map((c) => ({
+						numeroCuota: c.numero_cuota,
+						fechaVencimiento: c.fecha_vencimiento,
+						fechaPago: c.fecha_pago,
+					})),
 
 					// Datos de contacto (del caso de cobros primero, fallback al lead)
 					telefonoPrincipal:
@@ -5718,7 +5849,10 @@ export const cobrosRouter = {
 					if (!email) continue;
 					const userId = emailToUserId.get(email);
 					if (!userId) continue;
-					poolPorAsesor.set(userId, [...a.buckets].sort((x, y) => x - y));
+					poolPorAsesor.set(
+						userId,
+						[...a.buckets].sort((x, y) => x - y),
+					);
 				}
 			} catch (error) {
 				console.error("[getCierreDiarioPorRango] Pool de buckets:", error);

--- a/apps/crm/apps/server/src/routers/cobros.ts
+++ b/apps/crm/apps/server/src/routers/cobros.ts
@@ -1659,12 +1659,14 @@ export const cobrosRouter = {
 
 			if (!puedeVerTodos) {
 				const email = context.session?.user?.email?.trim().toLowerCase();
-				const advisors = await carteraBackClient.getAdvisors({
-					page: 1,
-					perPage: 500,
-				});
-				const propio = (advisors.data ?? []).find(
-					(a) => a.email?.trim().toLowerCase() === email,
+				// email_cash_in, NO getAdvisors()/platform_users.email: ese campo
+				// está desactualizado para varios asesores (Diego Gomez, Samuel
+				// Gamboa) y no coincide con el login real del CRM — mismo patrón ya
+				// corregido en getCierreDiarioPorRango (ver ese comentario, arriba
+				// en este archivo).
+				const asesoresConBuckets = await carteraBackClient.getPoolPorAsesor();
+				const propio = asesoresConBuckets.find(
+					(a) => a.email_cash_in?.trim().toLowerCase() === email,
 				);
 				if (!propio) {
 					return {

--- a/apps/crm/apps/server/src/routers/index.ts
+++ b/apps/crm/apps/server/src/routers/index.ts
@@ -139,6 +139,7 @@ export const cobrosAppRouter = {
 	getHistorialContactos: cobrosRouter.getHistorialContactos,
 	createConvenioPago: cobrosRouter.createConvenioPago,
 	getConveniosPago: cobrosRouter.getConveniosPago,
+	getConveniosListado: cobrosRouter.getConveniosListado,
 	asignarResponsableCobros: cobrosRouter.asignarResponsableCobros,
 	getUsuariosCobros: cobrosRouter.getUsuariosCobros,
 	getBucketsCatalogo: cobrosRouter.getBucketsCatalogo,

--- a/apps/crm/apps/server/src/services/cartera-back-client.ts
+++ b/apps/crm/apps/server/src/services/cartera-back-client.ts
@@ -20,6 +20,8 @@ import type {
 	CarteraBucketsHistorialResponse,
 	CarteraColaDiaResponse,
 	CarteraComportamientoPagoResponse,
+	CarteraConvenioCuota,
+	CarteraConvenioListado,
 	CarteraCredito,
 	CarteraCuotasProximasResponse,
 	CarteraInversionista,
@@ -42,6 +44,7 @@ import type {
 	GetBucketsHistorialParams,
 	GetCargaPorAsesorBucketParams,
 	GetColaDiaSLAParams,
+	GetConveniosListadoParams,
 	GetCreditosPorBucketParams,
 	GetInvestorReportParams,
 	GetInvestorsParams,
@@ -1141,6 +1144,52 @@ export class CarteraBackClient {
 			total: response.totalCount,
 			totalPages: response.totalPages,
 		};
+	}
+
+	// CB-027: listado paginado de convenios de pago (con cliente/SIFCO/asesor
+	// vía joins en cartera-back). Fuente de la tabla de la página
+	// /cobros/convenios del CRM. Sin cache: el progreso cambia con cada pago.
+	async getConveniosListado(
+		params: GetConveniosListadoParams = {},
+	): Promise<PaginatedResponse<CarteraConvenioListado>> {
+		const queryParams = new URLSearchParams({
+			...(params.estado && { estado: params.estado }),
+			...(params.numeroCreditoSifco && {
+				numero_credito_sifco: params.numeroCreditoSifco,
+			}),
+			...(params.nombreUsuario && { nombre_usuario: params.nombreUsuario }),
+			...(params.asesorId !== undefined && {
+				asesor_id: String(params.asesorId),
+			}),
+			...(params.emailAsesor && { email_asesor: params.emailAsesor }),
+			...(params.page && { page: params.page.toString() }),
+			...(params.perPage && { perPage: params.perPage.toString() }),
+		});
+		const response = await this.request<{
+			success: boolean;
+			data: CarteraConvenioListado[];
+			page: number;
+			perPage: number;
+			totalCount: number;
+			totalPages: number;
+		}>(`/payment-agreements/listado?${queryParams}`, { method: "GET" });
+		return {
+			data: response.data ?? [],
+			page: response.page,
+			perPage: response.perPage,
+			total: response.totalCount,
+			totalPages: response.totalPages,
+		};
+	}
+
+	// CB-027: plan de pagos (convenio_cuotas) de un convenio puntual — usado
+	// como fallback si `cuotasConvenioMensuales` no viene embebido en /credito.
+	async getConvenioCuotas(convenioId: number): Promise<CarteraConvenioCuota[]> {
+		const response = await this.request<{
+			success: boolean;
+			data: CarteraConvenioCuota[];
+		}>(`/payment-agreements/${convenioId}/cuotas`, { method: "GET" });
+		return response.data ?? [];
 	}
 
 	// CB-020: universo SLA de la Cola del Día — créditos del POOL de buckets

--- a/apps/crm/apps/server/src/types/cartera-back.ts
+++ b/apps/crm/apps/server/src/types/cartera-back.ts
@@ -206,6 +206,17 @@ export interface GetCreditosPorBucketParams {
 	asesor_id?: number;
 }
 
+/** CB-027: filtros de GET /payment-agreements/listado. */
+export interface GetConveniosListadoParams {
+	estado?: "active" | "completed" | "inactive" | "all";
+	numeroCreditoSifco?: string;
+	nombreUsuario?: string;
+	asesorId?: number;
+	emailAsesor?: string;
+	page?: number;
+	perPage?: number;
+}
+
 /** CB-018: filtros de GET /buckets/carga (carga por asesor y bucket). */
 export interface GetCargaPorAsesorBucketParams {
 	bucket?: number;
@@ -511,6 +522,55 @@ export interface CarteraConvenio {
 	observaciones?: string | null;
 	created_by?: number | null;
 	cuotaConvenioAPagar?: string | null;
+	/**
+	 * CB-027: plan de pagos del convenio (numero_cuota/fecha_vencimiento/
+	 * fecha_pago). Anidado DENTRO de convenioActivo, no top-level en
+	 * CreditoDirectoResponse — carteraFront ya espera este campo así
+	 * (cardInfo.tsx, registerPayment.ts spread solo result.convenioActivo).
+	 */
+	cuotasConvenioMensuales?: CarteraConvenioCuota[];
+}
+
+/** Fila de `convenio_cuotas` — plan de pagos del convenio (CB-027). */
+export interface CarteraConvenioCuota {
+	cuota_convenio_id: number;
+	convenio_id: number;
+	numero_cuota: number;
+	fecha_vencimiento: string;
+	/** null = pendiente. */
+	fecha_pago: string | null;
+	created_at?: string | null;
+}
+
+/** Fila de `GET /payment-agreements/listado` (CB-027). */
+export interface CarteraConvenioListado {
+	convenio_id: number;
+	credito_id: number;
+	numero_credito_sifco: string;
+	cliente_nombre: string;
+	asesor_id: number | null;
+	asesor_nombre: string | null;
+	asesor_email: string | null;
+	monto_total_convenio: string;
+	cuota_mensual: string;
+	numero_meses: number;
+	monto_pagado: string;
+	monto_pendiente: string;
+	pagos_realizados: number;
+	pagos_pendientes: number;
+	fecha_convenio: string;
+	activo: boolean;
+	completado: boolean;
+	motivo: string | null;
+	/** monto_pagado / monto_total_convenio * 100, calculado en cartera-back. */
+	progreso: string;
+	/**
+	 * Último bucket registrado en buckets_historial ANTES de que el crédito
+	 * saliera del funnel por el convenio (misma fuente que `bucket_previo` de
+	 * GET /buckets/credito/:sifco). null = sin traza en historial.
+	 */
+	bucket_previo: number | null;
+	bucket_previo_prefijo: string | null;
 }
 
 export interface CreditoDirectoResponse {
@@ -969,6 +1029,14 @@ export interface CarteraBucketActualCredito {
 	 * acá y una fecha inventada produciría un falso "gestión agotada".
 	 */
 	fecha_entrada_bucket: string | null;
+	/**
+	 * CB-027: último bucket registrado en buckets_historial, SIN el filtro de
+	 * fuera_funnel. Con convenio activo el motor deja de escribir transiciones
+	 * (sale del funnel) — esta fila queda congelada en el bucket real previo a
+	 * la salida. null = sin traza en historial.
+	 */
+	bucket_previo: number | null;
+	bucket_previo_prefijo: string | null;
 }
 
 // ============================================================================


### PR DESCRIPTION
## Summary
Consume los endpoints de cartera-back del PR #1213 (ya mergeado a COBROS-02):

- `getConveniosListado`: procedure oRPC para la página `/cobros/convenios`. Mismo patrón de "asesor forzado por email" que `getColaDia`/`getAgendaDia` — el rol `cobros` solo ve sus propios convenios. Errores reales de cartera-back se propagan como `ORPCError` en vez de disfrazarse de `success:false` — un outage debe verse como error en el frontend, no como "0 convenios".
- `getDetallesCreditoCarteraBack`: ahora devuelve `convenioActivo` completo (monto, progreso, plan de cuotas) en vez de solo `cuotaConvenio`. `cuotasConvenioMensuales` se lee anidado dentro de `convenioActivo` — así es como cartera-back lo expone (`carteraFront` ya esperaba ese shape en `cardInfo.tsx`/`registerPayment.ts`).
- `getBucketActualCredito`: hereda `bucket_previo`/`bucket_previo_prefijo` del cliente sin cambios de código propio.

## Test plan
- [x] `bun run check-types` limpio
- [x] `bun test` — 483 pass, mismos 17 fails preexistentes (no relacionados)
- [x] Verificado en vivo contra dev que `convenioActivoData?.cuotasConvenioMensuales` trae el shape real que cartera-back expone (anidado, no top-level)
- [ ] CRM web (página `/cobros/convenios` + card en detalle) va en un PR separado, después de que este se mergee

🤖 Generated with [Claude Code](https://claude.com/claude-code)