### PR TITLE
feat(crm-web): CB-027 — convenios de pago en detalle de caso y listado

### DIFF
--- a/apps/crm/apps/web/src/components/header.tsx
+++ b/apps/crm/apps/web/src/components/header.tsx
@@ -16,6 +16,7 @@ import {
 	FileText,
 	Gauge,
 	Gavel,
+	Handshake,
 	Landmark,
 	Layers,
 	LayoutDashboard,
@@ -275,6 +276,12 @@ export default function Header() {
 										<Link to="/cobros/cola" className="cursor-pointer">
 											<ClipboardList className="mr-2 h-4 w-4" />
 											Cola del día
+										</Link>
+									</DropdownMenuItem>
+									<DropdownMenuItem asChild>
+										<Link to="/cobros/convenios" className="cursor-pointer">
+											<Handshake className="mr-2 h-4 w-4" />
+											Convenios
 										</Link>
 									</DropdownMenuItem>
 									{PERMISSIONS.canAssignCobros(userRole) && (
@@ -683,6 +690,10 @@ function MobileNav({
 										<Link to="/cobros/cola" className={MOBILE_LINK_CLASS}>
 											<ClipboardList />
 											Cola del día
+										</Link>
+										<Link to="/cobros/convenios" className={MOBILE_LINK_CLASS}>
+											<Handshake />
+											Convenios
 										</Link>
 										{PERMISSIONS.canAssignCobros(userRole) && (
 											<Link to="/cobros/apertura" className={MOBILE_LINK_CLASS}>

--- a/apps/crm/apps/web/src/lib/cobros/buckets-catalogo.test.ts
+++ b/apps/crm/apps/web/src/lib/cobros/buckets-catalogo.test.ts
@@ -1,0 +1,106 @@
+import { describe, expect, test } from "bun:test";
+import { type BucketsCatalogoQueryData, esBucketB2 } from "./buckets-catalogo";
+
+const CATALOGO_ESTANDAR: BucketsCatalogoQueryData = [
+	{
+		numero: 0,
+		estadoMora: "al_dia",
+		label: "Cartera Sana",
+		prefijo: "B0",
+		color: null,
+		orden: 0,
+	},
+	{
+		numero: 1,
+		estadoMora: "mora_30",
+		label: "Alerta Temprana",
+		prefijo: "B1",
+		color: null,
+		orden: 1,
+	},
+	{
+		numero: 2,
+		estadoMora: "mora_60",
+		label: "Gestión Activa",
+		prefijo: "B2",
+		color: null,
+		orden: 2,
+	},
+	{
+		numero: 3,
+		estadoMora: "mora_90",
+		label: "Rescate",
+		prefijo: "B3",
+		color: null,
+		orden: 3,
+	},
+];
+
+// Catálogo con la numeración REASIGNADA por un admin: numero=2 ya no es
+// "mora_60" (B2), es "mora_30" (B1) — exactamente el escenario que el commit
+// 78c92c9c / PR #1205 corrigió en otros helpers de este mismo archivo.
+const CATALOGO_REASIGNADO: BucketsCatalogoQueryData = [
+	{
+		numero: 0,
+		estadoMora: "al_dia",
+		label: "Cartera Sana",
+		prefijo: "B0",
+		color: null,
+		orden: 0,
+	},
+	{
+		numero: 2,
+		estadoMora: "mora_30",
+		label: "Alerta Temprana",
+		prefijo: "B2",
+		color: null,
+		orden: 1,
+	},
+	{
+		numero: 1,
+		estadoMora: "mora_60",
+		label: "Gestión Activa",
+		prefijo: "B1",
+		color: null,
+		orden: 2,
+	},
+];
+
+describe("esBucketB2", () => {
+	test("null (sin traza en historial) nunca es B2", () => {
+		expect(esBucketB2(null, CATALOGO_ESTANDAR)).toBe(false);
+	});
+
+	test("con catálogo estándar, numero=2 SÍ es B2 (mora_60)", () => {
+		expect(esBucketB2(2, CATALOGO_ESTANDAR)).toBe(true);
+	});
+
+	test("con catálogo estándar, numero=1 (B1) NO es B2", () => {
+		expect(esBucketB2(1, CATALOGO_ESTANDAR)).toBe(false);
+	});
+
+	test("con catálogo estándar, numero=3 (B3) NO es B2", () => {
+		expect(esBucketB2(3, CATALOGO_ESTANDAR)).toBe(false);
+	});
+
+	// Caso central del fix: la numeración cruda NO decide el resultado, la
+	// clave estable "mora_60" sí. Antes del fix esto comparaba
+	// `bucketPrevio === 2` y hubiera dado un falso positivo/negativo según
+	// cuál número quedó reasignado.
+	test("con numeración reasignada, numero=2 YA NO es B2 (ahora es mora_30/B1)", () => {
+		expect(esBucketB2(2, CATALOGO_REASIGNADO)).toBe(false);
+	});
+
+	test("con numeración reasignada, numero=1 SÍ es B2 (mora_60 se movió ahí)", () => {
+		expect(esBucketB2(1, CATALOGO_REASIGNADO)).toBe(true);
+	});
+
+	test("sin catálogo cargado (undefined), cae al fallback ESTADO_MORA_POR_NUMERO donde numero=2 es mora_60", () => {
+		expect(esBucketB2(2, undefined)).toBe(true);
+		expect(esBucketB2(1, undefined)).toBe(false);
+	});
+
+	test("número fuera de rango (sin fila en catálogo ni fallback) no revienta y no es B2", () => {
+		expect(esBucketB2(99, CATALOGO_ESTANDAR)).toBe(false);
+	});
+});

--- a/apps/crm/apps/web/src/lib/cobros/buckets-catalogo.ts
+++ b/apps/crm/apps/web/src/lib/cobros/buckets-catalogo.ts
@@ -180,6 +180,28 @@ export function bucketDeNumero(
 }
 
 /**
+ * CB-027: ¿el bucket numérico dado es B2 ("Gestión Activa")? Usado para
+ * decidir si mostrar la card de convenio en el detalle de un caso, cuando
+ * `bucketPrevio` es el último bucket registrado en buckets_historial ANTES
+ * de que el crédito entrara en convenio (ver $id.tsx).
+ *
+ * NO compara `numero === 2`: `cartera.buckets.numero` es config dinámica (un
+ * admin puede reasignar qué número corresponde a qué etapa — mismo tipo de
+ * bug que el commit 78c92c9c / PR #1205 corrigió en otro lado). Resuelve la
+ * fila real vía `bucketDeNumero` (catálogo dinámico con fallback a
+ * ESTADO_MORA_POR_NUMERO) y compara por `key`, que es la clave estable
+ * ("mora_60" = B2 en el catálogo semilla, independiente de qué `numero` DB
+ * tenga asignado hoy).
+ */
+export function esBucketB2(
+	numero: number | null,
+	catalogo: BucketsCatalogoQueryData | undefined,
+): boolean {
+	if (numero === null) return false;
+	return bucketDeNumero(numero, catalogo).key === "mora_60";
+}
+
+/**
  * Inverso de `bucketDeNumero`: número de bucket (0-5) a partir de un
  * `estadoMora`, o null si no matchea ninguno (pseudo-buckets de status como
  * "en_convenio"/"pagado" no tienen número — no son filas de aging).

--- a/apps/crm/apps/web/src/routeTree.gen.ts
+++ b/apps/crm/apps/web/src/routeTree.gen.ts
@@ -35,6 +35,7 @@ import { Route as CobrosReportesRouteImport } from './routes/cobros/reportes'
 import { Route as CobrosReduccionRouteImport } from './routes/cobros/reduccion'
 import { Route as CobrosReasignacionesRouteImport } from './routes/cobros/reasignaciones'
 import { Route as CobrosMetasRouteImport } from './routes/cobros/metas'
+import { Route as CobrosConveniosRouteImport } from './routes/cobros/convenios'
 import { Route as CobrosColaRouteImport } from './routes/cobros/cola'
 import { Route as CobrosCierreRouteImport } from './routes/cobros/cierre'
 import { Route as CobrosCargaRouteImport } from './routes/cobros/carga'
@@ -190,6 +191,11 @@ const CobrosMetasRoute = CobrosMetasRouteImport.update({
   path: '/cobros/metas',
   getParentRoute: () => rootRouteImport,
 } as any)
+const CobrosConveniosRoute = CobrosConveniosRouteImport.update({
+  id: '/cobros/convenios',
+  path: '/cobros/convenios',
+  getParentRoute: () => rootRouteImport,
+} as any)
 const CobrosColaRoute = CobrosColaRouteImport.update({
   id: '/cobros/cola',
   path: '/cobros/cola',
@@ -329,6 +335,7 @@ export interface FileRoutesByFullPath {
   '/cobros/carga': typeof CobrosCargaRoute
   '/cobros/cierre': typeof CobrosCierreRoute
   '/cobros/cola': typeof CobrosColaRoute
+  '/cobros/convenios': typeof CobrosConveniosRoute
   '/cobros/metas': typeof CobrosMetasRoute
   '/cobros/reasignaciones': typeof CobrosReasignacionesRoute
   '/cobros/reduccion': typeof CobrosReduccionRoute
@@ -380,6 +387,7 @@ export interface FileRoutesByTo {
   '/cobros/carga': typeof CobrosCargaRoute
   '/cobros/cierre': typeof CobrosCierreRoute
   '/cobros/cola': typeof CobrosColaRoute
+  '/cobros/convenios': typeof CobrosConveniosRoute
   '/cobros/metas': typeof CobrosMetasRoute
   '/cobros/reasignaciones': typeof CobrosReasignacionesRoute
   '/cobros/reduccion': typeof CobrosReduccionRoute
@@ -432,6 +440,7 @@ export interface FileRoutesById {
   '/cobros/carga': typeof CobrosCargaRoute
   '/cobros/cierre': typeof CobrosCierreRoute
   '/cobros/cola': typeof CobrosColaRoute
+  '/cobros/convenios': typeof CobrosConveniosRoute
   '/cobros/metas': typeof CobrosMetasRoute
   '/cobros/reasignaciones': typeof CobrosReasignacionesRoute
   '/cobros/reduccion': typeof CobrosReduccionRoute
@@ -485,6 +494,7 @@ export interface FileRouteTypes {
     | '/cobros/carga'
     | '/cobros/cierre'
     | '/cobros/cola'
+    | '/cobros/convenios'
     | '/cobros/metas'
     | '/cobros/reasignaciones'
     | '/cobros/reduccion'
@@ -536,6 +546,7 @@ export interface FileRouteTypes {
     | '/cobros/carga'
     | '/cobros/cierre'
     | '/cobros/cola'
+    | '/cobros/convenios'
     | '/cobros/metas'
     | '/cobros/reasignaciones'
     | '/cobros/reduccion'
@@ -587,6 +598,7 @@ export interface FileRouteTypes {
     | '/cobros/carga'
     | '/cobros/cierre'
     | '/cobros/cola'
+    | '/cobros/convenios'
     | '/cobros/metas'
     | '/cobros/reasignaciones'
     | '/cobros/reduccion'
@@ -639,6 +651,7 @@ export interface RootRouteChildren {
   CobrosCargaRoute: typeof CobrosCargaRoute
   CobrosCierreRoute: typeof CobrosCierreRoute
   CobrosColaRoute: typeof CobrosColaRoute
+  CobrosConveniosRoute: typeof CobrosConveniosRoute
   CobrosMetasRoute: typeof CobrosMetasRoute
   CobrosReasignacionesRoute: typeof CobrosReasignacionesRoute
   CobrosReduccionRoute: typeof CobrosReduccionRoute
@@ -859,6 +872,13 @@ declare module '@tanstack/react-router' {
       preLoaderRoute: typeof CobrosMetasRouteImport
       parentRoute: typeof rootRouteImport
     }
+    '/cobros/convenios': {
+      id: '/cobros/convenios'
+      path: '/cobros/convenios'
+      fullPath: '/cobros/convenios'
+      preLoaderRoute: typeof CobrosConveniosRouteImport
+      parentRoute: typeof rootRouteImport
+    }
     '/cobros/cola': {
       id: '/cobros/cola'
       path: '/cobros/cola'
@@ -1039,6 +1059,7 @@ const rootRouteChildren: RootRouteChildren = {
   CobrosCargaRoute: CobrosCargaRoute,
   CobrosCierreRoute: CobrosCierreRoute,
   CobrosColaRoute: CobrosColaRoute,
+  CobrosConveniosRoute: CobrosConveniosRoute,
   CobrosMetasRoute: CobrosMetasRoute,
   CobrosReasignacionesRoute: CobrosReasignacionesRoute,
   CobrosReduccionRoute: CobrosReduccionRoute,

--- a/apps/crm/apps/web/src/routes/cobros/$id.tsx
+++ b/apps/crm/apps/web/src/routes/cobros/$id.tsx
@@ -789,12 +789,18 @@ function RouteComponent() {
 	// transiciones para créditos fuera del funnel, así que la última fila de
 	// buckets_historial queda CONGELADA en el bucket real previo al convenio
 	// — eso es `bucket_previo`. null = sin traza (crédito nunca procesado por
-	// el motor): se muestra igual, no se oculta info real por falta de backfill.
+	// el motor) O error real degradado a null por el server (getBucketActualCredito
+	// atrapa cualquier excepción y devuelve null) — en ambos casos se muestra
+	// igual, no se oculta info real. Pero mientras la query sigue en vuelo
+	// (isPending, data aún undefined) NO hay que tratarlo como "sin traza":
+	// eso mostraría la card de un convenio no-B2 antes de que llegue la
+	// respuesta real, solo para ocultarla un instante después.
 	// esBucketB2 resuelve el número contra el catálogo dinámico en vez de
 	// comparar el literal 2 (ver su doc en buckets-catalogo.ts).
 	const bucketPrevio = motorBucket?.bucket_previo ?? null;
 	const mostrarConvenio =
 		!!caso.convenioActivo &&
+		!bucketActual.isPending &&
 		(bucketPrevio === null || esBucketB2(bucketPrevio, bucketsCatalogo.data));
 
 	const getEstadoContacto = (estado: string) => {

--- a/apps/crm/apps/web/src/routes/cobros/$id.tsx
+++ b/apps/crm/apps/web/src/routes/cobros/$id.tsx
@@ -74,6 +74,7 @@ import {
 	bucketDeEstado,
 	bucketDeNumero,
 	catalogoDeNumero,
+	esBucketB2,
 	estiloBucket,
 	numeroDeEstadoMora,
 	useBucketsCatalogo,
@@ -485,14 +486,6 @@ function RouteComponent() {
 		enabled: !!session && !!casoDetails.data?.id,
 	});
 
-	// Obtener convenios de pago (solo para casos)
-	const conveniosPago = useQuery({
-		...orpc.getConveniosPago.queryOptions({
-			input: { casoCobroId: casoDetails.data?.id || "" },
-		}),
-		enabled: !!session && !!casoDetails.data?.id,
-	});
-
 	// Obtener historial de pagos del contrato
 	const historialPagos = useQuery({
 		...orpc.getHistorialPagos.queryOptions({
@@ -721,7 +714,6 @@ function RouteComponent() {
 	const contactos = (historialContactos.data || []).filter(
 		(c: any) => c.estadoContacto !== "promesa_pago",
 	);
-	const convenios = conveniosPago.data || [];
 	const cuotas = historialPagos.data || [];
 	const recuperacion = recuperacionInfo.data;
 
@@ -790,6 +782,20 @@ function RouteComponent() {
 			: estadoMoraDivergente
 				? `${bucketPrefijo} · ${bucketUI.label} (mora calculada: ${getEstadoLabel(caso.estadoMora)})`
 				: `${bucketPrefijo} · ${bucketUI.label}`;
+
+	// CB-027: con convenio activo, cartera-back saca el crédito del funnel
+	// (bucketDeCredito → null, statusCredit=EN_CONVENIO), así que "es B2" no se
+	// puede leer del bucket actual. El motor de buckets deja de escribir
+	// transiciones para créditos fuera del funnel, así que la última fila de
+	// buckets_historial queda CONGELADA en el bucket real previo al convenio
+	// — eso es `bucket_previo`. null = sin traza (crédito nunca procesado por
+	// el motor): se muestra igual, no se oculta info real por falta de backfill.
+	// esBucketB2 resuelve el número contra el catálogo dinámico en vez de
+	// comparar el literal 2 (ver su doc en buckets-catalogo.ts).
+	const bucketPrevio = motorBucket?.bucket_previo ?? null;
+	const mostrarConvenio =
+		!!caso.convenioActivo &&
+		(bucketPrevio === null || esBucketB2(bucketPrevio, bucketsCatalogo.data));
 
 	const getEstadoContacto = (estado: string) => {
 		const estados: Record<string, { label: string; color: string }> = {
@@ -2711,54 +2717,171 @@ function RouteComponent() {
 						</CardContent>
 					</Card>
 
-					{/* Convenios Activos */}
-					{convenios.length > 0 && (
+					{/* Convenio de Pago (CB-027) — dato REAL de cartera-back, no la tabla
+					    legacy del CRM. Solo se muestra si hay convenio activo y el
+					    crédito venía de B2 (o sin traza de bucket en historial). */}
+					{mostrarConvenio && caso.convenioActivo && (
 						<Card>
 							<CardHeader>
 								<CardTitle className="flex items-center gap-2">
 									<Shield className="h-5 w-5" />
-									Convenios de Pago
+									Convenio de Pago
 								</CardTitle>
+								<CardDescription>
+									Plan de pago acordado para regularizar el crédito
+								</CardDescription>
 							</CardHeader>
-							<CardContent>
-								<div className="space-y-3">
-									{convenios.map((convenio: any) => (
-										<div key={convenio.id} className="rounded border p-3">
-											<div className="mb-2 flex items-center justify-between">
-												<Badge
-													variant={convenio.activo ? "default" : "secondary"}
-												>
-													{convenio.activo ? "Activo" : "Inactivo"}
-												</Badge>
-												{convenio.cumplido && (
-													<Badge className="bg-green-100 text-green-800">
-														Cumplido
-													</Badge>
-												)}
-											</div>
-											<div className="space-y-1 text-sm">
-												<p>
-													<span className="font-medium">Monto:</span> Q
-													{Number(convenio.montoAcordado).toLocaleString()}
-												</p>
-												<p>
-													<span className="font-medium">Cuotas:</span>{" "}
-													{convenio.cuotasCumplidas}/
-													{convenio.numeroCuotasConvenio}
-												</p>
-												<p>
-													<span className="font-medium">Cuota:</span> Q
-													{Number(convenio.montoCuotaConvenio).toLocaleString()}
-												</p>
-												{convenio.condicionesEspeciales && (
-													<p className="mt-2 text-muted-foreground text-xs">
-														{convenio.condicionesEspeciales}
-													</p>
-												)}
-											</div>
+							<CardContent className="space-y-4">
+								<div className="rounded border p-3">
+									<div className="mb-3 flex items-center justify-between">
+										<Badge
+											variant={
+												caso.convenioActivo.activo ? "default" : "secondary"
+											}
+										>
+											{caso.convenioActivo.activo ? "Activo" : "Inactivo"}
+										</Badge>
+										{caso.convenioActivo.completado && (
+											<Badge className="bg-green-100 text-green-800">
+												Cumplido
+											</Badge>
+										)}
+									</div>
+
+									<div className="grid grid-cols-2 gap-3 text-sm">
+										<div>
+											<p className="text-muted-foreground">Monto total</p>
+											<p className="font-medium">
+												Q
+												{Number(
+													caso.convenioActivo.montoTotalConvenio,
+												).toLocaleString("es-GT", {
+													minimumFractionDigits: 2,
+													maximumFractionDigits: 2,
+												})}
+											</p>
 										</div>
-									))}
+										<div>
+											<p className="text-muted-foreground">Cuota mensual</p>
+											<p className="font-medium">
+												Q
+												{Number(
+													caso.convenioActivo.cuotaMensual,
+												).toLocaleString("es-GT", {
+													minimumFractionDigits: 2,
+													maximumFractionDigits: 2,
+												})}
+											</p>
+										</div>
+										<div>
+											<p className="text-muted-foreground">Pagos realizados</p>
+											<p className="font-medium">
+												{caso.convenioActivo.pagosRealizados} /{" "}
+												{caso.convenioActivo.numeroMeses}
+											</p>
+										</div>
+										<div>
+											<p className="text-muted-foreground">Pendiente</p>
+											<p className="font-medium text-red-600">
+												Q
+												{Number(
+													caso.convenioActivo.montoPendiente,
+												).toLocaleString("es-GT", {
+													minimumFractionDigits: 2,
+													maximumFractionDigits: 2,
+												})}
+											</p>
+										</div>
+									</div>
+
+									{/* Barra de progreso: monto pagado vs. monto total */}
+									<div className="mt-3">
+										<div className="mb-1 flex items-center justify-between text-muted-foreground text-xs">
+											<span>Progreso del convenio</span>
+											<span>
+												Q
+												{Number(caso.convenioActivo.montoPagado).toLocaleString(
+													"es-GT",
+													{
+														maximumFractionDigits: 0,
+													},
+												)}{" "}
+												de Q
+												{Number(
+													caso.convenioActivo.montoTotalConvenio,
+												).toLocaleString("es-GT", {
+													maximumFractionDigits: 0,
+												})}
+											</span>
+										</div>
+										<div className="h-2 w-full overflow-hidden rounded-full bg-muted">
+											<div
+												className="h-full rounded-full bg-green-500"
+												style={{
+													width: `${Math.min(
+														100,
+														(Number(caso.convenioActivo.montoPagado) /
+															Math.max(
+																1,
+																Number(caso.convenioActivo.montoTotalConvenio),
+															)) *
+															100,
+													)}%`,
+												}}
+											/>
+										</div>
+									</div>
+
+									{(caso.convenioActivo.motivo ||
+										caso.convenioActivo.observaciones) && (
+										<div className="mt-3 space-y-1 text-muted-foreground text-xs">
+											{caso.convenioActivo.motivo && (
+												<p>
+													<span className="font-medium">Motivo:</span>{" "}
+													{caso.convenioActivo.motivo}
+												</p>
+											)}
+											{caso.convenioActivo.observaciones && (
+												<p>
+													<span className="font-medium">Observaciones:</span>{" "}
+													{caso.convenioActivo.observaciones}
+												</p>
+											)}
+										</div>
+									)}
 								</div>
+
+								{/* Plan de cuotas del convenio */}
+								{caso.convenioCuotas && caso.convenioCuotas.length > 0 && (
+									<div>
+										<p className="mb-2 font-medium text-sm">Plan de pagos</p>
+										<div className="space-y-1">
+											{caso.convenioCuotas.map((cuota) => {
+												const pagada = !!cuota.fechaPago;
+												return (
+													<div
+														key={cuota.numeroCuota}
+														className="flex items-center justify-between rounded border px-3 py-2 text-sm"
+													>
+														<span>Cuota #{cuota.numeroCuota}</span>
+														<span className="text-muted-foreground">
+															Vence: {formatFechaLocal(cuota.fechaVencimiento)}
+														</span>
+														<Badge
+															className={
+																pagada
+																	? "bg-green-100 text-green-800"
+																	: "bg-yellow-100 text-yellow-800"
+															}
+														>
+															{pagada ? "Pagada" : "Pendiente"}
+														</Badge>
+													</div>
+												);
+											})}
+										</div>
+									</div>
+								)}
 							</CardContent>
 						</Card>
 					)}

--- a/apps/crm/apps/web/src/routes/cobros/convenios.tsx
+++ b/apps/crm/apps/web/src/routes/cobros/convenios.tsx
@@ -1,0 +1,474 @@
+import { keepPreviousData, useQuery } from "@tanstack/react-query";
+import { createFileRoute, useNavigate } from "@tanstack/react-router";
+import {
+	ChevronLeft,
+	ChevronRight,
+	Handshake,
+	Loader2,
+	Search,
+	UserRound,
+} from "lucide-react";
+import { useState } from "react";
+import { Badge } from "@/components/ui/badge";
+import { Button } from "@/components/ui/button";
+import {
+	Card,
+	CardContent,
+	CardDescription,
+	CardHeader,
+	CardTitle,
+} from "@/components/ui/card";
+import { Input } from "@/components/ui/input";
+import {
+	Select,
+	SelectContent,
+	SelectItem,
+	SelectTrigger,
+	SelectValue,
+} from "@/components/ui/select";
+import {
+	Table,
+	TableBody,
+	TableCell,
+	TableHead,
+	TableHeader,
+	TableRow,
+} from "@/components/ui/table";
+import { authClient } from "@/lib/auth-client";
+import {
+	bucketDeNumero,
+	estiloBucket,
+	useBucketsCatalogo,
+} from "@/lib/cobros/buckets-catalogo";
+import { PERMISSIONS } from "@/lib/roles";
+import { orpc } from "@/utils/orpc";
+
+export const Route = createFileRoute("/cobros/convenios")({
+	component: ConveniosPage,
+});
+
+interface ConvenioItem {
+	convenio_id: number;
+	credito_id: number;
+	numero_credito_sifco: string;
+	cliente_nombre: string;
+	asesor_id: number | null;
+	asesor_nombre: string | null;
+	asesor_email: string | null;
+	monto_total_convenio: string;
+	cuota_mensual: string;
+	numero_meses: number;
+	monto_pagado: string;
+	monto_pendiente: string;
+	pagos_realizados: number;
+	pagos_pendientes: number;
+	fecha_convenio: string;
+	activo: boolean;
+	completado: boolean;
+	motivo: string | null;
+	progreso: string;
+	/** Último bucket registrado antes de entrar en convenio. null = sin traza. */
+	bucket_previo: number | null;
+	bucket_previo_prefijo: string | null;
+}
+
+interface ConveniosResponse {
+	sinAsesor: boolean;
+	asesorForzado: { asesorId: number; nombre: string } | null;
+	items: ConvenioItem[];
+	total: number;
+	page: number;
+	perPage: number;
+	totalPages: number;
+}
+
+interface AsesorOption {
+	asesorId: number;
+	nombre: string;
+	activo: boolean;
+	email: string;
+	isActive: boolean;
+}
+
+type Estado = "active" | "completed" | "inactive" | "all";
+
+const PER_PAGE_CONVENIOS = 25;
+
+const ESTADOS: Array<{ value: Estado; label: string }> = [
+	{ value: "active", label: "Activos" },
+	{ value: "completed", label: "Cumplidos" },
+	{ value: "inactive", label: "Inactivos" },
+	{ value: "all", label: "Todos" },
+];
+
+function formatMoneda(valor: string) {
+	return `Q${Number(valor).toLocaleString("es-GT", {
+		minimumFractionDigits: 2,
+		maximumFractionDigits: 2,
+	})}`;
+}
+
+function fechaLegible(v: string | null) {
+	if (!v) return "—";
+	const [y, m, d] = v.split("T")[0].split("-");
+	return y && m && d ? `${d}/${m}/${y}` : v;
+}
+
+function EstadoBadge({ item }: { item: ConvenioItem }) {
+	if (item.completado) {
+		return <Badge className="bg-green-100 text-green-800">Cumplido</Badge>;
+	}
+	return (
+		<Badge variant={item.activo ? "default" : "secondary"}>
+			{item.activo ? "Activo" : "Inactivo"}
+		</Badge>
+	);
+}
+
+/**
+ * Último bucket registrado en buckets_historial ANTES de que el crédito
+ * saliera del funnel por el convenio. El motor deja de escribir para
+ * créditos EN_CONVENIO, así que esta fila queda congelada en el bucket real
+ * previo a la salida — null = sin traza (crédito nunca procesado por el
+ * motor, típico en ambientes sin backfill de COBROS-02).
+ */
+function UltimoBucketBadge({
+	item,
+	catalogo,
+}: {
+	item: ConvenioItem;
+	catalogo: ReturnType<typeof useBucketsCatalogo>["data"];
+}) {
+	if (item.bucket_previo === null) {
+		return <span className="text-muted-foreground text-xs">Sin traza</span>;
+	}
+	const ui = bucketDeNumero(item.bucket_previo, catalogo);
+	const prefijo = item.bucket_previo_prefijo || `B${item.bucket_previo}`;
+	return (
+		<Badge
+			variant="outline"
+			className="whitespace-nowrap text-[10px]"
+			style={estiloBucket(ui.colorHex)}
+			title={ui.label}
+		>
+			{prefijo} · {ui.label}
+		</Badge>
+	);
+}
+
+function ConveniosPage() {
+	const navigate = useNavigate();
+	const { data: session } = authClient.useSession();
+	const userRole = session?.user?.role;
+	const esSupervisor = !!userRole && PERMISSIONS.canAssignCobros(userRole);
+	const bucketsCatalogo = useBucketsCatalogo();
+
+	const [asesorSel, setAsesorSel] = useState("todos");
+	const [estado, setEstado] = useState<Estado>("active");
+	const [busquedaInput, setBusquedaInput] = useState("");
+	const [busqueda, setBusqueda] = useState("");
+	const [page, setPage] = useState(1);
+
+	const asesorIdInput =
+		esSupervisor && asesorSel !== "todos" ? Number(asesorSel) : undefined;
+
+	const conveniosQuery = useQuery({
+		...orpc.getConveniosListado.queryOptions({
+			input: {
+				estado,
+				// Búsqueda libre: matchea SIFCO o cliente (cartera-back combina
+				// ambos con OR, ver getConveniosListado en el server).
+				busqueda: busqueda || undefined,
+				asesorId: asesorIdInput,
+				page,
+				perPage: PER_PAGE_CONVENIOS,
+			},
+		}),
+		enabled: !!session,
+		placeholderData: keepPreviousData,
+	});
+
+	const asesoresQuery = useQuery({
+		...orpc.getAsesores.queryOptions({
+			input: { page: 1, perPage: 100 },
+		}),
+		enabled: !!session && esSupervisor,
+	});
+
+	if (!userRole || !PERMISSIONS.canAccessCobros(userRole)) {
+		return (
+			<div className="flex min-h-screen items-center justify-center">
+				<div className="text-center">
+					<h1 className="mb-4 font-bold text-2xl text-gray-800">
+						Acceso Denegado
+					</h1>
+					<p className="text-gray-600">
+						Solo el equipo de cobros puede ver los convenios de pago.
+					</p>
+				</div>
+			</div>
+		);
+	}
+
+	const data = conveniosQuery.data as ConveniosResponse | undefined;
+	const items = data?.items ?? [];
+	const total = data?.total ?? 0;
+	const totalPages = data?.totalPages ?? 1;
+	const sinAsesor = !!data?.sinAsesor;
+	const asesorForzado = data?.asesorForzado ?? null;
+
+	const asesores = (
+		(asesoresQuery.data as { asesores?: AsesorOption[] } | undefined)
+			?.asesores ?? []
+	).filter((a) => a.activo);
+
+	const cambiarAsesor = (v: string) => {
+		setAsesorSel(v);
+		setPage(1);
+	};
+
+	const cambiarEstado = (v: string) => {
+		setEstado(v as Estado);
+		setPage(1);
+	};
+
+	const aplicarBusqueda = () => {
+		setBusqueda(busquedaInput.trim());
+		setPage(1);
+	};
+
+	const irAlDetalle = (sifco: string) => {
+		navigate({
+			to: "/cobros/$id",
+			params: { id: sifco },
+			search: { tipo: "caso" },
+		});
+	};
+
+	return (
+		<div className="container mx-auto space-y-4 p-4 lg:p-6">
+			<Card>
+				<CardHeader className="pb-4">
+					<div className="flex flex-wrap items-start justify-between gap-3">
+						<div className="flex items-center gap-3">
+							<div className="flex h-10 w-10 items-center justify-center rounded-lg bg-primary/10 text-primary">
+								<Handshake className="h-5 w-5" />
+							</div>
+							<div>
+								<CardTitle className="text-xl">Convenios de Pago</CardTitle>
+								<CardDescription>
+									Convenios de pago creados desde cartera para regularizar
+									créditos en mora
+									{asesorForzado
+										? ` · Convenios de ${asesorForzado.nombre}`
+										: ""}
+								</CardDescription>
+							</div>
+						</div>
+						<div className="flex items-center gap-2">
+							<Badge variant="secondary">{total} convenios</Badge>
+							{conveniosQuery.isFetching && (
+								<Loader2 className="h-4 w-4 animate-spin text-muted-foreground" />
+							)}
+						</div>
+					</div>
+					<div className="flex flex-wrap items-center gap-2 pt-3">
+						<div className="flex items-center gap-1.5">
+							{ESTADOS.map((e) => (
+								<Button
+									key={e.value}
+									type="button"
+									size="sm"
+									variant={estado === e.value ? "default" : "outline"}
+									className="h-7 rounded-full px-3 text-xs"
+									onClick={() => cambiarEstado(e.value)}
+								>
+									{e.label}
+								</Button>
+							))}
+						</div>
+						<div className="flex flex-1 items-center gap-2 sm:max-w-xs">
+							<Input
+								placeholder="Buscar por SIFCO o cliente..."
+								value={busquedaInput}
+								onChange={(e) => setBusquedaInput(e.target.value)}
+								onKeyDown={(e) => e.key === "Enter" && aplicarBusqueda()}
+								className="h-8"
+							/>
+							<Button
+								variant="outline"
+								size="sm"
+								className="h-8"
+								onClick={aplicarBusqueda}
+							>
+								<Search className="h-3.5 w-3.5" />
+							</Button>
+						</div>
+						{esSupervisor && (
+							<Select value={asesorSel} onValueChange={cambiarAsesor}>
+								<SelectTrigger className="h-8 w-52">
+									<UserRound className="mr-1 h-3.5 w-3.5 text-muted-foreground" />
+									<SelectValue placeholder="Asesor" />
+								</SelectTrigger>
+								<SelectContent>
+									<SelectItem value="todos">Todos los asesores</SelectItem>
+									{asesoresQuery.isError && (
+										<div className="px-2 py-1.5 text-destructive text-xs">
+											Error al cargar asesores
+										</div>
+									)}
+									{asesores.map((a) => (
+										<SelectItem key={a.asesorId} value={String(a.asesorId)}>
+											{a.nombre}
+										</SelectItem>
+									))}
+								</SelectContent>
+							</Select>
+						)}
+					</div>
+				</CardHeader>
+			</Card>
+
+			{conveniosQuery.isPending && (
+				<div className="flex items-center justify-center py-16">
+					<Loader2 className="h-6 w-6 animate-spin text-muted-foreground" />
+				</div>
+			)}
+
+			{!conveniosQuery.isPending && conveniosQuery.isError && (
+				<Card>
+					<CardContent className="py-10 text-center text-destructive">
+						Error al cargar los convenios de pago. Intentá recargar la página.
+					</CardContent>
+				</Card>
+			)}
+
+			{!conveniosQuery.isPending && !conveniosQuery.isError && sinAsesor && (
+				<Card>
+					<CardContent className="py-10 text-center text-muted-foreground">
+						Tu usuario no está vinculado a un asesor de cartera (por correo).
+						Pedile al supervisor que revise tu correo de asesor.
+					</CardContent>
+				</Card>
+			)}
+
+			{!conveniosQuery.isPending &&
+				!conveniosQuery.isError &&
+				!sinAsesor &&
+				total === 0 && (
+					<Card>
+						<CardContent className="py-10 text-center text-muted-foreground">
+							No hay convenios de pago para los filtros seleccionados.
+						</CardContent>
+					</Card>
+				)}
+
+			{!conveniosQuery.isPending &&
+				!conveniosQuery.isError &&
+				!sinAsesor &&
+				total > 0 && (
+					<Card>
+						<CardContent className="pt-6">
+							<div className="overflow-x-auto">
+								<Table>
+									<TableHeader>
+										<TableRow>
+											<TableHead>Cliente</TableHead>
+											<TableHead>Crédito</TableHead>
+											<TableHead>Monto total</TableHead>
+											<TableHead>Cuota</TableHead>
+											<TableHead>Progreso</TableHead>
+											<TableHead>Pendiente</TableHead>
+											<TableHead>Fecha convenio</TableHead>
+											<TableHead>Estado</TableHead>
+											<TableHead>Último Bucket</TableHead>
+											{esSupervisor && asesorSel === "todos" && (
+												<TableHead>Asesor</TableHead>
+											)}
+										</TableRow>
+									</TableHeader>
+									<TableBody>
+										{items.map((item) => (
+											<TableRow
+												key={item.convenio_id}
+												className="cursor-pointer"
+												onClick={() => irAlDetalle(item.numero_credito_sifco)}
+											>
+												<TableCell className="font-medium">
+													{item.cliente_nombre}
+												</TableCell>
+												<TableCell className="max-w-45 truncate font-mono text-muted-foreground text-xs">
+													{item.numero_credito_sifco}
+												</TableCell>
+												<TableCell>
+													{formatMoneda(item.monto_total_convenio)}
+												</TableCell>
+												<TableCell>
+													{formatMoneda(item.cuota_mensual)}
+												</TableCell>
+												<TableCell className="text-sm">
+													{item.pagos_realizados}/{item.numero_meses} (
+													{Number(item.progreso).toFixed(0)}%)
+												</TableCell>
+												<TableCell className="text-red-600 text-sm">
+													{formatMoneda(item.monto_pendiente)}
+												</TableCell>
+												<TableCell className="text-sm">
+													{fechaLegible(item.fecha_convenio)}
+												</TableCell>
+												<TableCell>
+													<EstadoBadge item={item} />
+												</TableCell>
+												<TableCell>
+													<UltimoBucketBadge
+														item={item}
+														catalogo={bucketsCatalogo.data}
+													/>
+												</TableCell>
+												{esSupervisor && asesorSel === "todos" && (
+													<TableCell className="text-sm">
+														{item.asesor_nombre ?? "—"}
+													</TableCell>
+												)}
+											</TableRow>
+										))}
+									</TableBody>
+								</Table>
+							</div>
+
+							{totalPages > 1 && (
+								<div className="flex items-center justify-between pt-3">
+									<span className="text-muted-foreground text-xs">
+										Mostrando {items.length} de {total} · página {page} de{" "}
+										{totalPages}
+									</span>
+									<div className="flex items-center gap-1">
+										<Button
+											variant="outline"
+											size="sm"
+											className="h-8"
+											disabled={page <= 1 || conveniosQuery.isFetching}
+											onClick={() => setPage((p) => p - 1)}
+										>
+											<ChevronLeft className="h-4 w-4" />
+											Anterior
+										</Button>
+										<Button
+											variant="outline"
+											size="sm"
+											className="h-8"
+											disabled={page >= totalPages || conveniosQuery.isFetching}
+											onClick={() => setPage((p) => p + 1)}
+										>
+											Siguiente
+											<ChevronRight className="h-4 w-4" />
+										</Button>
+									</div>
+								</div>
+							)}
+						</CardContent>
+					</Card>
+				)}
+		</div>
+	);
+}


### PR DESCRIPTION
## Summary
Consume los endpoints del server (PR #1214, ya mergeado a COBROS-02).

- **`$id.tsx`**: card "Convenio de Pago" con datos reales de cartera-back (monto total, cuota, progreso con barra, plan de cuotas). Gated por `esBucketB2(bucket_previo, catalogo)` — se muestra si el crédito venía de B2 antes del convenio, o si no hay traza en `buckets_historial` (se degrada mostrando, no ocultando información real por falta de backfill).
- **`convenios.tsx`** (nueva): listado paginado en `/cobros/convenios` — filtros de estado (activos/cumplidos/inactivos/todos), búsqueda libre por SIFCO o cliente, columna "Último Bucket", y asesor forzado por email para el rol `cobros` (supervisor ve todos y puede filtrar por asesor).
- **`header.tsx`**: entrada "Convenios" en el nav de Cobros, desktop y mobile.
- **`buckets-catalogo.ts`**: `esBucketB2` extraída como función pura — resuelve el bucket contra el catálogo dinámico en vez de comparar un número hardcodeado (`cartera.buckets.numero` es config reasignable; mismo tipo de bug que el commit `78c92c9c`/PR #1205 corrigió en otro helper).

## Test plan
- [x] `bunx tsc --noEmit` limpio (web compilando contra el `AppRouter` real del server ya mergeado)
- [x] `bun test` — 79/79 pass, incluye 8 tests nuevos de `esBucketB2` (cubre el caso de numeración reasignada)
- [x] `vite build` exitoso
- [x] Verificado visualmente en navegador: detalle de caso con convenio, listado `/cobros/convenios`, filtros y paginación

🤖 Generated with [Claude Code](https://claude.com/claude-code)