### PR TITLE
fix(cartera): cascada cobraba la misma cuota dos veces cuando cuotas_credito está duplicada

### DIFF
--- a/apps/cartera-back/src/controllers/registerPayment.ts
+++ b/apps/cartera-back/src/controllers/registerPayment.ts
@@ -384,11 +384,34 @@ const obtenerInfoCompletaCredito = async (
     }
 
     console.log(cuotaApagar,"cuota a pagar");
-    const cuotasPendientesUnicas = Array.from(
-      new Map(
-        cuotasPendientes.map((item) => [item.cuotas_credito.cuota_id, item])
-      ).values()
+    // Dedupe por NUMERO_CUOTA, no por cuota_id: hay créditos con cuotas_credito
+    // duplicadas (mismo numero_cuota, cuota_id distinto — artefacto del flujo
+    // viejo de abonos). Si sobreviven ambas copias, la cascada cobra la misma
+    // cuota N veces y corre los tramos una casilla (caso crédito 793, cuota 17:
+    // el tramo de la 18 cerró la 17 fantasma y la 19 nunca recibió el suyo).
+    // Nos quedamos con la copia más reciente (mayor cuota_id): es la que trae
+    // el recibo re-sembrado vigente.
+    const porNumeroCuota = new Map<number, (typeof cuotasPendientes)[number]>();
+    for (const item of cuotasPendientes) {
+      const previo = porNumeroCuota.get(item.cuotas_credito.numero_cuota);
+      if (
+        !previo ||
+        item.cuotas_credito.cuota_id > previo.cuotas_credito.cuota_id
+      ) {
+        porNumeroCuota.set(item.cuotas_credito.numero_cuota, item);
+      }
+    }
+    const cuotasPendientesUnicas = Array.from(porNumeroCuota.values());
+    const cuotaIdsPendientes = new Set(
+      cuotasPendientes.map((item) => item.cuotas_credito.cuota_id)
     );
+    if (cuotaIdsPendientes.size > cuotasPendientesUnicas.length) {
+      console.warn(
+        `⚠️ Crédito ${credito_id}: cuotas_credito DUPLICADAS detectadas en pendientes ` +
+          `(${cuotaIdsPendientes.size} cuota_id para ${cuotasPendientesUnicas.length} números de cuota). ` +
+          `Se usa solo la copia más reciente de cada numero_cuota.`
+      );
+    }
     const numerosCuotas = cuotasPendientesUnicas.map((item) => item.cuotas_credito.numero_cuota);
     console.log("Números de cuotas pendientes:", numerosCuotas);
 


### PR DESCRIPTION
## El bug (caso real: crédito 793, 30-jul)

Un solo `/newPayment` de Q5,000 (cuotaApagar 17) produjo dos cierres en la cuota 17 y corrió toda la cascada una casilla. Cobros creyó que el sistema había "replicado" el pago — no: la cuota 17 existía **dos veces** en `cuotas_credito` (46061 seed original + 125196 creada por el flujo viejo de abonos en mayo).

`obtenerInfoCompletaCredito` dedupeaba las cuotas pendientes **por `cuota_id`**, así que ambas copias de la cuota 17 sobrevivían y el loop de la cascada procesó "cuota 17" dos veces:

| Tramo | Debía ir a | Fue a | Split |
|---|---|---|---|
| 1 (mora + 1,693.58) | cuota 17 | cuota 17 real ✓ | interés 217.29 ✓ |
| 2 (1,693.58) | cuota 18 | **cuota 17 fantasma** ✗ | interés 208.06 (el de la 18) |
| 3 (1,450.60 parcial) | cuota 19 | **cuota 18** ✗ | interés 198.67 (el de la 19) |

Los montos y facturas salieron correctos (la cascada calcula interés sobre el capital corrido); solo el etiquetado de cuotas quedó corrido — la 18 real figura parcial estando pagada y la 19 figura virgen teniendo Q1,450.60.

## El fix

Dedupe por **`numero_cuota`**, quedándose con la copia más reciente (mayor `cuota_id` — la que trae el recibo re-sembrado vigente), y `console.warn` cuando se detectan duplicadas para tener visibilidad.

## Contexto de datos

- Barrido en prod: 78 grupos de cuotas duplicadas en ~40 créditos (legacy). Riesgo activo: 10 créditos INCOBRABLES con la cuota 1 duplicada abierta — con este fix un pago de recuperación ya no la cobraría doble.
- El re-etiquetado de datos del crédito 793 se corrige por aparte (backups `cartera.backup_c793_*` ya creados).
- El typecheck reporta un error pre-existente en `registerPayment.ts` (`lockConn` possibly undefined) que ya está en develop; este cambio no introduce errores nuevos.

🤖 Generated with [Claude Code](https://claude.com/claude-code)